### PR TITLE
Add crushing recipe for shimmer crystals

### DIFF
--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -181,6 +181,11 @@ function crushingRecipes(event) {
                 ["tconstruct:debris_nugget", 0.03],
             ],
         },
+        // AE2 Fluix/Shimmer Crystal Crushing
+        {
+            input: "ae2:fluix_crystal",
+            outputs: [["ae2:fluix_dust", 1]],
+        },
     ].forEach((recipe) => {
         let cleanoutputs = [];
         recipe.outputs.forEach((output) => {


### PR DESCRIPTION
Currently, shimmer crystals don't have a use in the modpack. As the shimmer liquid is not common enough to feasibly get 10k blocks worth of it and a farm would require too many moving parts, this change will help accelerate progression in the AE2 part of the pack.

Attempts to rectify #78 