### PR TITLE
Buff nerfed Hephaestus tools

### DIFF
--- a/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/cleaver.json
+++ b/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/cleaver.json
@@ -16,10 +16,10 @@
   "stats": {
     "base": {
       "tconstruct:attack_damage": 3.0,
-      "tconstruct:attack_speed": 0.8
+      "tconstruct:attack_speed": 1.1
     },
     "multipliers": {
-      "tconstruct:attack_damage": 1.45,
+      "tconstruct:attack_damage": 1.5,
       "tconstruct:mining_speed": 0.25,
       "tconstruct:durability": 3.5
     }

--- a/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/excavator.json
+++ b/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/excavator.json
@@ -20,7 +20,7 @@
     },
     "multipliers": {
       "tconstruct:attack_damage": 1.2,
-      "tconstruct:mining_speed": 0.05,
+      "tconstruct:mining_speed": 0.15,
       "tconstruct:durability": 3.75
     }
   },

--- a/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/scythe.json
+++ b/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/scythe.json
@@ -19,7 +19,7 @@
       "tconstruct:attack_speed": 0.7
     },
     "multipliers": {
-      "tconstruct:mining_speed": 0.07,
+      "tconstruct:mining_speed": 0.25,
       "tconstruct:durability": 2.5
     }
   },

--- a/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/sledge_hammer.json
+++ b/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/sledge_hammer.json
@@ -21,7 +21,7 @@
     },
     "multipliers": {
       "tconstruct:attack_damage": 1.35,
-      "tconstruct:mining_speed": 0.1,
+      "tconstruct:mining_speed": 0.2,
       "tconstruct:durability": 4.0
     }
   },

--- a/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/vein_hammer.json
+++ b/global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/vein_hammer.json
@@ -22,7 +22,7 @@
     },
     "multipliers": {
       "tconstruct:attack_damage": 1.25,
-      "tconstruct:mining_speed": 0.08,
+      "tconstruct:mining_speed": 0.2,
       "tconstruct:durability": 5.0
     }
   },


### PR DESCRIPTION
This commit buffs ridiculously nerfed Hephaestus tools.

| Tool          | Stat                     | Current Astral | Default Hephaestus | My proposal |
|---------------|--------------------------|----------------|--------------------|-------------|
| Sledge Hammer | Mining Speed Multiplier  | 0.1x           | 0.4x               | 0.2x        |
| Vein Hammer   | Mining Speed Multiplier  | 0.08x          | 0.3x               | 0.2x        |
| Cleaver       | Attack Speed             | 0.8            | 1.0                | 1.1         |
| Cleaver       | Attack Damage Multiplier | 1.45x          | 1.5x               | 1.5x        |
| Excavator     | Mining Speed Multiplier  | 0.05x          | 0.3x               | 0.15x       |
| Scythe        | Mining Speed Multiplier  | 0.07x          | 0.45x              | 0.25x       |

Broad tools mining speed multipliers are so ridiculously low currently, that the 2x Whitestone/2x Desh meta emerged, just to have a tool with usable mining speed.
A hammer with endgame materials can just barely reach 5 mining speed!!!
(Especially since later TR completely outclasses Hephaestus broad tools).
On servers with TPS lag it's even worse since slow mining speeds cause blocks to be rubberbanded.
These buffs will make broad tools a bit more usable and convenient.

Cleaver's nerf made Cleaver unusable for combat, since Broad Axe outdamaged it a ton.
Attack Speed is an insanely important stat in this pack because of Better Combat's upswing delay, during which you are slowed down and vulnerable to monster attack, so you usually trade hits with monsters during combat.
The current Astral's Cleaver Attack Speed was not much better than the Broad Axe.
The proposed buff will make Cleaver's power between that of a Broad Axe and the Sword.