### PR TITLE
Balancing recipes for 'Createdeco' doors

### DIFF
--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -327,6 +327,13 @@ onEvent("recipes", (event) => {
         { mod: "create", output: "minecraft:andesite" },
         { input: "create:blaze_burner" },
 
+        // Create Deco
+
+        { output: "createdeco:andesite_door" },
+        { output: "createdeco:brass_door" },
+        { output: "createdeco:copper_door" },
+        { output: "createdeco:zinc_door" },
+
         //Create Additions
 
         { output: "createaddition:alternator" },

--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -793,6 +793,27 @@ onEvent("recipes", (event) => {
 
     //// ASSORTED CRAFTING BENCH RECIPES
 
+
+    // createdeco door recipe rebalance
+
+    event.shaped("3x createdeco:andesite_door", ["AA", "AA", "AA"], {
+        A: "create:andesite_alloy",
+    });
+
+    event.shaped("3x createdeco:brass_door", ["AA", "AA", "AA"], {
+        A: "create:brass_ingot",
+    });
+
+    event.shaped("3x createdeco:copper_door", ["AA", "AA", "AA"], {
+        A: "minecraft:copper_ingot",
+    });
+
+    event.shaped("3x createdeco:zinc_door", ["AA", "AA", "AA"], {
+        A: "create:zinc_ingot",
+    });
+
+    // end createdeco door recipe rebalance
+
     event.shaped("minecraft:bundle", [" S ", "A A", " A "], {
         S: "minecraft:string",
         A: "minecraft:leather",


### PR DESCRIPTION
Removed regular recipes for create deco doors (andesite, brass, copper, and zinc).

Added new recipes for create deco doors to give 3 doors instead of 1 like they do in vanilla (andesite, brass, copper, zinc).

-B0b