### PR TITLE
Fix - TechReborn compressor not creating Ad Astra steel plate

### DIFF
--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -183,6 +183,7 @@ onEvent("recipes", (event) => {
         { output: "techreborn:quantum_leggings" },
         { output: "techreborn:quantum_boots" },
         { output: "techreborn:copper_nugget" },
+        { output: "techreborn:steel_plate" },
 
         {
             type: "techreborn:grinder",


### PR DESCRIPTION
TechReborn compressor created TechReborn steel plate previously; adding this line fixes.