### PR TITLE
changed dispenser recipe

### DIFF
--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -551,6 +551,10 @@ onEvent("recipes", (event) => {
             input: "minecraft:copper_block",
             type: "minecraft:stonecutting",
         },
+
+        //dispenser recipe
+        {output: "minecraft:dispenser" },
+
     ].forEach((recipe) => {
         event.remove(recipe);
     });

--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -837,6 +837,12 @@ onEvent("recipes", (event) => {
 
     //// ASSORTED CRAFTING BENCH RECIPES
 
+    //dispenser recipe
+    event.shaped("minecraft:dispenser", ["AB ", "ACB", "AB "], {
+        A: "minecraft:string",
+        B: "minecraft:stick",
+        C: "minecraft:dropper",
+    });
 
     // createdeco door recipe rebalance
 


### PR DESCRIPTION
The dispenser recipe required a gun, which not only makes it harder to craft than in vanilla, but it also still uses an unstackable item making dispensers a pain to craft in bulk.

I changed the recipe to cost the same as it does in vanilla, but all items used to craft it can be stacked to 64 (droppers, string, and sticks).

-B0b