### PR TITLE
Make bedrock great again

### DIFF
--- a/config/cobblegen.json5
+++ b/config/cobblegen.json5
@@ -78,19 +78,23 @@
       "minecraft:bedrock": [
         {
           "id": "minecraft:stone",
-          "weight": 100
+          "weight": 5
         },
         {
           "id": "minecraft:granite",
-          "weight": 3
+          "weight": 1
         },
         {
           "id": "minecraft:diorite",
-          "weight": 3
+          "weight": 1
         },
         {
           "id": "minecraft:andesite",
-          "weight": 3
+          "weight": 1
+        },
+        {
+          "id": "minecraft:tuff",
+          "weight: 1
         }
       ],
       "ad_astra:moon_stone": [

--- a/config/cobblegen.json5
+++ b/config/cobblegen.json5
@@ -77,7 +77,7 @@
     "cobbleGen": {
       "minecraft:bedrock": [
         {
-          "id": "minecraft:stone",
+          "id": "minecraft:cobblestone",
           "weight": 5
         },
         {
@@ -151,24 +151,28 @@
       ]
     },
     "stoneGen": {
-      "minecraft:bedrock": [
+     "minecraft:bedrock": [
         {
           "id": "minecraft:stone",
-          "weight": 100
-        },
-        {
-          "id": "minecraft:diorite",
-          "weight": 3
-        },
-        {
-          "id": "minecraft:andesite",
-          "weight": 3
+          "weight": 5
         },
         {
           "id": "minecraft:granite",
-          "weight": 3
+          "weight": 1
+        },
+        {
+          "id": "minecraft:diorite",
+          "weight": 1
+        },
+        {
+          "id": "minecraft:andesite",
+          "weight": 1
+        },
+        {
+          "id": "minecraft:tuff",
+          "weight: 1
         }
-      ]
+      ],
     },
     "basaltGen": {
       "minecraft:bedrock": [


### PR DESCRIPTION
Given the additional constraints of bedrock cobblegen:
* cannot choose location
* must mine out significant area
* must transport if not building base at bedrock level (unlikely)

It does not make sense over double compressed andesite - which is significantly easier to automate around.

With this proposed change, bedrock would be worthwhile again with good alt stone rates and the additional ability to generate tuff - which can be processed into nuggets.