### PR TITLE
No more dusts & other useless TR stuff in REI

### DIFF
--- a/kubejs/client_scripts/hide_from_rei.js
+++ b/kubejs/client_scripts/hide_from_rei.js
@@ -6,6 +6,7 @@ function addTinkerTableVariants(list, item, chipped_block, max_num) {
 
 onEvent("rei.hide.items", (event) => {
     var HIDDEN_ITEMS = [
+        "ae2:silicon",
         "extended_drawers:t1_upgrade",
         "extended_drawers:t2_upgrade",
         "extended_drawers:t3_upgrade",
@@ -472,22 +473,6 @@ onEvent("rei.hide.items", (event) => {
         "techreborn:advanced_alloy_storage_block_stairs",
         "techreborn:advanced_alloy_storage_block_wall",
         "techreborn:advanced_circuit",
-        "techreborn:aluminum_dust",
-        "techreborn:aluminum_ingot",
-        "techreborn:aluminum_nugget",
-        "techreborn:aluminum_plate",
-        "techreborn:aluminum_storage_block",
-        "techreborn:aluminum_storage_block_slab",
-        "techreborn:aluminum_storage_block_stairs",
-        "techreborn:aluminum_storage_block_wall",
-        "techreborn:brass_dust",
-        "techreborn:brass_ingot",
-        "techreborn:brass_nugget",
-        "techreborn:brass_plate",
-        "techreborn:brass_storage_block",
-        "techreborn:brass_storage_block_slab",
-        "techreborn:brass_storage_block_stairs",
-        "techreborn:brass_storage_block_wall",
         Item.of("techreborn:bronze_axe", "{Damage:0}"),
         Item.of("techreborn:bronze_boots", "{Damage:0}"),
         Item.of("techreborn:bronze_chestplate", "{Damage:0}"),
@@ -513,15 +498,6 @@ onEvent("rei.hide.items", (event) => {
         Item.of("techreborn:cell", '{fluid:"tconstruct:molten_refined_obsidian"}'),
         Item.of("techreborn:cell", '{fluid:"tconstruct:molten_signalum"}'),
         Item.of("techreborn:cell", '{fluid:"tconstruct:molten_soulsteel"}'),
-        "techreborn:chrome_dust",
-        "techreborn:chrome_ingot",
-        "techreborn:chrome_nugget",
-        "techreborn:chrome_plate",
-        "techreborn:chrome_small_dust",
-        "techreborn:chrome_storage_block",
-        "techreborn:chrome_storage_block_slab",
-        "techreborn:chrome_storage_block_stairs",
-        "techreborn:chrome_storage_block_wall",
         "techreborn:copper_nugget",
         "techreborn:data_storage_core",
         "techreborn:energy_crystal",
@@ -553,7 +529,6 @@ onEvent("rei.hide.items", (event) => {
         Item.of("techreborn:peridot_pickaxe", "{Damage:0}"),
         Item.of("techreborn:peridot_spade", "{Damage:0}"),
         Item.of("techreborn:peridot_sword", "{Damage:0}"),
-        "techreborn:platinum_small_dust",
         "techreborn:raw_tungsten",
         "techreborn:refined_iron_ingot",
         "techreborn:refined_iron_nugget",
@@ -595,41 +570,28 @@ onEvent("rei.hide.items", (event) => {
         "techreborn:steel_storage_block_slab",
         "techreborn:steel_storage_block_stairs",
         "techreborn:steel_storage_block_wall",
-        "techreborn:titanium_dust",
-        "techreborn:titanium_ingot",
-        "techreborn:titanium_nugget",
-        "techreborn:titanium_plate",
-        "techreborn:titanium_small_dust",
-        "techreborn:titanium_storage_block",
-        "techreborn:titanium_storage_block_slab",
-        "techreborn:titanium_storage_block_stairs",
-        "techreborn:titanium_storage_block_wall",
-        "techreborn:tungsten_ingot",
-        "techreborn:tungsten_nugget",
-        "techreborn:tungsten_plate",
-        "techreborn:tungsten_small_dust",
-        "techreborn:tungsten_storage_block",
-        "techreborn:tungsten_storage_block_slab",
-        "techreborn:tungsten_storage_block_stairs",
-        "techreborn:tungsten_storage_block_wall",
-        "techreborn:tungstensteel_ingot",
-        "techreborn:tungstensteel_nugget",
-        "techreborn:tungstensteel_plate",
-        "techreborn:tungstensteel_storage_block",
-        "techreborn:tungstensteel_storage_block_slab",
-        "techreborn:tungstensteel_storage_block_stairs",
-        "techreborn:tungstensteel_storage_block_wall",
-        "techreborn:zinc_ingot",
-        "techreborn:zinc_nugget",
-        "techreborn:zinc_plate",
-        "techreborn:zinc_storage_block",
-        "techreborn:zinc_storage_block_slab",
-        "techreborn:zinc_storage_block_stairs",
-        "techreborn:zinc_storage_block_wall",
         "techreborn:neutron_reflector",
         "techreborn:thick_neturon_reflector",
         "techreborn:iridium_neutron_reflector",
         "techreborn:mixed_metal_ingot",
+        "techreborn:glowstone_small_dust",
+        "techreborn:redstone_small_dust",
+        "techreborn:bauxite_ore",
+        "techreborn:cinnabar_ore",
+        "techreborn:galena_ore",
+        "techreborn:pyrite_ore",
+        "techreborn:sheldonite_ore",
+        "techreborn:sodalite_ore",
+        "techreborn:sphalerite_ore",
+        "techreborn:tungsten_ore",
+        "techreborn:deepslate_bauxite_ore",
+        "techreborn:deepslate_sheldonite_ore",
+        "techreborn:deepslate_sodalite_ore",
+        "techreborn:deepslate_tungsten_ore",
+        "techreborn:raw_tungsten_storage_block",
+        "techreborn:raw_tungsten_storage_block_stairs",
+        "techreborn:raw_tungsten_storage_block_slab",
+        "techreborn:raw_tungsten_storage_block_wall",
         "createbigcannons:molten_bronze_bucket",
         "createbigcannons:molten_steel_bucket",
         "createbigcannons:molten_nethersteel_bucket",
@@ -652,6 +614,106 @@ onEvent("rei.hide.items", (event) => {
     addTinkerTableVariants(HIDDEN_ITEMS, "tconstruct:tinker_station", "crimson_planks", 41);
     addTinkerTableVariants(HIDDEN_ITEMS, "tconstruct:tinker_station", "warped_planks", 41);
 
+    const gems = [
+        "peridot",
+        "red_garnet",
+        "ruby",
+        "sapphire",
+        "yellow_garnet"
+    ]
+    gems.forEach((gem) => {
+        HIDDEN_ITEMS.push(`techreborn:${gem}_ore`);
+        HIDDEN_ITEMS.push(`techreborn:deepslate_${gem}_ore`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_storage_block`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_storage_block_stairs`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_storage_block_slab`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_storage_block_wall`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_gem`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_dust`);
+        HIDDEN_ITEMS.push(`techreborn:${gem}_small_dust`);
+    });
+
+    const ingots = [
+        "tungstensteel",
+        "chrome",
+        "titanium",
+        "nickel",
+        "refined_iron",
+        "aluminum",
+        "tungsten",
+        "platinum",
+        "brass",
+        "zinc"
+    ]
+    ingots.forEach((ingot) => {
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_tiny_dust`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_dust`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_ingot`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_nugget`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_plate`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_small_dust`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_storage_block`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_storage_block_slab`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_storage_block_stairs`);
+        HIDDEN_ITEMS.push(`techreborn:${ingot}_storage_block_wall`);
+    });
+
+    // format, dust name, true if used for anything (keep dust, but not tiny dust)
+    const dusts = [
+        ["almandine", false],
+        ["amethyst", true],
+        ["andesite", true],
+        ["andradite", false],
+        ["ashes", true],
+        ["basalt", true],
+        ["bauxite", false],
+        ["bronze", false],
+        ["calcite", true],
+        ["charcoal", true],
+        ["cinnabar", false],
+        ["clay", true],
+        ["coal", true],
+        ["dark_ashes", true],
+        ["diamond", true],
+        ["diorite", true],
+        ["electrum", true],
+        ["emerald", false],
+        ["ender_eye", false],
+        ["ender_pearl", false], // ae2 ender dust replaces it
+        ["endstone", false],
+        ["flint", true],
+        ["galena", true],
+        ["granite", true],
+        ["grossular", false],
+        ["invar", false],
+        ["lazurite", true],
+        ["magnesium", false],
+        ["manganese", false],
+        ["marble", false],
+        ["netherrack", true],
+        ["nickel", false],
+        ["obsidian", false], // replaced by create obsidian dust
+        ["olivine", true],
+        ["phosphorous", false],
+        ["pyrite", false],
+        ["pyrope", false],
+        ["quartz", false],
+        ["saltpeter", true],
+        ["saw", true],
+        ["sodalite", false],
+        ["spessartine", false],
+        ["sphalerite", false],
+        ["steel", true],
+        ["sulfur", true],
+        ["uvarovite", false],
+    ]
+    dusts.forEach((dust) => {
+        if (!dust[1]){
+            HIDDEN_ITEMS.push(`techreborn:${dust[0]}_dust`);
+        }
+        HIDDEN_ITEMS.push(`techreborn:${dust[0]}_small_dust`);
+    });
+
 
     const plates = [
         "carbon",
@@ -665,10 +727,8 @@ onEvent("rei.hide.items", (event) => {
         "lapis",
         "lazurite",
         "magnalium",
-        "nickel",
         "obsidian",
         "peridot",
-        "platinum",
         "quartz",
         "red_garnet",
         "redstone",

--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -113,7 +113,7 @@ function crushingRecipes(event) {
                 ["1x minecraft:purple_dye", 1],
                 ["2x minecraft:purple_dye", 0.5],
                 ["1x minecraft:popped_chorus_fruit", 0.1],
-                ["1x techreborn:ender_pearl_small_dust", 0.1],
+                ["1x ae2:ender_dust", 0.2],
                 ["1x techreborn:calcite_dust", 0.1],
                 ["1x minecraft:bubble_coral", 0.25],
                 ["1x minecraft:bubble_coral_fan", 0.25],
@@ -2642,7 +2642,12 @@ function compactingRecipes(event) {
         },
         {
             output: ["ae2:silicon_press", "ae2:printed_silicon"],
-            inputs: ["ae2:silicon_press", "2x ae2:silicon"],
+            inputs: ["ae2:silicon_press",
+                {
+                    fluid: "techreborn:silicon",
+                    amount: INGOT,
+                },
+            ],
         },
         {
             output: ["ae2:silicon_press", "ae2:silicon_press"],

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -5,6 +5,7 @@ onEvent("recipes", (event) => {
     //Tech Reborn
     [
         { output: "techreborn:chunk_loader" },
+        {output: "techreborn:pyrite_dust"},
         { output: "ae2:spatial_anchor" },
         { output: "techreborn:industrial_electrolyzer" },
         { output: "techreborn:industrial_sawmill" },
@@ -586,6 +587,8 @@ onEvent("recipes", (event) => {
         "platinum",
         "brass",
         "zinc",
+        "nickel",
+        "platinum"
     ];
 
     metal.forEach((metal) => {

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -516,7 +516,8 @@ onEvent("recipes", (event) => {
         { output: "minecraft:blackstone" },
         { output: "minecraft:gold_nugget", input: "minecraft:soul_sand" },
         { output: "minecraft:gravel", input: "techreborn:granite_dust" },
-        { output: "minecraft:gold_nugget", input: "minecraft:soul_soil" },
+        { output: "minecraft:gold_nugget", input: "minecraft:soul_soil" }
+        {output: "ae2:silicon"},
         { input: "minecraft:crying_obsidian" },
         {
             input: "minecraft:copper_block",
@@ -601,5 +602,62 @@ onEvent("recipes", (event) => {
         event.remove({ output: `techreborn:${metal}_dust` });
         event.remove({ output: `techreborn:${metal}_small_dust` });
         event.remove({ output: `techreborn:${metal}_nugget` });
+    });
+
+    const dusts = [
+        ["almandine", false],
+        ["amethyst", true],
+        ["andesite", true],
+        ["andradite", false],
+        ["ashes", true],
+        ["basalt", true],
+        ["bauxite", false],
+        ["bronze", false],
+        ["calcite", true],
+        ["charcoal", true],
+        ["cinnabar", false],
+        ["clay", true],
+        ["coal", true],
+        ["dark_ashes", true],
+        ["diamond", true],
+        ["diorite", true],
+        ["electrum", true],
+        ["emerald", false],
+        ["ender_eye", false],
+        ["ender_pearl", false], // ae2 ender dust replaces it
+        ["endstone", false],
+        ["flint", true],
+        ["galena", true],
+        ["granite", true],
+        ["grossular", false],
+        ["invar", false],
+        ["lazurite", true],
+        ["magnesium", false],
+        ["manganese", false],
+        ["marble", false],
+        ["netherrack", true],
+        ["nickel", false],
+        ["obsidian", false],
+        ["olivine", true],
+        ["phosphorous", false],
+        ["pyrite", false],
+        ["pyrope", false],
+        ["quartz", false],
+        ["saltpeter", true],
+        ["saw", true],
+        ["sodalite", false],
+        ["spessartine", false],
+        ["sphalerite", false],
+        ["steel", true],
+        ["sulfur", true],
+        ["uvarovite", false],
+        ["glowstone", true],
+        ["redstone", true]
+    ]
+    dusts.forEach((dust) => {
+        if (!dust[1]) {
+            event.remove({output: `techreborn:${dust[0]}_dust`});
+        }
+        event.remove({output: `techreborn:${dust[0]}_small_dust`});
     });
 });

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -516,8 +516,9 @@ onEvent("recipes", (event) => {
         { output: "minecraft:blackstone" },
         { output: "minecraft:gold_nugget", input: "minecraft:soul_sand" },
         { output: "minecraft:gravel", input: "techreborn:granite_dust" },
-        { output: "minecraft:gold_nugget", input: "minecraft:soul_soil" }
+        { output: "minecraft:gold_nugget", input: "minecraft:soul_soil" },
         {output: "ae2:silicon"},
+        {id: "techreborn:centrifuge/redstone" }, // remove other version of centrifuging certus quartz
         { input: "minecraft:crying_obsidian" },
         {
             input: "minecraft:copper_block",

--- a/kubejs/server_scripts/replacements.js
+++ b/kubejs/server_scripts/replacements.js
@@ -5,7 +5,7 @@ onEvent("recipes", (event) => {
         ["create:powdered_obsidian", "#c:dusts/obsidian"],
         ["techreborn:obsidian_dust", "#c:dusts/obsidian"],
         ["createaddition:diamond_grit", "techreborn:diamond_dust"],
-
+        ["ae2:ender_dust", "techreborn:ender_pearl_dust"],
         [
             { mod: "createbigcannons" },
             "create:iron_sheet",
@@ -47,7 +47,18 @@ onEvent("recipes", (event) => {
             "ad_astra:ostrum_ingot",
         ],
         [{ mod: "createbigcannons" }, "minecraft:string", "create:sand_paper"],
-
+        [
+            {output: "minecraft:pointed_dripstone"},
+            "techreborn:calcite_small_dust", "techreborn:calcite_dust"
+        ],
+        [
+            {output: "minecraft:calcite"},
+            "techreborn:calcite_small_dust", "techreborn:calcite_dust"
+        ],
+        [
+            {output: "techreborn:nanosaber"},
+            "techreborn:glowstone_small_dust", "minecraft:glowstone_dust"
+        ],
         [
             { output: "techreborn:copper_cable" },
             "minecraft:copper_ingot",

--- a/kubejs/server_scripts/resourcegen.js
+++ b/kubejs/server_scripts/resourcegen.js
@@ -80,7 +80,7 @@ function LakyCrushingRecipes(event) {
             outputs: [
                 ["minecraft:raw_gold", 1],
                 ["minecraft:raw_gold", 0.5],
-                ["techreborn:glowstone_small_dust", 0.9],
+                ["minecraft:glowstone_dust", 0.1],
                 ["minecraft:sand", 0.5],
                 ["ad_astra:desh_nugget", 0.4],
             ],
@@ -90,7 +90,7 @@ function LakyCrushingRecipes(event) {
             outputs: [
                 ["minecraft:raw_iron", 1],
                 ["minecraft:raw_iron", 0.5],
-                ["techreborn:redstone_small_dust", 0.9],
+                ["minecraft:redstone_dust", 0.1],
                 ["minecraft:granite", 0.5],
                 ["minecraft:red_dye", 0.25],
             ],
@@ -111,7 +111,7 @@ function LakyCrushingRecipes(event) {
             outputs: [
                 ["minecraft:raw_copper", 1],
                 ["minecraft:raw_copper", 0.9],
-                ["techreborn:olivine_small_dust", 0.9],
+                ["techreborn:olivine_dust", 0.1],
                 ["minecraft:sand", 0.5],
                 ["minecraft:green_dye", 0.25],
             ],
@@ -122,7 +122,7 @@ function LakyCrushingRecipes(event) {
                 ["techreborn:raw_tin", 1],
                 ["techreborn:raw_tin", 0.2],
                 ["minecraft:lapis_lazuli", 0.5],
-                ["techreborn:lazurite_small_dust", 0.9],
+                ["techreborn:lazurite_dust", 0.1],
                 ["minecraft:blue_dye", 0.25],
                 ["minecraft:prismarine_crystals", 0.2],
             ],

--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -1171,29 +1171,6 @@ onEvent("recipes", (event) => {
         output: "minecraft:redstone",
     });
     event.replaceInput("ae2:sky_stone_block", "ad_astra:sky_stone");
-    event.replaceInput("ae2:sky_stone_block", "ad_astra:sky_stone");
-
-    event.custom({
-        type: "techreborn:centrifuge",
-        power: 8,
-        time: 500,
-        ingredients: [
-            {
-                item: "farmersdelight:rich_soil",
-                count: 2,
-            },
-        ],
-        results: [
-            {
-                item: "minecraft:coarse_dirt",
-                count: 2,
-            },
-            {
-                item: "techreborn:saltpeter_dust",
-                count: 4,
-            },
-        ],
-    });
 
     event.shapeless(Item.of("techreborn:nitro_diesel_bucket"), ["ad_astra:fuel_bucket"]);
     event.shapeless(Item.of("techreborn:oil_bucket"), ["ad_astra:oil_bucket"]);

--- a/kubejs/server_scripts/sheets.js
+++ b/kubejs/server_scripts/sheets.js
@@ -174,8 +174,8 @@ onEvent("recipes", (event) => {
                     count: 36,
                 },
                 {
-                    item: "techreborn:ender_eye_small_dust",
-                    count: 1,
+                    item: "techreborn:dark_ashes_dust",
+                    count: 4,
                 },
             ],
         });

--- a/kubejs/server_scripts/techreborn.js
+++ b/kubejs/server_scripts/techreborn.js
@@ -91,7 +91,7 @@ onEvent("recipes", (event) => {
     ];
 
     for (let recipe of CRUSHING_RECIPES_TO_BECOME_GRINDING) {
-        event.remove({ type: "create:crushing", input: recipe[0] });
+        event.remove({type: "create:crushing", input: recipe[0]});
         event.custom({
             type: "techreborn:grinder",
             time: recipe[3] || DEFAULT_GRIND_TIME,
@@ -131,33 +131,61 @@ onEvent("recipes", (event) => {
         ],
     });
 
-    //Implosion Compressor
-
+    // centrifuge
     event.custom({
-        type: "techreborn:implosion_compressor",
-        power: 30,
+        type: "techreborn:centrifuge",
+        power: 8,
         time: 500,
         ingredients: [
             {
-                count: 1,
-                item: "techreborn:steel_dust",
-            },
-            {
-                item: "minecraft:tnt",
-                count: 1,
+                item: "farmersdelight:rich_soil",
+                count: 2,
             },
         ],
         results: [
             {
-                item: "ad_astra:steel_ingot",
-                count: 1,
+                item: "minecraft:coarse_dirt",
+                count: 2,
             },
             {
-                item: "techreborn:steel_nugget",
-                count: 2,
+                item: "techreborn:saltpeter_dust",
+                count: 4,
             },
         ],
     });
+
+    event.custom({
+        type: "techreborn:centrifuge",
+        power: 8,
+        time: 500,
+        ingredients: [
+            {
+                item: "ae2:certus_quartz_crystal",
+                count: 32,
+            },
+            {
+                item: "techreborn:cell",
+                count: 13
+            }
+        ],
+        results: [
+            {
+                item: "techreborn:cell",
+                nbt: {
+                    fluid: "techreborn:mercury",
+                },
+                count: 10,
+            },
+            {
+                item: "techreborn:cell",
+                nbt: {
+                    fluid: "techreborn:silicon",
+                },
+                count: 3,
+            },
+        ],
+    });
+
 
     // Vacuum Freezer
 


### PR DESCRIPTION
Removed all unused tech reborn dusts, and slightly modified recipes that returned them. 
1 major non-recipe change: ae2:silicon (used in press to make printed silicon) now instead uses techreborn:silicon (so now the recipe uses a fluid same as all other presses).

Dusts with no uses, that can be crafted (like granite dust for example) are still available.