### PR TITLE
All plates are equal! (and replace a lot of fluid values with constants)

### DIFF
--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -1,4 +1,3 @@
-
 onEvent("recipes", (event) => {
     crushingRecipes(event);
     millingRecipes(event);
@@ -2615,11 +2614,6 @@ function mechanicalCraftingRecipes(event) {
 function pressingRecipes(event) {
     // [Input string, Output string]
     [
-        //["techreborn:silver_ingot", "techreborn:silver_plate"],
-        //["techreborn:tin_ingot", "techreborn:tin_plate"],
-        //["techreborn:lead_ingot", "techreborn:lead_plate"],
-        //["techreborn:electrum_ingot", "techreborn:electrum_plate"],
-        //["createastral:bronze_ingot", "createastral:bronze_sheet"], // Moved to plates.js
         ["minecraft:lapis_block", "create:lapis_sheet"],
         ["createastral:pure_star_shard", "minecraft:nether_star"],
     ].forEach((recipe) => {
@@ -2627,7 +2621,7 @@ function pressingRecipes(event) {
     });
 }
 function farmersDelightIntegration(event) {
-    let knivesTag = "c:tools/knives"; // We are on Fabric, so why the check is here?
+    let knivesTag = "c:tools/knives";
     event.forEachRecipe(
         { type: "farmersdelight:cutting", tool: { tag: knivesTag } },
         (recipe) => {

--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -1,5 +1,3 @@
-var FULL_BUCKET_AMMOUNT = 81000;
-var INGOT_FLUID_AMMOUNT = 9000;
 
 onEvent("recipes", (event) => {
     crushingRecipes(event);
@@ -826,11 +824,11 @@ function sequencedAssemblyRecipes(event) {
             [
                 event.recipes.createFilling("ad_astra:ostrum_engine", [
                     "ad_astra:ostrum_engine",
-                    { fluid: "kubejs:molten_calorite", amount: 81000 },
+                    { fluid: "kubejs:molten_calorite", amount: BUCKET },
                 ]),
                 event.recipes.createFilling("ad_astra:ostrum_engine", [
                     "ad_astra:ostrum_engine",
-                    { fluid: "yttr:void", amount: 81000 },
+                    { fluid: "yttr:void", amount: BUCKET },
                 ]),
                 event.recipes.createDeploying("ad_astra:ostrum_engine", [
                     "ad_astra:ostrum_engine",
@@ -855,14 +853,14 @@ function sequencedAssemblyRecipes(event) {
                     "createastral:navigation_mechanism",
                     [
                         "createastral:navigation_mechanism",
-                        { fluid: "kubejs:molten_calorite", amount: 81000 },
+                        { fluid: "kubejs:molten_calorite", amount: BUCKET },
                     ]
                 ),
                 event.recipes.createFilling(
                     "createastral:navigation_mechanism",
                     [
                         "createastral:navigation_mechanism",
-                        { fluid: "yttr:void", amount: 81000 },
+                        { fluid: "yttr:void", amount: BUCKET },
                     ]
                 ),
                 event.recipes.createDeploying(
@@ -1034,7 +1032,7 @@ function sequencedAssemblyRecipes(event) {
                     // input
                     event.recipes.createFilling("create:copper_casing", [
                         "create:copper_casing",
-                        { fluid: "tconstruct:molten_silver", amount: 9000 },
+                        { fluid: "tconstruct:molten_silver", amount: INGOT },
                     ]),
                     event.recipes.createDeploying("create:copper_casing", [
                         "create:copper_casing",
@@ -1077,7 +1075,7 @@ function sequencedAssemblyRecipes(event) {
                                 "createastral:brass_" + item[0],
                                 {
                                     fluid: "tconstruct:molten_diamond",
-                                    amount: 20250,
+                                    amount: 250 * mB,
                                 },
                             ]
                         ),
@@ -1277,7 +1275,7 @@ function sequencedAssemblyRecipes(event) {
                 ), //yeah
                 event.recipes.createFilling("minecraft:ender_pearl", [
                     "minecraft:ender_pearl",
-                    { fluid: "minecraft:lava", amount: 20250 },
+                    { fluid: "minecraft:lava", amount: 250 * mB },
                 ]), //fill 1/4 bucket lava
                 event.recipes.createPressing(
                     "minecraft:ender_pearl",
@@ -1327,7 +1325,7 @@ function sequencedAssemblyRecipes(event) {
                     "createastral:incomplete_electronic_circuit",
                     [
                         "createastral:incomplete_electronic_circuit",
-                        { fluid: "ad_astra:cryo_fuel", amount: 40500 },
+                        { fluid: "ad_astra:cryo_fuel", amount: 500 * mB },
                     ]
                 ),
                 event.recipes.createDeploying(
@@ -1358,7 +1356,7 @@ function sequencedAssemblyRecipes(event) {
                 event.recipes
                     .createFilling("ad_astra:iron_plate", [
                         "ad_astra:iron_plate",
-                        { fluid: "kubejs:shimmer", amount: 9000 },
+                        { fluid: "kubejs:shimmer", amount: INGOT },
                     ])
                     .processingTime(75), //fill
                 event.recipes
@@ -1379,67 +1377,67 @@ function fillingRecipes(event) {
             input: "create:polished_rose_quartz",
             output: "create:electron_tube",
             fluid: "tconstruct:molten_rose_gold",
-            amount: 9000,
+            amount: INGOT,
         },
         {
             input: "minecraft:calcite",
             output: "3x minecraft:pointed_dripstone",
             fluid: "minecraft:water",
-            amount: FULL_BUCKET_AMMOUNT / 2,
+            amount: 500 * mB,
         },
         {
             input: "techreborn:netherrack_dust",
             output: "create:cinder_flour",
             fluid: "minecraft:water",
-            amount: FULL_BUCKET_AMMOUNT / 4,
+            amount: 250 * mB,
         },
         {
             input: "create:blaze_cake_base",
             output: "create:blaze_cake",
             fluid: "techreborn:nitro_diesel",
-            amount: 20250,
+            amount: 250 * mB,
         },
         {
             input: "techreborn:red_cell_battery",
             output: "techreborn:lithium_ion_battery",
             fluid: "techreborn:lithium",
-            amount: 81000,
+            amount: BUCKET,
         },
         {
             input: "minecraft:compass",
             output: "explorerscompass:explorerscompass",
             fluid: "tconstruct:molten_iron",
-            amount: 36000,
+            amount: 4 * INGOT,
         },
         {
             input: "doodads:brick_road",
             output: "doodads:yellow_brick_road",
             fluid: "tconstruct:molten_gold",
-            amount: 4500,
+            amount: 50 * mB,
         },
         {
             input: "doodads:stone_brick_road",
             output: "doodads:yellow_brick_road",
             fluid: "tconstruct:molten_gold",
-            amount: 2250,
+            amount: 25 * mB,
         },
         {
             input: "minecraft:warped_fungus",
             output: "minecraft:crimson_fungus",
             fluid: "minecraft:lava",
-            amount: 2250,
+            amount: 25 * mB,
         },
         {
             input: "vinery:wine_bottle",
             output: "vinery:red_grapejuice_wine_bottle",
             fluid: "kubejs:red_grape_juice",
-            amount: 20250,
+            amount: 250 * mB,
         },
         {
             input: "vinery:wine_bottle",
             output: "vinery:white_grapejuice_wine_bottle",
             fluid: "kubejs:white_grape_juice",
-            amount: 20250,
+            amount: 250 * mB,
         },
     ].forEach((recipe) => {
         event.recipes.createFilling(recipe.output, [
@@ -1465,7 +1463,7 @@ function mixingRecipes(event) {
                 "minecraft:blue_dye",
                 {
                     fluid: "kubejs:shimmer",
-                    amount: FULL_BUCKET_AMMOUNT / 10,
+                    amount: 100 * mB,
                 },
             ],
             heat: "",
@@ -1479,7 +1477,7 @@ function mixingRecipes(event) {
                 "minecraft:pink_dye",
                 {
                     fluid: "kubejs:shimmer",
-                    amount: FULL_BUCKET_AMMOUNT / 10,
+                    amount: 100 * mB,
                 },
             ],
             heat: "",
@@ -1493,7 +1491,7 @@ function mixingRecipes(event) {
                 "minecraft:purple_dye",
                 {
                     fluid: "kubejs:shimmer",
-                    amount: FULL_BUCKET_AMMOUNT / 10,
+                    amount: 100 * mB,
                 },
             ],
             heat: "",
@@ -1507,7 +1505,7 @@ function mixingRecipes(event) {
                 "minecraft:red_dye",
                 {
                     fluid: "kubejs:shimmer",
-                    amount: FULL_BUCKET_AMMOUNT / 10,
+                    amount: 100 * mB,
                 },
             ],
             heat: "",
@@ -1521,7 +1519,7 @@ function mixingRecipes(event) {
                 "minecraft:yellow_dye",
                 {
                     fluid: "kubejs:shimmer",
-                    amount: FULL_BUCKET_AMMOUNT / 10,
+                    amount: 100 * mB,
                 },
             ],
             heat: "",
@@ -1539,7 +1537,7 @@ function mixingRecipes(event) {
                 "9x #minecraft:leaves",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 2,
+                    amount: 500 * mB,
                 },
             ],
             heat: "heated",
@@ -1551,7 +1549,7 @@ function mixingRecipes(event) {
                 "9x #c:grass_variants",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 2,
+                    amount: 500 * mB,
                 },
             ],
             heat: "heated",
@@ -1563,7 +1561,7 @@ function mixingRecipes(event) {
                 "9x minecraft:kelp",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 2,
+                    amount: 500 * mB,
                 },
             ],
             heat: "heated",
@@ -1575,7 +1573,7 @@ function mixingRecipes(event) {
                 "9x minecraft:sugar_cane",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 2,
+                    amount: 500 * mB,
                 },
             ],
             heat: "heated",
@@ -1587,7 +1585,7 @@ function mixingRecipes(event) {
                 "3x farmersdelight:straw",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 2,
+                    amount: 500 * mB,
                 },
             ],
             heat: "heated",
@@ -1599,7 +1597,7 @@ function mixingRecipes(event) {
                 "4x minecraft:kelp",
                 {
                     fluid: "minecraft:water",
-                    amount: FULL_BUCKET_AMMOUNT / 4,
+                    amount: 250 * mB,
                 },
             ],
             heat: "",
@@ -1611,7 +1609,7 @@ function mixingRecipes(event) {
                 "4x minecraft:dried_kelp",
                 {
                     fluid: "minecraft:water",
-                    amount: FULL_BUCKET_AMMOUNT / 4,
+                    amount: 250 * mB,
                 },
             ],
             heat: "",
@@ -1653,21 +1651,18 @@ function mixingRecipes(event) {
             time: 700,
         },
         {
-            output: Fluid.of(
-                "kubejs:blast-resistant_cement",
-                FULL_BUCKET_AMMOUNT
-            ),
+            output: Fluid.of("kubejs:blast-resistant_cement", BUCKET),
             input: [
                 "#c:concrete_powder",
                 "2x createastral:lime",
                 "3x techreborn:steel_dust",
-                { fluid: "minecraft:water", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "minecraft:water", amount: BUCKET },
             ],
             heat: "heated",
             time: 1000,
         },
         {
-            output: Fluid.of("create:honey", FULL_BUCKET_AMMOUNT / 9),
+            output: Fluid.of("create:honey", BUCKET / 9),
             input: ["techreborn:sap", "minecraft:sugar"],
             heat: "",
             time: 100,
@@ -1705,82 +1700,82 @@ function mixingRecipes(event) {
             time: 400,
         },
         {
-            output: Fluid.of("tconstruct:molten_brass", 18000),
+            output: Fluid.of("tconstruct:molten_brass", INGOT * 2),
             input: ["minecraft:copper_ingot", "create:zinc_ingot"],
             heat: "heated",
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_brass", 1800),
+            output: Fluid.of("tconstruct:molten_brass", INGOT / 5),
             input: [
-                { fluid: "tconstruct:molten_copper", amount: 900 },
-                { fluid: "tconstruct:molten_zinc", amount: 900 },
+                { fluid: "tconstruct:molten_copper", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_zinc", amount: INGOT / 10 },
             ],
             heat: "heated",
             time: 5,
         },
         {
-            output: Fluid.of("tconstruct:molten_amethyst_bronze", 9000),
+            output: Fluid.of("tconstruct:molten_amethyst_bronze", INGOT),
             input: ["createastral:bronze_ingot", "minecraft:amethyst_shard"],
             heat: "heated",
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_amethyst_bronze", 900),
+            output: Fluid.of("tconstruct:molten_amethyst_bronze", INGOT / 10),
             input: [
-                { fluid: "tconstruct:molten_bronze", amount: 900 },
-                { fluid: "tconstruct:molten_amethyst", amount: 900 },
+                { fluid: "tconstruct:molten_bronze", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_amethyst", amount: INGOT / 10 },
             ],
             heat: "heated",
             time: 100,
         },
         {
-            output: Fluid.of("tconstruct:molten_bronze", 1800),
+            output: Fluid.of("tconstruct:molten_bronze", INGOT / 5),
             input: [
-                { fluid: "tconstruct:molten_tin", amount: 900 },
-                { fluid: "tconstruct:molten_copper", amount: 900 },
+                { fluid: "tconstruct:molten_tin", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_copper", amount: INGOT / 10 },
             ],
             heat: "",
             time: 100,
         },
         {
-            output: Fluid.of("tconstruct:molten_rose_gold", 9000),
+            output: Fluid.of("tconstruct:molten_rose_gold", INGOT),
             input: ["minecraft:copper_ingot", "minecraft:gold_ingot"],
             heat: "heated",
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_bronze", 18000),
+            output: Fluid.of("tconstruct:molten_bronze", INGOT * 2),
             input: ["minecraft:copper_ingot", "techreborn:tin_ingot"],
             heat: "",
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_rose_gold", 900),
+            output: Fluid.of("tconstruct:molten_rose_gold", INGOT / 10),
             input: [
-                { fluid: "tconstruct:molten_copper", amount: 900 },
-                { fluid: "tconstruct:molten_gold", amount: 900 },
+                { fluid: "tconstruct:molten_copper", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_gold", amount: INGOT / 10 },
             ],
             heat: "",
             time: 10,
         },
         {
-            output: Fluid.of("tconstruct:molten_electrum", 900),
+            output: Fluid.of("tconstruct:molten_electrum", INGOT / 10),
             input: [
-                { fluid: "tconstruct:molten_silver", amount: 900 },
-                { fluid: "tconstruct:molten_gold", amount: 900 },
+                { fluid: "tconstruct:molten_silver", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_gold", amount: INGOT / 10 },
             ],
             heat: "heated",
             time: 100,
         },
         {
-            output: Fluid.of("tconstruct:molten_steel", 9000),
+            output: Fluid.of("tconstruct:molten_steel", INGOT),
             input: ["techreborn:steel_dust"],
             heat: "heated",
             time: 100,
         },
         {
-            output: Fluid.of("tconstruct:molten_slimesteel", 9000),
+            output: Fluid.of("tconstruct:molten_slimesteel", INGOT),
             input: [
                 "minecraft:iron_ingot",
                 "tconstruct:sky_slime_ball",
@@ -1790,10 +1785,10 @@ function mixingRecipes(event) {
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_slimesteel", 9000),
+            output: Fluid.of("tconstruct:molten_slimesteel", INGOT),
             input: [
-                { fluid: "tconstruct:molten_iron", amount: 9000 },
-                { fluid: "tconstruct:sky_slime", amount: 20250 },
+                { fluid: "tconstruct:molten_iron", amount: INGOT },
+                { fluid: "tconstruct:sky_slime", amount: 250 * mB },
                 "#tconstruct:seared_blocks",
             ],
             heat: "heated",
@@ -1802,14 +1797,14 @@ function mixingRecipes(event) {
         {
             output: "1x ae2:certus_quartz",
             input: [
-                { fluid: "minecraft:water", amount: 20250 },
+                { fluid: "minecraft:water", amount: 250 * mB },
                 "1x ae2:certus_quartz_dust",
             ],
             heat: "heated",
             time: 40,
         },
         {
-            output: Fluid.of("tconstruct:molten_pig_iron", 9000),
+            output: Fluid.of("tconstruct:molten_pig_iron", INGOT),
             input: [
                 "minecraft:porkchop",
                 "minecraft:iron_ingot",
@@ -1819,52 +1814,52 @@ function mixingRecipes(event) {
             time: 300,
         },
         {
-            output: Fluid.of("tconstruct:molten_pig_iron", 9000),
+            output: Fluid.of("tconstruct:molten_pig_iron", INGOT),
             input: [
                 "minecraft:porkchop",
-                { fluid: "tconstruct:molten_iron", amount: 9000 },
-                { fluid: "tconstruct:molten_gold", amount: 9000 },
+                { fluid: "tconstruct:molten_iron", amount: INGOT },
+                { fluid: "tconstruct:molten_gold", amount: INGOT },
             ],
             heat: "heated",
             time: 250,
         },
         {
-            output: Fluid.of("tconstruct:molten_queens_slime", 1800),
+            output: Fluid.of("tconstruct:molten_queens_slime", INGOT / 5),
             input: [
-                { fluid: "tconstruct:molten_cobalt", amount: 900 },
-                { fluid: "tconstruct:molten_slimesteel", amount: 1800 },
+                { fluid: "tconstruct:molten_cobalt", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_slimesteel", amount: INGOT / 5 },
             ],
             heat: "heated",
             time: 5,
         },
         {
-            output: Fluid.of("tconstruct:molten_manyullyn", 9000),
+            output: Fluid.of("tconstruct:molten_manyullyn", INGOT),
             input: [
-                { fluid: "tconstruct:molten_cobalt", amount: 18000 },
+                { fluid: "tconstruct:molten_cobalt", amount: INGOT * 2 },
                 "1x minecraft:netherite_scrap",
-                { fluid: "kubejs:molten_desh", amount: 9000 },
+                { fluid: "kubejs:molten_desh", amount: INGOT },
             ],
             heat: "heated",
             time: 1000,
         },
         {
-            output: Fluid.of("tconstruct:molten_hepatizon", 1800),
+            output: Fluid.of("tconstruct:molten_hepatizon", INGOT / 5),
             input: [
-                { fluid: "tconstruct:molten_cobalt", amount: 900 },
-                { fluid: "tconstruct:molten_lead", amount: 1800 },
+                { fluid: "tconstruct:molten_cobalt", amount: INGOT / 10 },
+                { fluid: "tconstruct:molten_lead", amount: INGOT / 5 },
             ],
             heat: "heated",
             time: 5,
         },
         {
-            output: Fluid.of("tconstruct:molten_debris", 20250),
+            output: Fluid.of("tconstruct:molten_debris", 250 * mB),
             input: ["minecraft:ancient_debris"],
             heat: "superheated",
             time: 500,
         },
         {
-            output: Fluid.of("kubejs:hellfire", 81),
-            input: [{ fluid: "minecraft:lava", amount: 9000 }],
+            output: Fluid.of("kubejs:hellfire", 1 * mB),
+            input: [{ fluid: "minecraft:lava", amount: 100 * mB }],
             heat: "superheated",
             time: 100,
         },
@@ -1872,13 +1867,13 @@ function mixingRecipes(event) {
             output: "create:chromatic_compound",
             input: [
                 "5x techreborn:uu_matter",
-                { fluid: "kubejs:shimmer", amount: 81000 },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             heat: "superheated",
             time: 2500,
         },
         {
-            output: Fluid.of("kubejs:compound_mixture", 9000),
+            output: Fluid.of("kubejs:compound_mixture", INGOT),
             input: [
                 "minecraft:andesite",
                 "techreborn:tin_nugget",
@@ -1886,7 +1881,7 @@ function mixingRecipes(event) {
             ],
         },
         {
-            output: Fluid.of("kubejs:compound_mixture", 9000),
+            output: Fluid.of("kubejs:compound_mixture", INGOT),
             input: [
                 "minecraft:andesite",
                 "create:zinc_nugget",
@@ -1894,7 +1889,7 @@ function mixingRecipes(event) {
             ],
         },
         {
-            output: Fluid.of("kubejs:compound_mixture", 9000),
+            output: Fluid.of("kubejs:compound_mixture", INGOT),
             input: [
                 "minecraft:andesite",
                 "minecraft:iron_nugget",
@@ -1942,7 +1937,7 @@ function mixingRecipes(event) {
             time: 400,
         },
         {
-            output: Fluid.of("kubejs:shimmer", 40500),
+            output: Fluid.of("kubejs:shimmer", 500 * mB),
             input: ["5x minecraft:amethyst_shard", "2x minecraft:glow_ink_sac"],
             heat: "",
             time: 400,
@@ -1968,7 +1963,7 @@ function mixingRecipes(event) {
         {
             output: "minecraft:dolphin_spawn_egg",
             input: [
-                { fluid: "kubejs:shimmer", amount: 40500 },
+                { fluid: "kubejs:shimmer", amount: 500 * mB },
                 "createastral:orcane",
             ],
             heat: "",
@@ -1977,7 +1972,7 @@ function mixingRecipes(event) {
         {
             output: "adoptafloppa:kitney_item",
             input: [
-                { fluid: "kubejs:shimmer", amount: 40500 },
+                { fluid: "kubejs:shimmer", amount: 500 * mB },
                 "3x minecraft:ghast_tear",
             ],
             heat: "",
@@ -1986,7 +1981,7 @@ function mixingRecipes(event) {
         {
             output: "blahaj:gray_shark",
             input: [
-                { fluid: "kubejs:shimmer", amount: 81000 },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
                 "blahaj:blue_shark",
             ],
             heat: "",
@@ -1995,16 +1990,16 @@ function mixingRecipes(event) {
         {
             output: "createastral:separation_agent",
             input: [
-                { fluid: "yttr:void", amount: 81000 },
+                { fluid: "yttr:void", amount: BUCKET },
                 "createastral:refining_agent",
             ],
             heat: "superheated",
             time: 2000,
         },
         {
-            output: Fluid.of("kubejs:molten_radiance", 40500),
+            output: Fluid.of("kubejs:molten_radiance", 500 * mB),
             input: [
-                { fluid: "kubejs:shimmer", amount: 81000 },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
                 "createastral:pure_star_shard",
             ],
             heat: "superheated",
@@ -2013,7 +2008,7 @@ function mixingRecipes(event) {
         {
             output: "tconstruct:ichor_slime_ball",
             input: [
-                { fluid: "kubejs:shimmer", amount: 9000 },
+                { fluid: "kubejs:shimmer", amount: INGOT },
                 "4x tconstruct:sky_slime_ball",
             ],
             heat: "heated",
@@ -2022,7 +2017,7 @@ function mixingRecipes(event) {
         {
             output: "tconstruct:ender_slime_ball",
             input: [
-                { fluid: "kubejs:shimmer", amount: 9000 },
+                { fluid: "kubejs:shimmer", amount: INGOT },
                 "2x tconstruct:ichor_slime_ball",
             ],
             heat: "heated",
@@ -2031,7 +2026,7 @@ function mixingRecipes(event) {
         {
             output: "doodads:portable_nether",
             input: [
-                { fluid: "kubejs:shimmer", amount: 81000 },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
                 "minecraft:lodestone",
             ],
             heat: "heated",
@@ -2040,7 +2035,7 @@ function mixingRecipes(event) {
         {
             output: "32x doodads:stone_brick_road",
             input: [
-                { fluid: "kubejs:shimmer", amount: 40500 },
+                { fluid: "kubejs:shimmer", amount: 500 * mB },
                 "32x minecraft:stone_bricks",
             ],
             heat: "",
@@ -2049,7 +2044,7 @@ function mixingRecipes(event) {
         {
             output: "32x doodads:brick_road",
             input: [
-                { fluid: "kubejs:shimmer", amount: 40500 },
+                { fluid: "kubejs:shimmer", amount: 500 * mB },
                 "32x minecraft:bricks",
             ],
             heat: "",
@@ -2065,10 +2060,10 @@ function mixingRecipes(event) {
             time: 1000,
         },
         {
-            output: { fluid: "create:honey", amount: 40500 },
+            output: { fluid: "create:honey", amount: 500 * mB },
             input: [
-                { fluid: "minecraft:water", amount: 40500 },
-                { fluid: "kubejs:shimmer", amount: 40500 },
+                { fluid: "minecraft:water", amount: 500 * mB },
+                { fluid: "kubejs:shimmer", amount: 500 * mB },
             ],
             heat: "",
             time: 3000,
@@ -2076,7 +2071,7 @@ function mixingRecipes(event) {
         {
             output: "createastral:astral_conduit",
             input: [
-                { fluid: "kubejs:shimmer", amount: 81000 },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
                 "minecraft:diamond_block",
                 "phonos:redstone_chip",
                 "minecraft:flint_and_steel",
@@ -2085,13 +2080,13 @@ function mixingRecipes(event) {
             time: 30,
         },
         {
-            output: [{ fluid: "kubejs:liquid_xp_nuggies", amount: 81000 }],
+            output: [{ fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET }],
             input: ["kubejs:experience_block"],
             heat: "heated",
             time: 1000,
         },
         {
-            output: [{ fluid: "kubejs:liquid_xp_nuggies", amount: 9000 }],
+            output: [{ fluid: "kubejs:liquid_xp_nuggies", amount: INGOT }],
             input: ["kubejs:experience_ingot"],
             heat: "heated",
             time: 100,
@@ -2102,7 +2097,7 @@ function mixingRecipes(event) {
                 "8x minecraft:yellow_dye",
                 "2x minecraft:black_dye",
                 "1x minecraft:heart_of_the_sea",
-                { fluid: "minecraft:water", amount: FULL_BUCKET_AMMOUNT / 1 },
+                { fluid: "minecraft:water", amount: BUCKET },
             ],
             heat: "",
             time: 500,
@@ -2620,11 +2615,11 @@ function mechanicalCraftingRecipes(event) {
 function pressingRecipes(event) {
     // [Input string, Output string]
     [
-        ["techreborn:silver_ingot", "techreborn:silver_plate"],
-        ["techreborn:tin_ingot", "techreborn:tin_plate"],
-        ["techreborn:lead_ingot", "techreborn:lead_plate"],
-        ["techreborn:electrum_ingot", "techreborn:electrum_plate"],
-        ["createastral:bronze_ingot", "createastral:bronze_sheet"],
+        //["techreborn:silver_ingot", "techreborn:silver_plate"],
+        //["techreborn:tin_ingot", "techreborn:tin_plate"],
+        //["techreborn:lead_ingot", "techreborn:lead_plate"],
+        //["techreborn:electrum_ingot", "techreborn:electrum_plate"],
+        //["createastral:bronze_ingot", "createastral:bronze_sheet"], // Moved to plates.js
         ["minecraft:lapis_block", "create:lapis_sheet"],
         ["createastral:pure_star_shard", "minecraft:nether_star"],
     ].forEach((recipe) => {
@@ -2632,7 +2627,7 @@ function pressingRecipes(event) {
     });
 }
 function farmersDelightIntegration(event) {
-    let knivesTag = Platform.isFabric ? "c:tools/knives" : "forge:tools/knives";
+    let knivesTag = "c:tools/knives"; // We are on Fabric, so why the check is here?
     event.forEachRecipe(
         { type: "farmersdelight:cutting", tool: { tag: knivesTag } },
         (recipe) => {
@@ -2652,7 +2647,7 @@ function compactingRecipes(event) {
             inputs: [
                 "3x minecraft:bone_meal",
                 "minecraft:gravel",
-                { fluid: "minecraft:lava", amount: FULL_BUCKET_AMMOUNT / 10 },
+                { fluid: "minecraft:lava", amount: 100 * mB },
             ],
         },
         {
@@ -2660,7 +2655,7 @@ function compactingRecipes(event) {
             inputs: [
                 "3x techreborn:lazurite_dust",
                 "2x minecraft:iron_nugget",
-                { fluid: "minecraft:lava", amount: FULL_BUCKET_AMMOUNT / 30 },
+                { fluid: "minecraft:lava", amount: BUCKET / 30 },
             ],
         },
         {
@@ -2668,7 +2663,7 @@ function compactingRecipes(event) {
             inputs: [
                 "minecraft:diorite",
                 "minecraft:flint",
-                { fluid: "minecraft:lava", amount: FULL_BUCKET_AMMOUNT / 10 },
+                { fluid: "minecraft:lava", amount: 100 * mB },
             ],
         },
         {
@@ -2718,7 +2713,7 @@ function compactingRecipes(event) {
                 "minecraft:rotten_flesh",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 9,
+                    amount: BUCKET / 9,
                 },
             ],
         },
@@ -2729,7 +2724,7 @@ function compactingRecipes(event) {
                 "3x #c:grass_variants",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 9,
+                    amount: BUCKET / 9,
                 },
             ],
         },
@@ -2740,7 +2735,7 @@ function compactingRecipes(event) {
                 "farmersdelight:rice",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 9,
+                    amount: BUCKET / 9,
                 },
             ],
         },
@@ -2751,7 +2746,7 @@ function compactingRecipes(event) {
                 "#minecraft:wool",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 9,
+                    amount: BUCKET / 9,
                 },
             ],
         },
@@ -2762,7 +2757,7 @@ function compactingRecipes(event) {
                 "minecraft:carrot",
                 {
                     fluid: "createaddition:seed_oil",
-                    amount: FULL_BUCKET_AMMOUNT / 9,
+                    amount: BUCKET / 9,
                 },
             ],
         },
@@ -2776,7 +2771,7 @@ function compactingRecipes(event) {
             inputs: [
                 "2x minecraft:flint",
                 "minecraft:gravel",
-                { fluid: "minecraft:lava", amount: FULL_BUCKET_AMMOUNT / 10 },
+                { fluid: "minecraft:lava", amount: 100 * mB },
             ],
         },
         {
@@ -2828,7 +2823,7 @@ function compactingRecipes(event) {
                 "ae2:logic_processor_press",
                 {
                     fluid: "tconstruct:molten_gold",
-                    amount: FULL_BUCKET_AMMOUNT / 3,
+                    amount: 3 * INGOT,
                 },
             ],
         },
@@ -2845,7 +2840,7 @@ function compactingRecipes(event) {
                 "ae2:engineering_processor_press",
                 {
                     fluid: "tconstruct:molten_diamond",
-                    amount: FULL_BUCKET_AMMOUNT / 3,
+                    amount: 3 * INGOT,
                 },
             ],
         },
@@ -2865,7 +2860,7 @@ function compactingRecipes(event) {
                 "ae2:calculation_processor_press",
                 {
                     fluid: "kubejs:molten_desh",
-                    amount: FULL_BUCKET_AMMOUNT / 3,
+                    amount: 3 * INGOT,
                 },
             ],
         },

--- a/kubejs/server_scripts/enchantment.js
+++ b/kubejs/server_scripts/enchantment.js
@@ -1,5 +1,3 @@
-var FULL_BUCKET_AMMOUNT = 81000;
-var INGOT_FLUID_AMMOUNT = 9000;
 
 onEvent("recipes", (event) => {
     event.recipes
@@ -20,7 +18,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -49,7 +47,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -78,7 +76,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -107,7 +105,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -136,7 +134,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -165,7 +163,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -194,7 +192,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -223,7 +221,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -252,7 +250,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -281,7 +279,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -310,7 +308,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -339,7 +337,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -368,7 +366,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -397,7 +395,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -426,7 +424,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -455,7 +453,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -484,7 +482,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -513,7 +511,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -542,7 +540,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -571,7 +569,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -604,7 +602,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -633,7 +631,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -662,7 +660,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -691,7 +689,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -720,7 +718,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -749,7 +747,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -784,7 +782,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -813,7 +811,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -842,7 +840,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -871,7 +869,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -900,7 +898,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -929,7 +927,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -958,7 +956,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -987,7 +985,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -1016,7 +1014,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -1044,7 +1042,7 @@ onEvent("recipes", (event) => {
             ]), // insert crystal here / def something that could be changed
             event.recipes.createFilling("minecraft:enchanted_book", [
                 "minecraft:enchanted_book",
-                { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "xpcrystals:soul", amount: BUCKET },
             ]), //gathering the souls / def something that could be changed
             event.recipes.createPressing(
                 "minecraft:enchanted_book",
@@ -1071,7 +1069,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -1100,7 +1098,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -1129,7 +1127,7 @@ onEvent("recipes", (event) => {
                 ]), // insert crystal here / def something that could be changed
                 event.recipes.createFilling("minecraft:enchanted_book", [
                     "minecraft:enchanted_book",
-                    { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT },
+                    { fluid: "xpcrystals:soul", amount: BUCKET },
                 ]), //gathering the souls / def something that could be changed
                 event.recipes.createPressing(
                     "minecraft:enchanted_book",
@@ -1151,8 +1149,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1167,7 +1165,7 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1182,8 +1180,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1199,8 +1197,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1216,8 +1214,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1233,8 +1231,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:sharpness",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1249,8 +1247,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:unbreaking",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1265,8 +1263,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:unbreaking",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1281,8 +1279,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:unbreaking",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1298,8 +1296,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:unbreaking",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1314,8 +1312,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1330,8 +1328,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1346,8 +1344,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1363,8 +1361,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1380,8 +1378,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1397,8 +1395,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:protection",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1413,8 +1411,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_protection",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1429,8 +1427,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_protection",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1445,8 +1443,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_protection",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1462,8 +1460,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:fire_protection",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1479,8 +1477,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:fire_protection",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1495,8 +1493,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:blast_protection",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1511,8 +1509,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:blast_protection",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1527,8 +1525,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:blast_protection",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1544,8 +1542,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:blast_protection",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1561,8 +1559,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:blast_protection",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1577,8 +1575,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:projectile_protection",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1593,8 +1591,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:projectile_protection",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1609,8 +1607,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:projectile_protection",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1626,8 +1624,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:projectile_protection",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1643,8 +1641,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:projectile_protection",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1659,8 +1657,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:thorns",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1675,8 +1673,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:thorns",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1691,8 +1689,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:thorns",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1708,8 +1706,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:thorns",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1724,8 +1722,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sweeping",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1740,8 +1738,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sweeping",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1756,8 +1754,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:sweeping",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1773,8 +1771,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:sweeping",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1789,8 +1787,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:soul_speed",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1805,8 +1803,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:soul_speed",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1821,8 +1819,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:soul_speed",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1838,8 +1836,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:soul_speed",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1854,8 +1852,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1870,8 +1868,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1886,8 +1884,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1903,8 +1901,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1920,8 +1918,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -1937,8 +1935,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:smite",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -1953,8 +1951,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:respiration",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -1969,8 +1967,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:respiration",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -1985,8 +1983,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:respiration",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2002,8 +2000,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:respiration",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2018,8 +2016,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:quick_charge",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2034,8 +2032,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:quick_charge",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2050,8 +2048,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:quick_charge",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2067,8 +2065,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:quick_charge",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2083,8 +2081,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:punch",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2099,8 +2097,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:punch",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2115,8 +2113,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:punch",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2131,8 +2129,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2147,8 +2145,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2163,8 +2161,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2180,8 +2178,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2197,8 +2195,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2214,8 +2212,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:power",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2230,8 +2228,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:piercing",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2246,8 +2244,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:piercing",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2262,8 +2260,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:piercing",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2279,8 +2277,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:piercing",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2296,8 +2294,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:piercing",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2312,8 +2310,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:looting",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2328,8 +2326,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:looting",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2344,8 +2342,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:looting",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2361,8 +2359,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:looting",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2377,8 +2375,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:knockback",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2393,8 +2391,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:knockback",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2409,8 +2407,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:knockback",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2425,8 +2423,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:frost_walker",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2441,8 +2439,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:frost_walker",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2457,7 +2455,7 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:frost_walker",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2472,8 +2470,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fortune",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2488,8 +2486,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fortune",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2504,8 +2502,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fortune",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2521,8 +2519,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:fortune",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2537,8 +2535,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_aspect",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2553,8 +2551,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_aspect",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2569,8 +2567,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:fire_aspect",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2585,8 +2583,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:feather_falling",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2601,8 +2599,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:feather_falling",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2617,8 +2615,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:feather_falling",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2634,8 +2632,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:feather_falling",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2651,8 +2649,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:feather_falling",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2667,8 +2665,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2683,8 +2681,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2699,8 +2697,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2716,8 +2714,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2733,8 +2731,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2750,8 +2748,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:efficiency",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2766,8 +2764,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:depth_strider",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2782,8 +2780,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:depth_strider",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2798,8 +2796,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2814,8 +2812,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2830,8 +2828,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2847,8 +2845,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2864,8 +2862,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2881,8 +2879,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:bane_of_arthropods",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2897,8 +2895,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:lure",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2913,8 +2911,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:lure",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2929,8 +2927,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:lure",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -2946,8 +2944,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:lure",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -2962,8 +2960,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:luck_of_the_sea",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -2978,8 +2976,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:luck_of_the_sea",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -2994,8 +2992,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:luck_of_the_sea",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -3011,8 +3009,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:luck_of_the_sea",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -3027,8 +3025,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:loyalty",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3043,8 +3041,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:loyalty",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -3059,8 +3057,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:loyalty",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -3076,8 +3074,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:loyalty",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -3092,8 +3090,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:riptide",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3108,8 +3106,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:riptide",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -3124,8 +3122,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:riptide",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -3141,8 +3139,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:riptide",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -3157,8 +3155,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3173,8 +3171,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3189,8 +3187,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3206,8 +3204,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -3223,8 +3221,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:5s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 40500 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -3240,8 +3238,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"minecraft:impaling",lvl:6s}]}'
                 ),
                 "create:experience_block",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -3256,8 +3254,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"farmersdelight:backstabbing",lvl:1s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 3000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 3 * NUGGET },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: false,
             time: null,
@@ -3272,8 +3270,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"farmersdelight:backstabbing",lvl:2s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
-                { fluid: "kubejs:shimmer", amount: FULL_BUCKET_AMMOUNT },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
+                { fluid: "kubejs:shimmer", amount: BUCKET },
             ],
             superheated: true,
             time: null,
@@ -3288,8 +3286,8 @@ onEvent("recipes", (event) => {
                     "minecraft:enchanted_book",
                     '{StoredEnchantments:[{id:"farmersdelight:backstabbing",lvl:3s}]}'
                 ),
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 10125 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 125 * mB },
             ],
             superheated: true,
             time: null,
@@ -3305,8 +3303,8 @@ onEvent("recipes", (event) => {
                     '{StoredEnchantments:[{id:"farmersdelight:backstabbing",lvl:4s}]}'
                 ),
                 "createastral:experience_ingot",
-                { fluid: "kubejs:liquid_xp_nuggies", amount: 18000 },
-                { fluid: "kubejs:hellfire", amount: 20250 },
+                { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * INGOT },
+                { fluid: "kubejs:hellfire", amount: 250 * mB },
             ],
             superheated: true,
             time: null,
@@ -3318,13 +3316,13 @@ onEvent("recipes", (event) => {
             time: 10,
         },
         {
-            output: { fluid: "kubejs:liquid_xp_nuggies", amount: 9000 },
+            output: { fluid: "kubejs:liquid_xp_nuggies", amount: INGOT },
             input: ["createastral:experience_ingot"],
             superheated: false,
             time: 100,
         },
         {
-            output: { fluid: "kubejs:liquid_xp_nuggies", amount: 81000 },
+            output: { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
             input: ["create:experience_block"],
             superheated: false,
             time: 1000,
@@ -3338,7 +3336,7 @@ onEvent("recipes", (event) => {
         {
             output: {
                 fluid: "tconstruct:liquid_soul",
-                amount: FULL_BUCKET_AMMOUNT / 4,
+                amount: 250 * mB,
             },
             input: ["xpcrystals:soul_compound"],
             superheated: false,
@@ -3360,18 +3358,18 @@ onEvent("recipes", (event) => {
         .createMixing(
             {
                 fluid: "tconstruct:liquid_soul",
-                amount: FULL_BUCKET_AMMOUNT / 4,
+                amount: 250 * mB,
             },
             [
                 "xpcrystals:soul_compound",
-                { fluid: "minecraft:water", amount: FULL_BUCKET_AMMOUNT / 8 },
+                { fluid: "minecraft:water", amount: 125 * mB },
             ]
         )
         .processingTime(25);
     event.recipes
         .createMixing(
-            { fluid: "xpcrystals:soul", amount: FULL_BUCKET_AMMOUNT / 4 },
-            { fluid: "tconstruct:liquid_soul", amount: FULL_BUCKET_AMMOUNT / 4 }
+            { fluid: "xpcrystals:soul", amount: 250 * mB },
+            { fluid: "tconstruct:liquid_soul", amount: 250 * mB }
         )
         .processingTime(25);
     event.recipes.createCrushing(
@@ -3390,11 +3388,11 @@ onEvent("recipes", (event) => {
         ["minecraft:soul_sand"]
     );
     event.recipes.createFilling("xpcrystals:sticky_crystal_pudding", [
-        { fluid: "kubejs:liquid_xp_nuggies", amount: FULL_BUCKET_AMMOUNT },
+        { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET },
         "createaddition:cake_base_baked",
     ]);
     event.recipes.createFilling("xpcrystals:crystal_broth", [
-        { fluid: "kubejs:liquid_xp_nuggies", amount: FULL_BUCKET_AMMOUNT / 2 },
+        { fluid: "kubejs:liquid_xp_nuggies", amount: BUCKET / 2 },
         "minecraft:bowl",
     ]);
     event.recipes
@@ -3406,21 +3404,21 @@ onEvent("recipes", (event) => {
                     "minecraft:glass_bottle",
                     {
                         fluid: "kubejs:liquid_xp_nuggies",
-                        amount: FULL_BUCKET_AMMOUNT / 3,
+                        amount: BUCKET / 3,
                     },
                 ]),
                 event.recipes.createFilling("minecraft:glass_bottle", [
                     "minecraft:glass_bottle",
                     {
                         fluid: "xpcrystals:soul",
-                        amount: FULL_BUCKET_AMMOUNT / 3,
+                        amount: BUCKET / 3,
                     },
                 ]),
                 event.recipes.createFilling("minecraft:glass_bottle", [
                     "minecraft:glass_bottle",
                     {
                         fluid: "kubejs:shimmer",
-                        amount: FULL_BUCKET_AMMOUNT / 3,
+                        amount: BUCKET / 3,
                     },
                 ]),
             ]

--- a/kubejs/server_scripts/plates.js
+++ b/kubejs/server_scripts/plates.js
@@ -1,0 +1,179 @@
+// All plates are equal!
+
+const MATERIALS = [
+    {
+        ingot: "minecraft:copper_ingot",
+        block: "minecraft:copper_block",
+        plate: "create:copper_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "create:brass_ingot",
+        block: "create:brass_block",
+        plate: "create:brass_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "minecraft:iron_ingot",
+        block: "minecraft:iron_block",
+        plate: "create:iron_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "minecraft:gold_ingot",
+        block: "minecraft:gold_block",
+        plate: "create:golden_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "create:zinc_ingot",
+        block: "create:zinc_block",
+        plate: "createaddition:zinc_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "minecraft:netherite_ingot",
+        block: "minecraft:netherite_block",
+        plate: "createdeco:netherite_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "createdeco:cast_iron_ingot",
+        block: "createdeco:cast_iron_block",
+        plate: "createdeco:cast_iron_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "createastral:bronze_ingot",
+        block: "createastral:bronze_block",
+        plate: "createastral:bronze_sheet",
+        useMechPress: true,
+    },
+    {
+        ingot: "ad_astra:steel_ingot",
+        block: "ad_astra:steel_block",
+        plate: "ad_astra:steel_plate",
+        useMechPress: false,
+    },
+    {
+        ingot: "ad_astra:desh_ingot",
+        block: "ad_astra:desh_block",
+        plate: "ad_astra:desh_plate",
+        useMechPress: false,
+    },
+    {
+        ingot: "ad_astra:ostrum_ingot",
+        block: "ad_astra:ostrum_block",
+        plate: "ad_astra:ostrum_plate",
+        useMechPress: false,
+    },
+    {
+        ingot: "ad_astra:calorite_ingot",
+        block: "ad_astra:calorite_block",
+        plate: "ad_astra:calorite_plate",
+        useMechPress: false,
+    },
+    {
+        ingot: "techreborn:electrum_ingot",
+        block: "techreborn:electrum_storage_block",
+        plate: "techreborn:electrum_plate",
+        useMechPress: true,
+    },
+    {
+        ingot: "techreborn:invar_ingot",
+        block: "techreborn:invar_storage_block",
+        plate: "techreborn:invar_plate",
+        useMechPress: true,
+    },
+    {
+        ingot: "techreborn:iridium_ingot",
+        block: "techreborn:iridium_storage_block",
+        plate: "techreborn:iridium_plate",
+        useMechPress: false,
+    },
+    {
+        ingot: "techreborn:lead_ingot",
+        block: "techreborn:lead_storage_block",
+        plate: "techreborn:lead_plate",
+        useMechPress: true,
+    },
+    {
+        ingot: "techreborn:silver_ingot",
+        block: "techreborn:silver_storage_block",
+        plate: "techreborn:silver_plate",
+        useMechPress: true,
+    },
+    {
+        ingot: "techreborn:diamond_dust",
+        block: "minecraft:diamond_block",
+        plate: "techreborn:diamond_plate",
+        useMechPress: false,
+    },
+];
+
+onEvent("recipes", (event) => {
+    MATERIALS.forEach((material) => {
+        event.remove({ not: { mod: "tconstruct" }, output: material.plate });
+        if (material.useMechPress) {
+            event.recipes.createPressing(material.plate, material.ingot);
+        }
+        event.custom({
+            type: "techreborn:compressor",
+            power: 10,
+            time: 300,
+            ingredients: [
+                {
+                    item: material.ingot,
+                },
+            ],
+            results: [
+                {
+                    item: material.plate,
+                },
+            ],
+        });
+        event.custom({
+            type: "techreborn:implosion_compressor",
+            power: 30,
+            time: 1200,
+            ingredients: [
+                {
+                    item: material.block,
+                },
+                {
+                    item: "minecraft:tnt",
+                },
+            ],
+            results: [
+                {
+                    item: material.plate,
+                    count: 9,
+                },
+            ],
+        });
+        event.custom({
+            type: "techreborn:implosion_compressor",
+            power: 50,
+            time: 300,
+            ingredients: [
+                {
+                    item: material.block,
+                    count: 4,
+                },
+                {
+                    item: "minecraft:end_crystal",
+                },
+            ],
+            results: [
+                {
+                    item: material.plate,
+                    count: 36,
+                },
+                {
+                    item: "techreborn:ender_eye_small_dust",
+                    count: 1,
+                },
+            ],
+        });
+    });
+});

--- a/kubejs/server_scripts/resourcegen.js
+++ b/kubejs/server_scripts/resourcegen.js
@@ -1,6 +1,3 @@
-var FULL_BUCKET_AMMOUNT = 81000;
-var INGOT_FLUID_AMMOUNT = 9000;
-
 onEvent("recipes", (event) => {
     LakyCompactingRecipes(event);
     LakyCrushingRecipes(event);
@@ -12,49 +9,49 @@ function LakyCompactingRecipes(event) {
             "create:ochrum",
             "minecraft:sandstone",
             "minecraft:dripstone_block",
-            { fluid: "create:honey", amount: 8100 },
+            { fluid: "create:honey", amount: 100 * mB },
             "minecraft:yellow_dye",
         ],
         [
             "create:crimsite",
             "minecraft:tuff",
             "minecraft:red_sand",
-            { fluid: "tconstruct:blood", amount: 8100 },
+            { fluid: "tconstruct:blood", amount: 100 * mB },
             "minecraft:red_dye",
         ],
         [
             "create:limestone",
             "minecraft:calcite",
             "minecraft:clay",
-            { fluid: "milk:still_milk", amount: 8100 },
+            { fluid: "milk:still_milk", amount: 100 * mB },
             "minecraft:white_dye",
         ],
         [
             "create:veridium",
             "minecraft:basalt",
             "minecraft:slime_ball",
-            { fluid: "minecraft:lava", amount: 8100 },
+            { fluid: "minecraft:lava", amount: 100 * mB },
             "minecraft:green_dye",
         ],
         [
             "create:asurine",
             "minecraft:prismarine",
             "minecraft:kelp",
-            { fluid: "minecraft:water", amount: 8100 },
+            { fluid: "minecraft:water", amount: 100 * mB },
             "minecraft:blue_dye",
         ],
         [
             "create:scorchia",
             "minecraft:blackstone",
             "ad_astra:moon_sand",
-            { fluid: "tconstruct:blazing_blood", amount: 8100 },
+            { fluid: "tconstruct:blazing_blood", amount: 100 * mB },
             "minecraft:black_dye",
         ],
         [
             "create:scoria",
             "tconstruct:seared_stone",
             "minecraft:soul_soil",
-            { fluid: "create:chocolate", amount: 8100 },
+            { fluid: "create:chocolate", amount: 100 * mB },
             "minecraft:brown_dye",
         ],
     ];

--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -1,3 +1,9 @@
+const BUCKET = 81000;
+const INGOT = 9000;
+const NUGGET = 1000;
+const GEM = 8100;
+const mB = 81;
+
 // priority: 0
 
 settings.logAddedRecipes = false;
@@ -1559,7 +1565,7 @@ onEvent("recipes", (event) => {
 
     event.recipes.createCompacting("4x minecraft:purpur_block", [
         "4x ad_astra:strophar_cap",
-        { fluid: "minecraft:water", amount: FULL_BUCKET_AMMOUNT / 10 },
+        { fluid: "minecraft:water", amount: 100 * mB },
     ]);
 
     event.recipes

--- a/kubejs/server_scripts/tconstruct.js
+++ b/kubejs/server_scripts/tconstruct.js
@@ -1,6 +1,3 @@
-var FULL_BUCKET_AMMOUNT = 81000;
-var INGOT_FLUID_AMMOUNT = 9000;
-
 onEvent("recipes", (event) => {
     // Fluid: [string Fluid Name, Fluid Amount]
     // Result: string Item Name
@@ -8,43 +5,43 @@ onEvent("recipes", (event) => {
     // Cast: [string Item Name, bool Cast Consumed] or null if none
     [
         {
-            fluid: ["kubejs:compound_mixture", INGOT_FLUID_AMMOUNT * 9],
+            fluid: ["kubejs:compound_mixture", INGOT * 9],
             result: "createastral:andesite_alloy_block",
             cooling_time: 180,
             cast: null,
         },
         {
-            fluid: ["kubejs:blast-resistant_cement", FULL_BUCKET_AMMOUNT],
+            fluid: ["kubejs:blast-resistant_cement", BUCKET],
             result: "createastral:blast-resistant_concrete",
             cooling_time: 400,
             cast: null,
         },
         {
-            fluid: ["tconstruct:molten_quartz", (3 * FULL_BUCKET_AMMOUNT) / 10],
+            fluid: ["tconstruct:molten_quartz", GEM * 3],
             result: "minecraft:granite",
             cooling_time: 140,
             cast: ["minecraft:diorite", true],
         },
         {
-            fluid: ["tconstruct:liquid_soul", FULL_BUCKET_AMMOUNT],
+            fluid: ["tconstruct:liquid_soul", BUCKET],
             result: "minecraft:diorite",
             cooling_time: 80,
             cast: ["minecraft:basalt", true],
         },
         {
-            fluid: ["kubejs:liquid_xp_nuggies", INGOT_FLUID_AMMOUNT * 9],
+            fluid: ["kubejs:liquid_xp_nuggies", INGOT * 9],
             result: "create:experience_block",
             cooling_time: 180,
             cast: null,
         },
         {
-            fluid: ["tconstruct:ender_slime", FULL_BUCKET_AMMOUNT],
+            fluid: ["tconstruct:ender_slime", BUCKET],
             result: "tconstruct:ender_slime_vine",
             cooling_time: 80,
             cast: ["minecraft:vine", true],
         },
         {
-            fluid: ["tconstruct:sky_slime", FULL_BUCKET_AMMOUNT],
+            fluid: ["tconstruct:sky_slime", BUCKET],
             result: "tconstruct:sky_slime_vine",
             cooling_time: 80,
             cast: ["minecraft:vine", true],
@@ -79,49 +76,49 @@ onEvent("recipes", (event) => {
 
     [
         {
-            fluid: ["kubejs:shimmer", 4500],
+            fluid: ["kubejs:shimmer", BUCKET / 20],
             result: "ae2:fluix_dust",
             cooling_time: 40,
             cast: ["ae2:certus_quartz_dust", true],
         },
         {
-            fluid: ["tconstruct:molten_bronze", 4000],
+            fluid: ["tconstruct:molten_bronze", 4 * NUGGET],
             result: "create:cogwheel",
             cooling_time: 100,
             cast: ["tconstruct:coin_cast", false],
         },
         {
-            fluid: ["tconstruct:molten_bronze", 12000],
+            fluid: ["tconstruct:molten_bronze", 12 * NUGGET],
             result: "create:large_cogwheel",
             cooling_time: 100,
             cast: ["tconstruct:gear_cast", false],
         },
         {
-            fluid: ["tconstruct:molten_gold", 12000],
+            fluid: ["tconstruct:molten_gold", 12 * NUGGET],
             result: "tconstruct:gear_cast",
             cooling_time: 100,
             cast: ["create:large_cogwheel", true],
         },
         {
-            fluid: ["tconstruct:molten_gold", 45000],
+            fluid: ["tconstruct:molten_gold", BUCKET / 2],
             result: "createastral:golden_bowl",
             cooling_time: 100,
             cast: ["tconstruct:round_plate_cast", false],
         },
         {
-            fluid: ["kubejs:liquid_xp_nuggies", 9000],
+            fluid: ["kubejs:liquid_xp_nuggies", INGOT],
             result: "createastral:experience_ingot",
             cooling_time: 100,
             cast: ["tconstruct:ingot_cast", false],
         },
         {
-            fluid: ["kubejs:liquid_xp_nuggies", 1000],
+            fluid: ["kubejs:liquid_xp_nuggies", NUGGET],
             result: "create:experience_nugget",
             cooling_time: 10,
             cast: ["tconstruct:nugget_cast", false],
         },
         {
-            fluid: ["kubejs:liquid_xp_nuggies", 8000],
+            fluid: ["kubejs:liquid_xp_nuggies", 8 * NUGGET],
             result: "minecraft:experience_bottle",
             cooling_time: 30,
             cast: ["minecraft:glass_bottle", true],


### PR DESCRIPTION
# All plates are equal!
Some materials could be pressed by both Mechanical Presses and TR Compressors.
Some could be pressed with TR Compressor only (intentionally).
Some could only be pressed with a Create Mechanical Press...

Come on, if one has energy, one should be able to press materials with whatever newest technology available.

This PR adds a file `plates.js` with plate recipes added for:
- Create Mechanical Press (for "soft" plates) - 1 ingot → 1 plate,
- TR Compressor - 1 ingot → 1 plate - 10 E/t for 15 seconds,
- TR Implosion Compressor - 1 block + 1 TNT → 9 plates, 30 E/t for 60 seconds,
- TR Implosion Compressor - 4 blocks + 1 End Crystal → 36 plates + 1 Small Pile of Ender Eye Dust, 50 E/t for 15 seconds.

Using TR machines later on can reduce FPS lag caused by Create machines.

![2024-02-03_18 18 50](https://github.com/Laskyyy/Create-Astral/assets/125081901/b2e9beca-13d9-48c5-b7be-da89b2ab3045)
![techreborn_kjs_b8yr0313ql26uf743aizqi2lk](https://github.com/Laskyyy/Create-Astral/assets/125081901/6373ee00-8c48-4ced-9a9f-5127c3b8f586)
![techreborn_kjs_ej2ajztrn6ccig1v9is5vkk0o](https://github.com/Laskyyy/Create-Astral/assets/125081901/b5b6991b-3b05-4e99-ba69-a02d3906619d)
![techreborn_kjs_2a211ycmn6zbqrfstdpcoiuxt](https://github.com/Laskyyy/Create-Astral/assets/125081901/3cf0825c-f449-4d0b-9392-0fe5c3dd7582)

# Constants
Replaced a lot of fluid values and numerical values with values derived from constants.
Changed the misspelled names to `BUCKET` and `INGOT`.
Added `NUGGET`, `GEM` and `mB` constants.