### PR TITLE
Updated Create to 0.5.1c

### DIFF
--- a/mods/create-fabric.pw.toml
+++ b/mods/create-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Create"
-filename = "create-fabric-0.5.1-b-build.1088+mc1.18.2.jar"
+filename = "create-fabric-0.5.1-c-build.1159+mc1.18.2.jar"
 side = "both"
 
 [download]
 mode = "metadata:curseforge"
 hash-format = "sha1"
-hash = "de790d26583a3c767aef804f0fecbdcf09c9f6f7"
+hash = "0ad591968deb867651e803eda017ed8d326e34c2"
 
 [update]
 [update.curseforge]
-file-id = 4622429
+file-id = 4721056
 project-id = 624165


### PR DESCRIPTION
Updated Create to 0.5.1c in order to match the version the existing Steam 'n' Rails file is compatible with in order to avoid game crash when selecting bogey styles and assembling a train with an invisible bogey. Steam 'n' Rails functionality seems to work flawlessly in this department now and bogey styles can be selected.