### PR TITLE
Fix Backpack Mod

### DIFF
--- a/config/ftbquests/quests/chapters/assorted_goals.snbt
+++ b/config/ftbquests/quests/chapters/assorted_goals.snbt
@@ -1068,7 +1068,7 @@
 			tasks: [{
 				id: "18650A6066610756"
 				type: "item"
-				item: "camsbackpacks:white_backpack"
+				item: "travelersbackpack:standard"
 			}]
 			description: ["{chapter.1.quest.31.description.1}"]
 			id: "501AD44D7875F4D9"

--- a/index.toml
+++ b/index.toml
@@ -554,7 +554,7 @@ hash = "a0639f34ad67d0e2a9a2102214d43269bc6892b5d6897a1813e707af59f423fe"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/assorted_goals.snbt"
-hash = "f10b7a49eb901c1d91b31e3f78b38feb135514df8236fde3f719c518bb3be89f"
+hash = "f6677dc9cb1a0aa979fc23d5e97f15a0015b44e0fce8438c42592ad6c67da051"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/astral_storage.snbt"

--- a/pack.toml
+++ b/pack.toml
@@ -6,8 +6,8 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "8869efec9b50ab4812dfb259f1c4cfb50975bf84e010d6c9c930712afb713607"
+hash = "7ee977cef2e08c5b59a0d4ec9a1c9210601c71aafd6fafe4c6d31fc807a7aaac"
 
 [versions]
-fabric = "0.15.10"
+fabric = "0.15.6"
 minecraft = "1.18.2"


### PR DESCRIPTION
According to #66, the backpack mod is being replaced with Traveler's Backpacks. However, references to the old one still exist.

This aims to finish that transition by fixing quests and fully removing the deprecated backpack mod.