### PR TITLE
Fix biome's for "Martian Traveller" quest

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_5.snbt
+++ b/config/ftbquests/quests/chapters/chapter_5.snbt
@@ -417,13 +417,13 @@
 					id: "68293CB7A35DED12"
 					type: "biome"
 					icon: "ad_astra:mars_sand"
-					biome: "ad_astra:mars_wastelands"
+					biome: "ad_astra:martian_wastelands"
 				}
 				{
 					id: "0EADEDD630D75A8E"
 					type: "biome"
 					icon: "ad_astra:conglomerate"
-					biome: "ad_astra:mars_canyon_creek"
+					biome: "ad_astra:martian_canyon_creek"
 				}
 				{
 					id: "3A9B33851300612F"


### PR DESCRIPTION
Previously using `ad_astra:mars_` when it's `ad_astra:martian_`