### PR TITLE
undo hellfire nerf and increase the amount of blaze cakes it can craft instead

### DIFF
--- a/global_packs/required_data/zLaky Core/data/createastral/recipes/liquid_burning/hellfire.json
+++ b/global_packs/required_data/zLaky Core/data/createastral/recipes/liquid_burning/hellfire.json
@@ -4,6 +4,6 @@
       	"fluid": "kubejs:hellfire",
       	"amount": 20250
 	},
-	"burnTime": 900,
+	"burnTime": 3300,
 	"superheated": true
 }

--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -1372,7 +1372,7 @@ function fillingRecipes(event) {
             input: "create:blaze_cake_base",
             output: "create:blaze_cake",
             fluid: "kubejs:hellfire",
-            amount: 250 * mB,
+            amount: 75 * mB,
         },
         {
             input: "techreborn:red_cell_battery",


### PR DESCRIPTION
The hellfire nerf might've made super heating too expensive. This PR reverts hellfire to its original burn value and decreases how much hellfire is needed to make a blaze cake instead.