### PR TITLE
fix some wrong id in recipes

### DIFF
--- a/config/cobblegen.json5
+++ b/config/cobblegen.json5
@@ -141,7 +141,7 @@
       ],
       "compressor:quadruple_compressed_andesite": [
         {
-          "id": "compressor:single_compressed_andesite",
+          "id": "compressor:compressed_andesite",
           "weight": 1.0
         }
       ]

--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -469,7 +469,7 @@ function lizardCH3Biofuel(event) {
   event.recipes.createSplashing([
     'createastral:pure_biomatter',
     Item.of('minecraft:sugar').withChance(.2),
-    Item.of('minecraft:bonemeal').withChance(.2),
+    Item.of('minecraft:bone_meal').withChance(.2),
   ], 'createaddition:biomass')
   
 


### PR DESCRIPTION
fix #10 
fix the "bonemeal" mistake in splashing recipe to pure_biomatter