### PR TITLE
Copper cutting unification, also fix a bug

### DIFF
--- a/kubejs/server_scripts/tags/block.js
+++ b/kubejs/server_scripts/tags/block.js
@@ -1,0 +1,4 @@
+onEvent("item.tags", (event) => {
+    //TODO: move tags processing from server.js to tags/xxx.js
+
+});

--- a/kubejs/server_scripts/tags/block.js
+++ b/kubejs/server_scripts/tags/block.js
@@ -1,4 +1,4 @@
-onEvent("item.tags", (event) => {
-    //TODO: move tags processing from server.js to tags/xxx.js
+onEvent("tags.blocks", (event) => {
+    //TODO: move tags processing from server.js to tags/xxx.js, this should be done in a single and seperate PR
 
 });

--- a/kubejs/server_scripts/tags/item.js
+++ b/kubejs/server_scripts/tags/item.js
@@ -1,0 +1,6 @@
+onEvent("item.tags", (event) => {
+    //TODO: move tags processing from server.js to tags/xxx.js
+
+    //Cut Copper block unification, another part at unification.js
+    event.get("c:storage_blocks/copper").remove("minecraft:cut_copper");
+});

--- a/kubejs/server_scripts/unification.js
+++ b/kubejs/server_scripts/unification.js
@@ -1,0 +1,8 @@
+onEvent("recipes", (event) => {
+    //TODO: move other unification recipes, which is NOT related to progession, to this file
+
+    // target: Cut Copper block
+    // another part of this is tag cleanup, see tags/unification.js
+    event.remove({ id: "minecraft:cut_copper" });
+    event.stonecutting("4x minecraft:cut_copper", "minecraft:copper_block");
+});


### PR DESCRIPTION
## Summary
- The Cut Copper block(why such a name?) is now produced by stonecutting Copper Block, instead of a 2*2 workbench recipe. 
- Now every one Copper Block can make four Cut Copper (was one). This matches the style of making Weathered Cut Copper, also making a more affordable decoration block. 
- Now in smeltry, every one Cut Copper can turn into 2 ingots and 2 nuggets. This does not add any recipes, because there are two conflicting recipes for Cut Copper in smeltry, I removed the wrong one. 
- This also fixes #55

## Testing
Before: 
<img width="219" alt="image" src="https://github.com/Laskyyy/Create-Astral/assets/47418975/37ff43dd-1e89-4169-9c11-e0b3030d44d4">
After: 
<img width="238" alt="image" src="https://github.com/Laskyyy/Create-Astral/assets/47418975/ff9f7220-bf34-4cb5-a1b3-b1e31f780128">

Also, about the bug55, 
<img width="178" alt="image" src="https://github.com/Laskyyy/Create-Astral/assets/47418975/f47cf8bb-d5ca-42ed-adbe-33733e2b7a42">
<img width="183" alt="image" src="https://github.com/Laskyyy/Create-Astral/assets/47418975/22b8e0d5-188f-472d-b28f-1724e6914bd0">
<img width="200" alt="image" src="https://github.com/Laskyyy/Create-Astral/assets/47418975/0c364eaa-22fe-4433-b1e7-58f11b566e46">
Then, if one Cut Copper can still turn into 9 ingots, the amount of Copper will be x4, that's fixed now.