### PR TITLE
Custom potato cannon go brr

### DIFF
--- a/global_packs/required_data/zLaky Core/data/createastral/potato_cannon_projectile_types/flakCannon.json
+++ b/global_packs/required_data/zLaky Core/data/createastral/potato_cannon_projectile_types/flakCannon.json
@@ -1,0 +1,12 @@
+{
+    "items": [
+      "createbigcannons:flak_autocannon_round"
+    ],
+    "reload_ticks": 5,
+    "damage": 4,
+    "knockback": 0,
+    "drag": 1,
+    "velocity_multiplier": 1.3,
+    "gravity_multiplier": 1,
+    "sound_pitch": 1
+  }

--- a/kubejs/server_scripts/interaction.js
+++ b/kubejs/server_scripts/interaction.js
@@ -63,21 +63,23 @@ onEvent("block.right_click", (event) => {
 //* Use the cog as an example.
 
 //? Possable Fields:
-
-//? projectileItem - Required - String
-//? particlesEnable - Required - Bool
-//? particleSpread - Required if particlesEnable is true - Float
-//? particleSize - Required if particlesEnable is true - Float
-//? particleSpeed - Required if particlesEnable is true - Float
-//? particleCount - Required if particlesEnable is true - Float
-//? particleType - Required if particlesEnable is true - String
-//? particleHasColour - Required if particlesEnable is true - Bool
-//? particleColourR - Required if particleHasColour is true - Float
-//? particleColourG - Required if particleHasColour is true - Float
-//? particleColourB - Required if particleHasColour is true - Float
-//? explosionEnable - Required - Bool
-//? explosionStrength - Required if explosionEnable is true - Float
-//? explosionDamageTerrain - Required if explosionEnable is true - Bool
+/**
+ * @typedef {object} ProjectileConfig
+ * @property {string} projectileItem - Required - String
+ * @property {boolean} particlesEnable - Required - Bool
+ * @property {number} [particleSpread] - Required if particlesEnable is true - Float
+ * @property {number} [particleSize] - Required if particlesEnable is true - Float
+ * @property {number} [particleSpeed] - Required if particlesEnable is true - Float
+ * @property {number} [particleCount] - Required if particlesEnable is true - Float
+ * @property {string} [particleType] - Required if particlesEnable is true - String
+ * @property {boolean} [particleHasColour] - Required if particlesEnable is true - Bool
+ * @property {number} [particleColourR] - Required if particleHasColour is true - Float
+ * @property {number} [particleColourG] - Required if particleHasColour is true - Float
+ * @property {number} [particleColourB] - Required if particleHasColour is true - Float
+ * @property {boolean} explosionEnable - Required - Bool
+ * @property {number} [explosionStrength] Required if explosionEnable is true - Float
+ * @property {boolean} [explosionDamageTerrain] Required if explosionEnable is true - Bool
+ */
 
 const ammos = [
     {
@@ -92,10 +94,9 @@ const ammos = [
     explosionStrength: 10, explosionDamageTerrain: true,                            //? How strong it go boom and if it hurt the land
     },
 
-
     {
     projectileItem: "createbigcannons:flak_autocannon_round",
-    particlesEnable: false, 
+    particlesEnable: false,
 
     explosionEnable: true,
     explosionStrength: 5, explosionDamageTerrain: true,
@@ -131,5 +132,7 @@ server.scheduleInTicks(5, event => {
         return
     }
     event.reschedule()
-})}})})
+})}
+})
 //! Made by TheOverlyCaffeinatedTrashPanda 
+})

--- a/kubejs/server_scripts/interaction.js
+++ b/kubejs/server_scripts/interaction.js
@@ -52,31 +52,84 @@ onEvent("block.right_click", (event) => {
         }
 }})});
   
-  
-  //? Add code to make different potato projectiles go bang
-  const projectileItem         = "createastral:astral_singularity" //? The Item to change
-  const particleSpread         = 2.5 
-  const particleSize           = 10 
-  const particleSpeed          = 5
-  const particleCount          = 100
-  const explosionStrength      = 10
-  const explosionDamageTerrain = true
-  
-  onEvent('entity.spawned', event => {
-      const { entity, server} = event
-      if (entity.type === "create:potato_projectile" && entity.fullNBT.Item.id === projectileItem) {
-          server.scheduleInTicks(5, event => {
-              if(entity.removed || entity.deadOrDying || !entity.alive) {
-                  let x = entity.fullNBT.Pos[0] 
-                  let y = entity.fullNBT.Pos[1]
-                  let z = entity.fullNBT.Pos[2]
-                  let explosion =    entity.block.offset(0,0,0).createExplosion()
-                  explosion.strength(explosionStrength)
-                  explosion.damagesTerrain(explosionDamageTerrain)
-                  //? This is the line to comment out if you do not want particles
-                  server.runCommandSilent(`particle dust 0.31 0 0.78 ${particleSize} ${x} ${y} ${z} ${particleSpread} ${particleSpread} ${particleSpread} ${particleSpeed} ${particleCount}`)
-                  explosion.explode()
-                  return
-              }
-              event.reschedule()
-  })}})
+
+
+
+
+//? Add code to make different potato projectiles go bang
+
+//! READ ME: 
+//* when you add a new ammo type. make sure it add it to Create-Astral\global_packs\required_data\zLaky Core\data\createastral\potato_cannon_projectile_types
+//* Use the cog as an example.
+
+//? Possable Fields:
+
+//? projectileItem - Required - String
+//? particlesEnable - Required - Bool
+//? particleSpread - Required if particlesEnable is true - Float
+//? particleSize - Required if particlesEnable is true - Float
+//? particleSpeed - Required if particlesEnable is true - Float
+//? particleCount - Required if particlesEnable is true - Float
+//? particleType - Required if particlesEnable is true - String
+//? particleHasColour - Required if particlesEnable is true - Bool
+//? particleColourR - Required if particleHasColour is true - Float
+//? particleColourG - Required if particleHasColour is true - Float
+//? particleColourB - Required if particleHasColour is true - Float
+//? explosionEnable - Required - Bool
+//? explosionStrength - Required if explosionEnable is true - Float
+//? explosionDamageTerrain - Required if explosionEnable is true - Bool
+
+const ammos = [
+    {
+    projectileItem: "createastral:astral_singularity",                              //? Item ID
+    particlesEnable: true,                                                          //? Does it have particles
+    particleSpread: 2.5, particleSize: 10, particleSpeed: 5, particleCount: 100,    //? Settings
+
+    particleType: "minecraft:dust", particleHasColour: true,                        //? Type of particle and if its colour can be changed
+    particleColourR: 0.31, particleColourG: 0, particleColourB: 0.7,                //? Colour settings
+
+    explosionEnable: true,                                                          //? Does it go boom         
+    explosionStrength: 10, explosionDamageTerrain: true,                            //? How strong it go boom and if it hurt the land
+    },
+
+
+    {
+    projectileItem: "createbigcannons:flak_autocannon_round",
+    particlesEnable: false, 
+
+    explosionEnable: true,
+    explosionStrength: 5, explosionDamageTerrain: true,
+    }
+]
+
+onEvent('entity.spawned', event => {
+const { entity, server} = event
+ammos.forEach(ammoType => {
+if (entity.type === "create:potato_projectile" && entity.fullNBT.Item.id === ammoType.projectileItem) {
+
+server.scheduleInTicks(5, event => {
+    if(entity.removed || entity.deadOrDying || !entity.alive) {
+        let x = entity.fullNBT.Pos[0] 
+        let y = entity.fullNBT.Pos[1]
+        let z = entity.fullNBT.Pos[2]
+        let explosion = entity.block.offset(0,0,0).createExplosion()
+
+        if (ammoType.particlesEnable) {
+            if (ammoType.particleHasColour) {
+                server.runCommandSilent(`particle ${ammoType.particleType} ${ammoType.particleColourR} ${ammoType.particleColourG} ${ammoType.particleColourB} ${ammoType.particleSize} ${x} ${y} ${z} ${ammoType.particleSpread} ${ammoType.particleSpread} ${ammoType.particleSpread} ${ammoType.particleSpeed} ${ammoType.particleCount}`)
+            }
+            else {
+                server.runCommandSilent(`particle ${ammoType.particleType} ${x} ${y} ${z} ${ammoType.particleSpread} ${ammoType.particleSpread} ${ammoType.particleSpread} ${ammoType.particleSpeed} ${ammoType.particleCount}`)
+            }
+        }
+
+        if (ammoType.explosionEnable === true) {
+            explosion.strength(ammoType.explosionStrength)
+            explosion.damagesTerrain(ammoType.explosionDamageTerrain)
+            explosion.explode()
+        }
+        return
+    }
+    event.reschedule()
+})}})})
+//! Made by TheOverlyCaffeinatedTrashPanda 

--- a/kubejs/server_scripts/interaction.js
+++ b/kubejs/server_scripts/interaction.js
@@ -123,7 +123,7 @@ server.scheduleInTicks(5, event => {
             }
         }
 
-        if (ammoType.explosionEnable === true) {
+        if (ammoType.explosionEnable) {
             explosion.strength(ammoType.explosionStrength)
             explosion.damagesTerrain(ammoType.explosionDamageTerrain)
             explosion.explode()


### PR DESCRIPTION
Improved the potato cannon code to allow more custom control and can handle more then 1 item now.

Also added an new json to the datapacks to allow the flak auto cannon round to be shot from potato cannon. This was just an example