### PR TITLE
fix two bugs

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_4.snbt
+++ b/config/ftbquests/quests/chapters/chapter_4.snbt
@@ -2202,15 +2202,22 @@
 		}
 		{
 			tasks: [
-				{
-					id: "3967A624C03BA62B"
-					type: "item"
-					item: "tconstruct:scorched_fuel_tank"
-				}
-				{
-					id: "3F799EF56B42E640"
-					type: "item"
-					item: "tconstruct:scorched_fuel_gauge"
+				title: "Any Scorched Tank"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "tconstruct:scorched_fuel_tank"
+								Count: 1b
+							}
+							{
+								id: "tconstruct:scorched_fuel_gauge"
+								Count: 1b
+							}
+						]
+					}
 				}
 			]
 			description: ["{chapter.5.quest.85.description.1}"]

--- a/kubejs/server_scripts/tags/graveReplaceBlacklist.js
+++ b/kubejs/server_scripts/tags/graveReplaceBlacklist.js
@@ -1,0 +1,9 @@
+onEvent("tags.blocks", (event) => {
+
+    const graveReplaceBlacklist = [
+        "customportalapi:customportalblock"
+    ];
+    graveReplaceBlacklist.forEach((entry) => {
+        event.add("yigd:replace_blacklist",entry);
+    });
+});


### PR DESCRIPTION
## Summary
- fix #95 by adding tag `yigd:replace_blacklist` to `customportalapi:customportalblock` 
- fix #169 using `itemfilter:or` 

## Testing
step into a portal, than run `/kill ZZZank` using a command block, the result:
![2023-06-07_20 11 05](https://github.com/Laskyyy/Create-Astral/assets/47418975/c600f0cd-d43f-4030-88e0-83c7e5ab605c)
The portal is not replaced.

and the quest:
![2023-06-07_20 11 41](https://github.com/Laskyyy/Create-Astral/assets/47418975/c446f00e-d547-4773-9ba6-6e429f0f0d1f)
![2023-06-07_20 11 45](https://github.com/Laskyyy/Create-Astral/assets/47418975/1c33e66c-6bb4-4129-90ef-3d819c0e2202)
