### PR TITLE
Prototype earlygame stone recipes

### DIFF
--- a/kubejs/server_scripts/alloys/Base_alloying.js
+++ b/kubejs/server_scripts/alloys/Base_alloying.js
@@ -1,0 +1,3 @@
+onEvent("recipes", event => {
+    
+})

--- a/kubejs/server_scripts/alloys/efficient_recipes.js
+++ b/kubejs/server_scripts/alloys/efficient_recipes.js
@@ -1,0 +1,3 @@
+onEvent("recipes", event => {
+    
+})

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -84,4 +84,50 @@ onEvent("recipes", event => {
         Item.of("techreborn:raw_tin").withChance(0.1),
         Item.of("minecraft:clay_ball").withChance(0.2)
     ], "create:asurine")
+    //crimsite - base
+    let inter = "createastral:incomplete_crimsite" //feel free to change this
+    event.recipes.createSequencedAssembly([
+        Item.of("create:crimsite").withChance(16.0),
+        Item.of("minecraft:flint").withChance(4.0)//this results in 80% success chance
+    ], "minecraft:flint", [ //input
+        event.recipes.createFilling(inter, [inter, Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10)]),
+        event.recipes.createDeploying(inter, [inter, Item.of("minecraft:flint")]),
+        event.recipes.createPressing(inter, inter) //smol changes to default crimsite
+    ]).transitionalItem(inter).loops(2)
+    //crimsite + netherrack - upgraded
+    event.recipes.createMixing([
+        Item.of("minecraft:netherrack"),
+        Item.of("techreborn:small_pile_of_sulfur_dust").withChance(0.4)
+    ], [
+        Item.of("create:scoria"),
+        Item.of("minecraft:red_sand"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10)
+    ])
+    event.recipes.createMixing([
+        Item.of("minecraft:netherrack"),
+        Item.of("techreborn:small_pile_of_cinnabar_dust").withChance(0.75)
+    ], [
+        Item.of("create:scoria"),
+        Item.of("minecraft:red_dye"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
+    ]).heated()
+    event.recipes.createCrushing([
+        Item.of("techreborn:netherrack_dust"),
+        Item.of("techreborn:netherrack_dust").withChance(0.75),
+        Item.of("techreborn:granite_dust").withChance(0.4)
+    ], [
+        Item.of("minecraft:netherrack")
+    ])
+    event.recipes.createMilling([
+        Item.of("techreborn:netherrack_dust"),
+        Item.of("techreborn:netherrack_dust").withChance(0.3)
+    ])
+    event.recipes.createCompacting([
+        Item.of("2x create:crimsite"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 2)
+    ], [
+        Item.of("2x minecraft:basalt"),
+        Item.of("techreborn:netherrack_dust"),
+        Item.of("2x minecraft:flint")
+    ])
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -1,0 +1,39 @@
+onEvent("recipes", event => {
+    //base method
+    event.custom({
+        "type": "tconstruct:casting_basin",
+        "cast": {
+          "item": "tconstruct:seared_stone"
+        },
+        "cast_consumed": true,
+        "fluid": {
+          "tag": "minecraft:lava",
+          "amount": 1000
+        },
+        "result": "create:veridium",
+        "cooling_time": 60
+      })
+    event.recipes.createCrushing("create:veridium",
+     [Item.of("minecraft:raw_copper").withChance(0.3), 
+     Item.of("minecraft:clay_ball").withChance(0.25), 
+     Item.of("techreborn:olivine_dust").withChance(0.5)
+    ])
+    event.recipes.createMilling("create:veridium", [
+        Item.of("minecraft:raw_copper").withChance(0.15),
+        Item.of("minecraft:clay_ball").withChance(0.15)
+    ])
+    //upgraded method
+    event.recipes.createMixing(Item.of("2x create:veridium"), [
+        "techreborn:peridot",
+        "techreborn:peridot",
+        "create:scoria",
+        "create:scoria"
+    ])
+    event.recipes.createCompacting(Item.of("4x techreborn:peridot"), [
+        "techreborn:olivine_dust",
+        "techreborn:olivine_dust",
+        "techreborn:olivine_dust",
+        Fluid.of("minecraft:lava", 200)
+    ])
+
+})

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -1,3 +1,5 @@
+var FULL_BUCKET_AMMOUNT = 81000;
+var INGOT_FLUID_AMMOUNT = 9000;
 onEvent("recipes", event => {
     //base method
     event.custom({
@@ -8,7 +10,7 @@ onEvent("recipes", event => {
         "cast_consumed": true,
         "fluid": {
           "tag": "minecraft:lava",
-          "amount": 1000
+          "amount": FULL_BUCKET_AMMOUNT
         },
         "result": "create:veridium",
         "cooling_time": 60
@@ -33,7 +35,7 @@ onEvent("recipes", event => {
         "techreborn:olivine_dust",
         "techreborn:olivine_dust",
         "techreborn:olivine_dust",
-        Fluid.of("minecraft:lava", 200)
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 5)
     ])
     //ochrum - base method
     event.recipes.createCompacting(Item.of("create:ochrum"), [
@@ -55,7 +57,7 @@ onEvent("recipes", event => {
     event.recipes.createCompacting(Item.of("2x create:ochrum"), [
         Item.of("2x create:limestone"),
         Item.of("6x minecraft:pyrite_dust"),
-        Fluid.of("kubejs:shimmer", 100)
+        Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10)
     ])
     //asurine - base method
     //time is intentional - gotta deal with logistics in this one (100 secs btw)
@@ -67,7 +69,7 @@ onEvent("recipes", event => {
         "cast_consumed": true,
         "fluid": {
           "tag": "minecraft:water",
-          "amount": 1000
+          "amount": FULL_BUCKET_AMMOUNT
         },
         "result": "tconstruct:seared_brick",
         "cooling_time": 2000

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -227,4 +227,42 @@ onEvent("recipes", event => {
         Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10)
     ]).heated()
     event.recipes.createSplashing(Item.of("create:zinc_nugget").withChance(0.6), "minecraft:red_sand")
+    //diorite time - a la Bob
+    event.recipes.createCompacting([
+        Item.of("minecraft:diorite")
+    ], [
+        Item.of("minecraft:cobblestone"),
+        Item.of("techreborn:diorite_dust"),
+        Fluid.of("tconstruct:molten_quartz", FULL_BUCKET_AMMOUNT / 40) //=25 mb
+    ])
+    event.recipes.createCompacting([
+        Item.of("2x minecraft:diorite")
+    ], [
+        Item.of("techreborn:diorite_dust"),
+        Item.of("minecraft:cobblestone"),
+        Fluid.of("tconstruct:molten_quartz", FULL_BUCKET_AMMOUNT / 25) //=40 mb
+    ]).heated()
+    //making the diorite loop whole
+    event.recipes.createMilling([
+        Item.of("techreborn:diorite_dust")
+    ], [
+        Item.of("minecraft:diorite")
+    ])
+    event.recipes.createCrushing([
+        Item.of("techreborn:diorite_dust"),
+        Item.of("techreborn:diorite_dust").withChance(0.25),
+        Item.of("techreborn:marble_dust").withChance(0.2)
+    ], [
+        Item.of("minecraft:diorite")
+    ])
+    //insert grinding for a guaranteed 2 diorite dust here
+    let downloadbattlecats = "kubejs:incomplete_quartz"
+    event.recipes.createSequencedAssembly([
+        Item.of("minecraft:nether_quartz").withChance(16.0),
+        Item.of("2x minecraft:nether_quartz").withChance(4.0) //20% chance for double quartz, for fun 
+    ], "minecraft:diorite", [ //input
+        event.recipes.createPressing(downloadbattlecats, downloadbattlecats),
+        event.recipes.createSawing(downloadbattlecats, downloadbattlecats),
+        event.recipes.createDeploying(downloadbattlecats, [downloadbattlecats, "create:sandpaper"])
+    ]).transitionalItem(downloadbattlecats).loops(1)
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -239,7 +239,7 @@ onEvent("recipes", event => {
         Item.of("2x minecraft:diorite")
     ], [
         Item.of("techreborn:diorite_dust"),
-        Item.of("minecraft:cobblestone"),
+        Item.of("2x minecraft:cobblestone"),
         Fluid.of("tconstruct:molten_quartz", FULL_BUCKET_AMMOUNT / 25) //=40 mb
     ]).heated()
     //making the diorite loop whole
@@ -250,7 +250,7 @@ onEvent("recipes", event => {
     ])
     event.recipes.createCrushing([
         Item.of("techreborn:diorite_dust"),
-        Item.of("techreborn:diorite_dust").withChance(0.25),
+        Item.of("techreborn:diorite_dust").withChance(0.5),
         Item.of("techreborn:marble_dust").withChance(0.2)
     ], [
         Item.of("minecraft:diorite")
@@ -265,4 +265,101 @@ onEvent("recipes", event => {
         event.recipes.createSawing(downloadbattlecats, downloadbattlecats),
         event.recipes.createDeploying(downloadbattlecats, [downloadbattlecats, "create:sandpaper"])
     ]).transitionalItem(downloadbattlecats).loops(1)
+    //tuff a la bob
+    let fortniteshit = "kubejs:incomplete_tuff"
+    event.recipes.createSequencedAssembly([
+        Item.of("minecraft:tuff")
+    ], "minecraft:cobblestone", [
+        event.recipes.createDeploying(fortniteshit, [fortniteshit, "techreborn:small_pile_of_granite_dust"]),
+        event.recipes.createDeploying(fortniteshit, [fortniteshit, "techreborn:small_pile_of_andesite_dust"]),
+        event.recipes.createDeploying(fortniteshit, [fortniteshit, "techreborn:small_pile_of_diorite_dust"])
+    ]).transitionalItem(fortniteshit).loops(1)
+    event.custom({
+        "type":"createaddition:charging",
+        "input": {
+            "item": "minecraft:tuff",
+            "count": 1
+        },
+        "result": {
+            "item": "techreborn:ashes",
+            "count": 2
+        },
+        "energy": 10000
+    })
+    event.recipes.createSplashing([
+        Item.of("minecraft:gold_nugget").withChance(0.2),
+        Item.of("create:zinc_nugget").withChance(0.225),
+        Item.of("create:copper_nugget").withChance(0.3),
+        Item.of("techreborn:tin_nugget").withChance(0.25)
+    ], [
+        "techreborn:ashes"
+    ])
+    //granite a la bob
+    event.recipes.createCompacting([
+        Item.of("minecraft:granite"),
+        Fluid.of("techreborn:sodium_persulfate", FULL_BUCKET_AMMOUNT / 100).withChance(0.35)
+    ], [
+        Item.of("minecraft:cobblestone"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 40),
+        Item.of("minecraft:red_sand")
+    ]) //sodium persulfate increases yields in industrial grinder in vanilla TR
+    event.recipes.createCompacting([
+        Item.of("2x minecraft:granite"),
+        Fluid.of("techreborn:sodium_persulfate", FULL_BUCKET_AMMOUNT / 50).withChance(0.6)
+    ], [
+        Item.of("2x minecraft:cobblestone"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 25), //=40 mb
+        Item.of("minecraft:red_sand")
+    ])
+    let intermediate = "kubejs:incomplete_granite"
+    event.recipes.createSequencedAssembly([
+        Item.of("techreborn:ruby").withChance(6.0),
+        Item.of("minecraft:raw_gold").withChance(2.0),
+        Item.of("createastral:cinnabar").withChance(4.0) //50% ruby, 36% cinnabar, 14% gold
+    ], "minecraft:granite", [
+        event.recipes.createPressing(intermediate, intermediate),
+        event.recipes.createSawing(intermediate, intermediate),
+        event.recipes.createDeploying(intermediate, [intermediate, "create:sandpaper"])
+    ]).transitionalItem(intermediate).loops(2)
+    //drip
+    event.recipes.createMixing([
+        Item.of("10x minecraft:clay_ball")
+    ], [
+        Fluid.of("minecraft:water", FULL_BUCKET_AMMOUNT / 2),
+        Item.of("minecraft:sand"),
+        Item.of("minecraft:gravel"),
+        Item.of("minecraft:dripstone_spike") //this id is probably wrong
+    ])
+    event.recipes.createMixing([
+        Item.of("6x techreborn:clay_dust") //since water takes up mass it would give more wet clay than dry
+    ], [
+        Item.of("minecraft:gravel"),
+        Item.of("minecraft:sand"),
+        Item.of("minecraft:dripstone_spike")
+    ])
+    //stone dusts need an extra recipe lol
+    event.custom({
+        "type": "createaddition:charging",
+        "input": {
+            "item": "minecraft:stone",
+            "count": 1
+        },
+        "result": {
+            "item": "techreborn:stone_dust",
+            "count": 10
+        },
+        "energy": 5000
+    })
+    event.custom({
+        type: "techreborn:grinder",
+        power: 10, //in E/tick
+        time: 10, //in seconds I believe
+        input: {
+            item: "minecraft:smooth_stone"
+        },
+        result: {
+            item: "techreborn:stone_dust",
+            count: 2
+        }
+    }) //this recipe should use 2000 E
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -85,7 +85,7 @@ onEvent("recipes", event => {
         Item.of("minecraft:clay_ball").withChance(0.2)
     ], "create:asurine")
     //crimsite - base
-    let inter = "createastral:incomplete_crimsite" //feel free to change this
+    let inter = "kubejs:incomplete_crimsite" //feel free to change this
     event.recipes.createSequencedAssembly([
         Item.of("create:crimsite").withChance(16.0),
         Item.of("minecraft:flint").withChance(4.0)//this results in 80% success chance

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -111,6 +111,15 @@ onEvent("recipes", event => {
         Item.of("minecraft:red_dye"),
         Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
     ]).heated()
+    event.recipes.createMixing([
+        Item.of("minecraft:netherrack"),
+        Item.of("minecraft:netherrack").withChance(0.5),
+        Item.of("techreborn:sulfur_dust").withChance(0.3)
+    ], [
+        Item.of("create:scoria"),
+        Item.of("minecraft:red_sand"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
+    ]).heated()
     event.recipes.createCrushing([
         Item.of("techreborn:netherrack_dust"),
         Item.of("techreborn:netherrack_dust").withChance(0.75),

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -226,4 +226,5 @@ onEvent("recipes", event => {
         Item.of("techreborn:sodalite_dust"),
         Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10)
     ]).heated()
+    event.recipes.createSplashing(Item.of("create:zinc_nugget").withChance(0.6), "minecraft:red_sand")
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -95,42 +95,7 @@ onEvent("recipes", event => {
         event.recipes.createPressing(inter, inter) //smol changes to default crimsite
     ]).transitionalItem(inter).loops(2)
     //crimsite + netherrack - upgraded
-    event.recipes.createMixing([
-        Item.of("minecraft:netherrack"),
-        Item.of("techreborn:small_pile_of_sulfur_dust").withChance(0.4)
-    ], [
-        Item.of("create:scoria"),
-        Item.of("minecraft:red_sand"),
-        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10)
-    ])
-    event.recipes.createMixing([
-        Item.of("minecraft:netherrack"),
-        Item.of("techreborn:small_pile_of_cinnabar_dust").withChance(0.75)
-    ], [
-        Item.of("create:scoria"),
-        Item.of("minecraft:red_dye"),
-        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
-    ]).heated()
-    event.recipes.createMixing([
-        Item.of("minecraft:netherrack"),
-        Item.of("minecraft:netherrack").withChance(0.5),
-        Item.of("techreborn:sulfur_dust").withChance(0.3)
-    ], [
-        Item.of("create:scoria"),
-        Item.of("minecraft:red_sand"),
-        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
-    ]).heated()
-    event.recipes.createCrushing([
-        Item.of("techreborn:netherrack_dust"),
-        Item.of("techreborn:netherrack_dust").withChance(0.75),
-        Item.of("techreborn:granite_dust").withChance(0.4)
-    ], [
-        Item.of("minecraft:netherrack")
-    ])
-    event.recipes.createMilling([
-        Item.of("techreborn:netherrack_dust"),
-        Item.of("techreborn:netherrack_dust").withChance(0.3)
-    ])
+
     event.recipes.createCompacting([
         Item.of("2x create:crimsite"),
         Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 2)
@@ -371,4 +336,80 @@ onEvent("recipes", event => {
             count: 2
         }
     }) //this recipe should use 2000 E
+    //nether blocks time
+    function nethershit(event) {
+        //netherrack
+        event.recipes.createMixing([
+            Item.of("minecraft:netherrack"),
+            Item.of("techreborn:small_pile_of_sulfur_dust").withChance(0.4)
+        ], [
+            Item.of("create:scoria"),
+            Item.of("minecraft:red_sand"),
+            Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10)
+        ])
+        event.recipes.createMixing([
+            Item.of("minecraft:netherrack"),
+            Item.of("techreborn:small_pile_of_cinnabar_dust").withChance(0.75)
+        ], [
+            Item.of("create:scoria"),
+            Item.of("minecraft:red_dye"),
+            Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
+        ]).heated()
+        event.recipes.createMixing([
+            Item.of("minecraft:netherrack"),
+            Item.of("minecraft:netherrack").withChance(0.5),
+            Item.of("techreborn:sulfur_dust").withChance(0.3)
+        ], [
+            Item.of("create:scoria"),
+            Item.of("minecraft:red_sand"),
+            Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 20)
+        ]).heated()
+        event.recipes.createCrushing([
+            Item.of("techreborn:netherrack_dust"),
+            Item.of("techreborn:netherrack_dust").withChance(0.75),
+            Item.of("techreborn:granite_dust").withChance(0.4)
+        ], [
+            Item.of("minecraft:netherrack")
+        ])
+        event.recipes.createMilling([
+            Item.of("techreborn:netherrack_dust"),
+            Item.of("techreborn:netherrack_dust").withChance(0.3)
+        ], "minecraft:netherrack")
+    //crimson nylium
+    let i = "kubejs:incomplete_crimson_nylium"
+    event.recipes.createSequencedAssembly([
+        Item.of("minecraft:crimson_nylium")
+    ], "minecraft:netherrack", [
+        event.recipes.createDeploying(i, [i, "minecraft:crimson_fungus"]),
+        event.recipes.createFilling(i, [i, Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 40)]),
+        event.recipes.createDeploying(i, [i, "minecraft:nether_wart"])
+    ]).transitionalItem(i).loops(1)
+    event.recipes.createCompacting([
+        Item.of("2x minecraft:crimson_nylium"),
+        Fluid.of("techreborn:methane", FULL_BUCKET_AMMOUNT / 50).withChance(0.5)
+    ], [
+        Item.of("minecraft:crimson_fungus"),
+        Item.of("2x minecraft:netherrack"),
+        Item.of("minecraft:nether_wart"),
+        Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 20)
+    ]).heated()
+    //warped nylium
+    let jeoma = "kubejs:incomplete_warped_nylium"
+    event.recipes.createSequencedAssembly([
+        Item.of("minecraft:warped_nylium")
+    ], "minecraft:netherrack", [
+        event.recipes.createDeploying(jeoma, [jeoma, "minecraft:warped_fungus"]),
+        event.recipes.createFilling(jeoma, [jeoma, Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 40)]),
+        event.recipes.createDeploying(jeoma, [jeoma, "minecraft:nether_wart"])
+    ]).transitionalItem(jeoma).loops(1)
+    event.recipes.createCompacting([
+        Item.of("2x minecraft:warped_nylium"),
+        Fluid.of("techreborn:methane", FULL_BUCKET_AMMOUNT / 50).withChance(0.5)
+    ], [
+        Item.of("minecraft:warped_fungus"),
+        Item.of("2x minecraft:netherrack"),
+        Item.of("minecraft:nether_wart"),
+        Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 20)
+    ]).heated()
+    }
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -13,15 +13,15 @@ onEvent("recipes", event => {
         "result": "create:veridium",
         "cooling_time": 60
       })
-    event.recipes.createCrushing("create:veridium",
-     [Item.of("minecraft:raw_copper").withChance(0.3), 
-     Item.of("minecraft:clay_ball").withChance(0.25), 
-     Item.of("techreborn:olivine_dust").withChance(0.5)
-    ])
-    event.recipes.createMilling("create:veridium", [
-        Item.of("minecraft:raw_copper").withChance(0.15),
-        Item.of("minecraft:clay_ball").withChance(0.15)
-    ])
+    //veridium - outputs - base
+    event.recipes.createCrushing([
+    Item.of("minecraft:raw_copper").withChance(0.3), 
+    Item.of("minecraft:clay_ball").withChance(0.25), 
+    Item.of("techreborn:olivine_dust").withChance(0.5)
+   ], "create:veridium")
+    event.recipes.createMilling([
+    Item.of("minecraft:raw_copper").withChance(0.15),
+    Item.of("minecraft:clay_ball").withChance(0.15)], "create:veridium")
     //upgraded method
     event.recipes.createMixing(Item.of("2x create:veridium"), [
         "techreborn:peridot",
@@ -35,5 +35,51 @@ onEvent("recipes", event => {
         "techreborn:olivine_dust",
         Fluid.of("minecraft:lava", 200)
     ])
-
+    //ochrum - base method
+    event.recipes.createCompacting(Item.of("create:ochrum"), [
+        Item.of("4x minecraft:sand"),
+        "create:limestone",
+        "techreborn:pyrite_dust"
+    ])
+    event.recipes.createSplashing(Item.of("techreborn:pyrite_dust").withChance(0.3), "minecraft:sand")
+    event.recipes.createCrushing([
+        Item.of("minecraft:raw_gold").withChance(0.15),
+        Item.of("techreborn:pyrite_dust").withChance(0.4),
+        Item.of("techreborn:limestone_dust").withChance(0.6)
+    ], "create:ochrum")
+    event.recipes.createMilling([
+        Item.of("minecraft:raw_gold").withChance(0.1),
+        Item.of("techreborn:granite_dust").withChance(0.3)
+    ], "create:ochrum")
+    //ochrum - upgraded method
+    event.recipes.createCompacting(Item.of("2x create:ochrum"), [
+        Item.of("2x create:limestone"),
+        Item.of("6x minecraft:pyrite_dust"),
+        Fluid.of("kubejs:shimmer", 100)
+    ])
+    //asurine - base method
+    //time is intentional - gotta deal with logistics in this one (100 secs btw)
+    event.custom({
+        "type": "tconstruct:casting_basin",
+        "cast": {
+          "item": "minecraft:seared_stone"
+        },
+        "cast_consumed": true,
+        "fluid": {
+          "tag": "minecraft:water",
+          "amount": 1000
+        },
+        "result": "tconstruct:seared_brick",
+        "cooling_time": 2000
+      })
+    //asurine - outputs - base
+    event.recipes.createCrushing([
+        Item.of("techreborn:raw_tin").withChance(0.2),
+        Item.of("techreborn:lazurite_dust").withChance(0.3),
+        Item.of("minecraft:clay_ball").withChance(0.4)
+    ], "create:asurine")
+    event.recipes.createMilling([
+        Item.of("techreborn:raw_tin").withChance(0.1),
+        Item.of("minecraft:clay_ball").withChance(0.2)
+    ], "create:asurine")
 })

--- a/kubejs/server_scripts/rock_and_stone/earlygame.js
+++ b/kubejs/server_scripts/rock_and_stone/earlygame.js
@@ -130,4 +130,100 @@ onEvent("recipes", event => {
         Item.of("techreborn:netherrack_dust"),
         Item.of("2x minecraft:flint")
     ])
+    //red sandstone - base
+    //sand
+    event.recipes.createCrushing([
+        Item.of("minecraft:gravel"),
+        Item.of("techreborn:andesite_dust").withChance(0.2),
+        Item.of("techreborn:granite_dust").withChance(0.15),
+        Item.of("techreborn:diorite_dust").withChance(0.15)
+    ], [
+        Item.of("minecraft:cobblestone")
+    ])
+    event.recipes.createMilling("minecraft:gravel", "minecraft:cobblestone")
+    //cant find the grinder json rq, so I'll treat it as midgame and not bother
+    //sand
+    event.recipes.createMixing([
+        Item.of("minecraft:sand"),
+        Item.of("minecraft:clay_ball").withChance(0.2)
+    ], [
+        Item.of("2x minecraft:gravel"),
+        Fluid.of("minecraft:water", FULL_BUCKET_AMMOUNT)  
+    ])
+    event.recipes.createMilling([
+        Item.of("minecraft:sand").withChance(0.33),
+        Item.of("techreborn:flint_dust").withChance(0.2),
+        Item.of("techreborn:small_pile_of_yellow_garnet_dust").withChance(0.4)
+    ], [
+        Item.of("minecraft:gravel")
+    ])
+    event.recipes.createCrushing([
+        Item.of("minecraft:sand"),
+        Item.of("minecraft:sand").withChance(0.25),
+        Item.of("minecraft:clay_ball").withChance(0.1)
+    ])
+    //red sand
+    event.recipes.createCompacting([
+        Item.of("minecraft:red_sand"),
+    ], [
+        Item.of("minecraft:sand"),
+        Item.of("techreborn:granite_dust")
+    ])
+    event.recipes.createCompacting([
+        Item.of("minecraft:red_sand"),
+        Item.of("minecraft:red_sand").withChance(0.5)
+    ], [
+        Item.of("minecraft:sand"),
+        Item.of("minecraft:red_dye"),
+        Item.of("techreborn:granite_dust")
+    ])
+    //red sandstone
+    event.recipes.createCompacting([
+        Item.of("minecraft:red_sandstone")
+    ], [
+        Item.of("4x minecraft:red_sand")
+    ])
+    event.custom({
+        "type": "tconstruct:casting_basin",
+        "cast": {
+          "item": "minecraft:red_sand"
+        },
+        "cast_consumed": true,
+        "fluid": {
+          "tag": "tconstruct:molten_clay",
+          "amount": FULL_BUCKET_AMMOUNT / 10
+        },
+        "result": "minecraft:red_sandstone",
+        "cooling_time": 100
+      })
+    //outputs of our sandstone - base
+    event.recipes.createCrushing([
+        Item.of("create:raw_zinc").withChance(0.33),
+        Item.of("techreborn:yellow_garnet").withChance(0.25)
+    ], [
+        Item.of("minecraft:chiseled_red_sandstone")
+    ]),
+    event.recipes.createMilling([
+        Item.of("create:raw_zinc").withChance(0.2)
+    ], [
+        Item.of("minecraft:chiseled_red_sandstone")
+    ])
+    event.recipes.createMixing([
+        Item.of("create:raw_zinc").withChance(0.5),
+        Item.of("techreborn:grossular_dust").withChance(0.25),
+        Item.of("techreborn:yellow_garnet").withChance(0.4)
+    ], [
+        Item.of("minecraft:chiseled_red_sandstone"),
+        Item.of("techreborn:stone_dust"),
+        Fluid.of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10)
+    ])
+    event.recipes.createMixing([
+        Item.of("create:raw_zinc"),
+        Item.of("techreborn:yellow_garnet").withChance(0.5),
+        Item.of("techreborn:red_garnet").withChance(0.3)
+    ], [
+        Item.of("minecraft:chiseled_red_sandstone"),
+        Item.of("techreborn:sodalite_dust"),
+        Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10)
+    ]).heated()
 })

--- a/kubejs/server_scripts/rock_and_stone/endgame.js
+++ b/kubejs/server_scripts/rock_and_stone/endgame.js
@@ -1,0 +1,3 @@
+onEvent("recipes", event => {
+    
+})

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -1,0 +1,3 @@
+onEvent("recipes", event => {
+    
+})

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -12,15 +12,15 @@ onEvent("recipes", event => {
     event.recipes.createCrushing([
         Item.of("techreborn:cinnabar_dust")
     ], [
-        Item.of("createastral:cinnabar") //add a custom crystal thingy here
+        Item.of("kubejs:cinnabar") //add a custom crystal thingy here
     ])
     event.recipes.createMilling([
         Item.of("techreborn:cinnabar_dust").withChance(0.7)
     ], [
-        Item.of("createastral:cinnabar")
+        Item.of("kubejs:cinnabar")
     ])
     event.recipes.createMixing([
-        Fluid.of("createastral:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10), //add a custom fluid here
+        Fluid.of("kubejs:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10), //add a custom fluid here
         Item.of("techreborn:andradite_dust").withChance(0.6)
     ], [
         Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 10),
@@ -30,7 +30,7 @@ onEvent("recipes", event => {
         Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 20),
         Fluid.of("tconstruct:molten_gold", INGOT_FLUID_AMMOUNT * 3)
     ], [
-        Fluid.of("createastral:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10)
+        Fluid.of("kubejs:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10)
     ]).heated()
 }
 function skystoneshit (event) {

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -151,4 +151,78 @@ function skystoneshit (event) {
             "block_in": "minecraft:water"
           })
     }
+    function marsshit (event) {
+        event.custom({
+            "type": "lychee:block_crushing",
+            "post": [
+              {
+                "type": "prevent_default"
+              },
+              {
+                "type": "drop_item",
+                "contextual": [
+                  {
+                    "type": "chance",
+                    "chance": 0.4
+                  }
+                ],
+                "item": "ad_astra:mars:sand"
+              },
+              {
+                "type": "place",
+                "block": "ad_astra:mars_stone"
+              }
+            ],
+            "max_repeats": 1,
+            "falling_block": "minecraft:anvil",
+            "landing_block": "ad_astra:mars_stone"
+          }
+          )
+        event.recipes.createCompacting([
+            Item.of("ad_astra:conglomerate").withChance(0.4),
+            Item.of("minecraft:gold_nugget").withChance(0.2)
+        ], [
+            Item.of("ad_astra:mars_sand"),
+            Fluid,of("minecraft:lava", FULL_BUCKET_AMMOUNT / 10),
+            Item.of("create:limestone")
+        ])
+        event.recipes.createCrushing([
+            Item.of("techreborn:raw_lead").withChance(0.3),
+            Item.of("techreborn:sulfur_dust").withChance(0.6),
+            Item.of("powah:uraninite").withChance(0.2)
+        ], [
+            Item.of("ad_astra:conglomerate")
+        ])
+        event.custom({
+            type: "techreborn:grinder",
+            power: 20,
+            time: 5, //is 5*20*20 = 2000 E
+            input: {
+                Item: "ad_astra:conglomerate",
+                count: 1
+            },
+            result: {
+                Item: "techreborn:lead_dust"
+            }
+        })
+        event.custom({
+            type: "techreborn:industrial_grinder",
+            power: 50,
+            time: 10, //is 50*10*20 = 20000 E
+            tank: {
+                fluid: "techreborn:mercury",
+                amount: 200
+            },
+            ingredients: {
+                Item: "ad_astra:conglomerate",
+                count: 4
+            },
+            results: [{
+                Item: "techreborn:lead_dust",
+                count: 2
+            }, {
+                Item: "powah:uraninite"
+            }]
+        })
+    }
 })

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -106,28 +106,6 @@ function skystoneshit (event) {
             ],
             "block_in": "minecraft:water"
           })
-    event.custom({
-        "type": "lychee:item_inside",
-        "post": [
-          {
-            "type": "drop_item",
-            "contextual": [
-              {
-                "type": "chance",
-                "chance": 0.5
-              }
-            ],
-            "item": "ad_astra:desh_nugget",
-            "count": 1
-          },
-        ],
-        "item_in": [
-          {
-            "item": "ad_astra:moon_sand"
-          }
-        ],
-        "block_in": "minecraft:water"
-      })
         event.custom({
             "type": "lychee:item_inside",
             "contextual": [

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -63,5 +63,114 @@ function skystoneshit (event) {
         Item.of("2x ae2:skystone_dust"),
         Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10) //=100 mb
       ])
-}
+    }
+    function moonstone (event) {
+        event.custom({
+            "type": "lychee:item_inside",
+            "contextual": [
+              {
+                "type": "location",
+                "predicate": {
+                  "dimension": "ad_astra:moon"
+                }
+              }
+            ],
+            "post": [
+              {
+                "type": "drop_item",
+                "contextual": [
+                  {
+                    "type": "chance",
+                    "chance": 0.7
+                  }
+                ],
+                "item": "ad_astra:desh_nugget",
+                "count": 4
+              },
+              {
+                "type": "drop_item",
+                "contextual": [
+                  {
+                    "type": "chance",
+                    "chance": 0.3
+                  }
+                ],
+                "item": "ad_astra:moon_cheese",
+                "count": 2
+              }
+            ],
+            "item_in": [
+              {
+                "item": "ad_astra:moon_sand"
+              }
+            ],
+            "block_in": "minecraft:water"
+          })
+    event.custom({
+        "type": "lychee:item_inside",
+        "post": [
+          {
+            "type": "drop_item",
+            "contextual": [
+              {
+                "type": "chance",
+                "chance": 0.5
+              }
+            ],
+            "item": "ad_astra:desh_nugget",
+            "count": 1
+          },
+        ],
+        "item_in": [
+          {
+            "item": "ad_astra:moon_sand"
+          }
+        ],
+        "block_in": "minecraft:water"
+      })
+        event.custom({
+            "type": "lychee:item_inside",
+            "contextual": [
+              {
+                "type": "location",
+                "predicate": {
+                  "dimension": "ad_astra:moon"
+                }
+              }
+            ],
+            "post": [
+              {
+                "type": "drop_item",
+                "contextual": [
+                  {
+                    "type": "chance",
+                    "chance": 0.7
+                  }
+                ],
+                "item": "ad_astra:desh_nugget",
+                "count": 4
+              },
+              {
+                "type": "drop_item",
+                "contextual": [
+                  {
+                    "type": "chance",
+                    "chance": 0.3
+                  }
+                ],
+                "item": "ad_astra:moon_cheese",
+                "count": 2
+              }
+            ],
+            "item_in": [
+              {
+                "item": "ad_astra:moon_sand"
+              },
+              {
+                "item": "ae2:skystone_dust"
+              }
+            ],
+            "block_in": "minecraft:water"
+          })
+    }
 })

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -1,6 +1,7 @@
 var FULL_BUCKET_AMMOUNT = 81000;
 var INGOT_FLUID_AMMOUNT = 9000;
 onEvent("recipes", event => {
+    function goldshit(event) {
     //ochrum - outputs - advanced
     event.recipes.createMixing([
         Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 10),
@@ -31,4 +32,36 @@ onEvent("recipes", event => {
     ], [
         Fluid.of("createastral:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10)
     ]).heated()
+}
+function skystoneshit (event) {
+    event.custom({
+        "type": "lychee:block_exploding",
+        "post": [
+          {
+            "type": "drop_item",
+            "item": "ae2:skystone_dust",
+            "count": 2
+          },
+          {
+            "type": "place",
+            "block": "ae2:skystone"
+          }
+        ],
+        "block_in": "ae2:skystone"
+      })
+      event.recipes.createCompacting(
+        "ae2:skystone", [
+            Item.of("2x ae2:skystone_dust"),
+            Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 20)  //=50 mb
+        ]
+      )
+      event.recipes.createCompacting([
+        Item.of("ae2:skystone").withChance(0.5),
+        Item.of("ae2:skystone")
+      ], [
+        Item.of("minecraft:basalt"),
+        Item.of("2x ae2:skystone_dust"),
+        Fluid.of("kubejs:shimmer", FULL_BUCKET_AMMOUNT / 10) //=100 mb
+      ])
+}
 })

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -179,6 +179,12 @@ function skystoneshit (event) {
           }
           )
         event.recipes.createCompacting([
+            Item.of("ad_astra:mars_stone")
+        ], [
+            Item.of("ad_astra:mars_sand"),
+            Item.of("ad_astra:mars_sand")
+        ]).heated()
+        event.recipes.createCompacting([
             Item.of("ad_astra:conglomerate").withChance(0.4),
             Item.of("minecraft:gold_nugget").withChance(0.2)
         ], [
@@ -224,5 +230,61 @@ function skystoneshit (event) {
                 Item: "powah:uraninite"
             }]
         })
+        //infernal spire - netherite
+        let inter = "kubejs:incomplete_infernal_spire"
+        event.recipes.createSequencedAssembly([
+            Item.of("ad_astra:infernal_spire_block").withChance(4),
+            Item.of("techreborn:scrap").withChance(1)
+        ], "minecraft:basalt", [
+            event.recipes.createDeploying(inter, [inter, "ad_astra:mars_sand"]),
+            event.recipes.createFilling(inter, [inter, Fluid.of("kubejs:hellfire", FULL_BUCKET_AMMOUNT / 20)]), //is 50 mb
+            event.recipes.createCutting(inter, inter)
+        ]).transitionalItem(inter).loops(2)
+        event.recipes.createCrushing([
+            Item.of("tconstruct:debris_nugget").withChance(0.1),
+            Item.of("powah:uraninite").withChance(0.25)
+        ], [
+            Item.of("ad_astra:infernal_spire_block")
+        ])
+        event.custom({
+            type: "techreborn:grinder",
+            power: 15,
+            time: 10, //is 10*15*20 = 3000 E
+            input: {
+                item: "ad_astra:infernal_spire_block",
+                count: 4
+            },
+            result: {
+                item: "tconstruct:debris_nugget"
+            }
+        })
+        event.custom({
+            type: "techreborn:industrial_grinder",
+            power: 30,
+            time: 20, //is 30*20*20 = 12000 E
+            tank: {
+                fluid: "techreborn:mercury",
+                amount: 500
+            },
+            ingredients: [{
+                item: "ad_astra:infernal_spire_block",
+                count: 2
+            }],
+            results: [{
+                item: "kubejs:ground_debris"
+            }, {
+                fluid: "techreborn:sodium_persulfate",
+                amount: 100
+            }]
+        })
+        event.recipes.createCutting("kubejs:cut_debris", "kubejs:ground_debris")
+        event.recipes.createCompacting([
+            Item.of("minecraft:ancient_debris").withChance(0.7),
+            Item.of("techreborn:sulfur_dust"),
+            Fluid.of("kubejs:hellfire", FULL_BUCKET_AMMOUNT / 10)
+        ], [
+            Item.of("kubejs:cut_debris"),
+            Fluid.of("techreborn:sodium_persulfate", FULL_BUCKET_AMMOUNT / 10)
+        ]).heated()
     }
 })

--- a/kubejs/server_scripts/rock_and_stone/midgame.js
+++ b/kubejs/server_scripts/rock_and_stone/midgame.js
@@ -1,3 +1,34 @@
+var FULL_BUCKET_AMMOUNT = 81000;
+var INGOT_FLUID_AMMOUNT = 9000;
 onEvent("recipes", event => {
-    
+    //ochrum - outputs - advanced
+    event.recipes.createMixing([
+        Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 10),
+        Item.of("techreborn:sulfur_dust").withChance(0.4)
+    ], [
+        Item.of("techreborn:cinnabar_dust")
+    ]).heated()
+    event.recipes.createCrushing([
+        Item.of("techreborn:cinnabar_dust")
+    ], [
+        Item.of("createastral:cinnabar") //add a custom crystal thingy here
+    ])
+    event.recipes.createMilling([
+        Item.of("techreborn:cinnabar_dust").withChance(0.7)
+    ], [
+        Item.of("createastral:cinnabar")
+    ])
+    event.recipes.createMixing([
+        Fluid.of("createastral:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10), //add a custom fluid here
+        Item.of("techreborn:andradite_dust").withChance(0.6)
+    ], [
+        Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 10),
+        Item.of("create:ochrum")
+    ])
+    event.recipes.createMixing([
+        Fluid.of("techreborn:mercury", FULL_BUCKET_AMMOUNT / 20),
+        Fluid.of("tconstruct:molten_gold", INGOT_FLUID_AMMOUNT * 3)
+    ], [
+        Fluid.of("createastral:gold-mercury_solution", FULL_BUCKET_AMMOUNT / 10)
+    ]).heated()
 })

--- a/kubejs/startup_scripts/spokesman's_shit.js
+++ b/kubejs/startup_scripts/spokesman's_shit.js
@@ -1,0 +1,20 @@
+onEvent("item.registry", event => {
+    event.create("kubejs:incomplete_crimsite").type("create:sequenced_assembly"),
+    event.create("kubejs:incomplete_tuff").type("create:sequenced_assembly"),
+    event.create("kubejs:incomplete_quartz").type("create:sequenced_assembly"),
+    event.create("kubejs:incomplete_granite").type("create:sequenced_assembly"),
+    event.create("kubejs:incomplete_crimson_nylium").type("create:assembly_assembly"),
+    event.create("kubejs:incomplete_warped_nylium").type("create:sequenced_assembly"),
+    event.create("kubejs:incomplete_infernal_spire").type("create:sequenced_assembly")
+
+    event.create("kubejs:ground_debris"),
+    event.create("kubejs:cut_debris")
+})
+onEvent("fluid.registry", event => {
+	event.create('gold-mercury_solution')
+       .thickTexture(0xffff99)
+       .bucketColor(0xffff99)
+       .displayName('gold-mercury solution')
+	     .stillTexture('tconstruct:block/fluid/molten/still')
+	     .flowingTexture('tconstruct:block/fluid/molten/flowing')
+})


### PR DESCRIPTION
Yeah well prototypes lol, my intents:
1. having a certain gimmick with a recipe, like cooling taking exceptionally long
2. byproducts
3. rerouting said byproducts to improve gainz
4. all earlygame recipes do not need byproducts from other recipe chains, this changes from midgame onward
5. all recipes are grouped in early-mid-lategame
6. this stuff is typed from memory, so there have to be several errors :P
Feel free to comment ur opinion, or devs in our channel :D