### PR TITLE
Small QOL changes (including crushed cobalt, and cast fixes)

### DIFF
--- a/config/tconstruct-client.toml
+++ b/config/tconstruct-client.toml
@@ -13,14 +13,14 @@
 	#If true, the game will log all modifier textures which do not exist in resource packs but can be added, can be helpful for moddevs or resourcepack makers
 	logMissingModifierTextures = false
 	#If true, modifiers will be added to the JEI ingredient list. If false, they will only be visible in the modifiers recipe tab.
-	showModifiersInJEI = false
+	showModifiersInJEI = true
 	#If true, the game will log all material textures which do not exist in resource packs but can be added, can be helpful for moddevs or resourcepack makers
 	logMissingMaterialTextures = false
 
 	#Settings related to modifiers
 	[client.modifiers]
 		#If true, the shield slot legging modifier will render the next offhand item above the offhand slot.
-		renderShieldSlotItem = false
+		renderShieldSlotItem = true
 
 		#Settings related to the frame helmet modifier
 		[client.modifiers.itemFrame]

--- a/index.toml
+++ b/index.toml
@@ -6,7 +6,7 @@ hash = "2cde14117c96226c89ebafaca24728978ee5b572caa122de791826c21798ff79"
 
 [[files]]
 file = "config/SkipTransitions.properties"
-hash = "57aff8e15bfd1a7ad48ef2b985993a3b2d9d0a69139da5402f8730299699bbfc"
+hash = "b461b46f0e7b5a1c945deb98deafea32332b5de90f1eaa9e35e2b9c6ee2c6440"
 
 [[files]]
 file = "config/ad_astra.toml"
@@ -18,7 +18,7 @@ hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 [[files]]
 file = "config/appleskin.json5"
-hash = "ae87f2d1b38dfd4b1e0767dfeb539261deaaf4fd2eb73692afcbaac7147855b9"
+hash = "d66629409d569769fac6ecb44706adf7e7fad4df4f2afa612cc54379dcf33b78"
 
 [[files]]
 file = "config/appliedenergistics2/client.json"
@@ -34,27 +34,27 @@ hash = "21df35da5538b764fb7d54cce81940a91b887b7676dd0b82f93edba31bbc94cf"
 
 [[files]]
 file = "config/bettercombat/client.conf"
-hash = "2df6270ea325d1ae65d2d185560455963e71505665a5ef14ef2ce69b60888d32"
+hash = "45fd4e1fc2ec119398a617211472cce4526e2837093b3ca3644e78916251fc82"
 
 [[files]]
 file = "config/bettercombat/client.json5"
-hash = "2cdf8010a89c43c88f59d511de9c35e144bb42aa4d029301d059cfc1f4796688"
+hash = "b64fe0e35f9b02bd052a3dcb34a835b8b1a2c3caa85336313fbab6abbd9a8144"
 
 [[files]]
 file = "config/bettercombat/fallback_compatibility.json"
-hash = "d8e931e736891a663c5a781482b472480af45c82ec4ce059e9e942ffb0f7ebda"
+hash = "159005fa4ebf77590ffcaaed52f1757a0e98e5f70df7898516f85946459242b1"
 
 [[files]]
 file = "config/bettercombat/server.conf"
-hash = "ad145e5fbe2af4c5d81a805fe7d0ed4fc6c164d270581ea109356c189fd15d79"
+hash = "0c395c3d2f76049bf97dc4d38ffa980099162988719bb324909305b3d90b368d"
 
 [[files]]
 file = "config/bettercombat/server.json5"
-hash = "c27355c54bfa33f6db2b3e73313edcfd160a50a3ed6261c5880093aaeff02d00"
+hash = "00a43e11c7fc2548d446ccbe687400855335b0670b1440f787ee6489181a3cfb"
 
 [[files]]
 file = "config/blanket_client-fixes.json"
-hash = "bd28e24b4a7c691676d8e6d77b4a3d712952bf8fd21167eb780ee1af639a0201"
+hash = "0df92e05937202886edd9346324dd62756ee4f8b7715be68ff78e4cf0c3d695d"
 
 [[files]]
 file = "config/building_gadgets.json"
@@ -70,15 +70,15 @@ hash = "c9f8e0f225123d3c11febf309b62a5f95cecb566cc1102fb4b43c162b13ca9b5"
 
 [[files]]
 file = "config/campanion.json"
-hash = "256e6f1c80b8bddf8ebba8d4aacfb769c046c5b688201be5ccaf7bb29d657d80"
+hash = "d5779d479edc906caf1d71f2b6b5c832d94aa85c88af9244890355156f4b4fb2"
 
 [[files]]
 file = "config/capybara.json"
-hash = "45ae8450a6aadae4f4a1cd01fc430ba16008c73ec0e8230bb01570ca59c7c78f"
+hash = "3d820104bb33a2c2ef6295668af2cbb2352a19c124c630b90b3f7f6f941e9077"
 
 [[files]]
 file = "config/cardinal-components-api.properties"
-hash = "f7e7f346e0724cf9cfb77f44dec2e7d202ea2507729ec7b95ee6a8f089c82982"
+hash = "9fed9968597fd4a8cd4221ade32109f3f026033245809f2676b85e86057cd1ee"
 
 [[files]]
 file = "config/carpet/default_carpet-fixes.conf"
@@ -90,19 +90,19 @@ hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 [[files]]
 file = "config/cem.conf"
-hash = "c869b1e1cf73b7b0d5ca03e4657fdbed845d85ab5aca0449248fd144545ecfb7"
+hash = "1f6c406790c04431adfa22c1e10e4c6bff0bdae50b6716566a10e87057a918d0"
 
 [[files]]
 file = "config/chat_heads.json5"
-hash = "e20733723e9e8a2789a9e56600f48b292b695c3b176072a0988c07cfb282872b"
+hash = "43f98e721e4e479ab2044b665ecbd6a30f87f70a3c4450c0d3b278d00998a46d"
 
 [[files]]
 file = "config/citresewn-defaults.json"
-hash = "0b333b0bf9a0e573fa14f81610a621b488d5277c9e8f8c6a4c81e6a6cb37e482"
+hash = "ec350db1d59f642c8aef73e5e0cb12e25ce73772df7dc01fd1a58a44a5aac735"
 
 [[files]]
 file = "config/citresewn.json"
-hash = "1ea03400477ac2075d61ae58cfc573bc78ce954507d090ab69547de279918656"
+hash = "4ae8241015ed1dad4c97bf133d4dd48f07fb9ed409b95b7e70e5df0470b83221"
 
 [[files]]
 file = "config/cobblegen-meta.json5"
@@ -114,7 +114,7 @@ hash = "53a1f7bd0157f7dc761e3676fdc10b238809c3a772d4b7d98979359fbd27215f"
 
 [[files]]
 file = "config/collective-fabric.json5"
-hash = "f482611e63206c368381d69f35d10260086f52a56ac41348a709eaa4a71ae060"
+hash = "ab5d7b49358ea1c2476512c219ef1074f0161823bccb184bfa345c37ce203127"
 
 [[files]]
 file = "config/colormatic.properties"
@@ -126,15 +126,15 @@ hash = "8e1af48fbafb26e374fb91793cd950e32dc4008e423267f8d2006c2350bfd567"
 
 [[files]]
 file = "config/connectivity.json"
-hash = "a17f84d0c9a37e9ea618679133dc4498c270753517e12974cb9e07611a716201"
+hash = "55bcc86819984041c3baeddd296d55149c16514cfb4cd629814c101bea1f8b03"
 
 [[files]]
 file = "config/continuity.json"
-hash = "00267a602028cbb037dcb0b5f803db31bed284235ca9c1ea189ad4179311a2f4"
+hash = "77f86e18fff51b0c06b773b5bc9608b5b74e264e2220589d6b1723b044b18e10"
 
 [[files]]
 file = "config/cookingforblockheads.toml"
-hash = "42695bb95965a735d510815df9f66eda78806cb4658a855fadbea9ac55444faa"
+hash = "36e078cb4733c4de3d41c67198141c38ea285235d50e7d3256e61e625588e649"
 
 [[files]]
 file = "config/create-client.toml"
@@ -158,15 +158,15 @@ hash = "0d054c60f6c57e3e351a4512b8e105f4331d9c1ee3fc30b2ed25242525b1d62d"
 
 [[files]]
 file = "config/crowdin.txt"
-hash = "fadbd1094e4079597c631b59da43ea2e315aa610c47282045384e888894ecc41"
+hash = "1550defe024769c2d4eda18be853083af5293d1fa747900592bad3d9bafa02d1"
 
 [[files]]
 file = "config/ctm.json"
-hash = "108892821d53d2d12cbc07e37028e3c350a0d179a6620fc4e2067b6dcb9d6caa"
+hash = "eac593b595350ad351d4f90a7727e048591d12c95aa118d0b0f605721812d154"
 
 [[files]]
 file = "config/cull-less-leaves.toml"
-hash = "338da294aef3676c893b796487083d24204cbb83e66ebd6dbdc3fd6e7f090dd3"
+hash = "15fe1fba8cd635af0d99640e565d70bd15c99f67479619f497d9d26815afe0d4"
 
 [[files]]
 file = "config/customloadingscreen_general_.properties"
@@ -174,7 +174,7 @@ hash = "9d028f0eaf92fb26137b7b4388753250f29e3007f4bdec310dcbdcb377a893f9"
 
 [[files]]
 file = "config/custommachinery.toml"
-hash = "d447d2769ab75866cda7fd9cb7131bf3ab43134e25530423d0752d07f6c5889c"
+hash = "77773207bc630f83b9cd6b9020c3dc2498eb84da39e0999f1fea4097c56f5a71"
 
 [[files]]
 file = "config/debugify-descriptions.json"
@@ -182,15 +182,15 @@ hash = "981f18c0cffb0ab5894724985f1de7e6b36435677ae8ae82497644e6cc099ba3"
 
 [[files]]
 file = "config/debugify.json"
-hash = "39abdafbddef1f987ab62faf2dc5960a619d46121b4b51e5f89e64edcff51dd5"
+hash = "5d4b8303b19b4b2e49e66dbabb236c5ebdf0d5c5ecb6a837416d821e6318371d"
 
 [[files]]
 file = "config/doodads.toml"
-hash = "ec9122c7f5f614ba42b78ffdd3b134cd91813b820ea500c7f7c36abef120dd19"
+hash = "378204bfe4de8b9bf7abcfc12ddd5e423f49b1505e1c3c13c3e159e6f15ef6d7"
 
 [[files]]
 file = "config/drippyloadingscreen/config.cfg"
-hash = "b73c8d8a4d0a39a02eea93ce6542beb7f8c3ef61b6f788030f9c83e31968e03a"
+hash = "1cc23e2f7170517c4e51584a836f7eadcba1760139e43504447df4da287428fe"
 
 [[files]]
 file = "config/drippyloadingscreen/customization/createastral.dllayout"
@@ -198,11 +198,11 @@ hash = "485f45349c087534cc728977034931a33d1469edae85821cdb2142a1e5b4c245"
 
 [[files]]
 file = "config/drippyloadingscreen/locals/en_us.local"
-hash = "09108361eb5ab1be4b0387b8f31d3b2af3be151c048b78d75e54ca451459db04"
+hash = "8b84bc0494845e087776708a55ccb475967142f135f8215041dadefc1c0d3abe"
 
 [[files]]
 file = "config/dustrial_decor.json"
-hash = "03b3db2e605956f190f25cf43e414cc322077789713688cb2b41d20b0af95a4d"
+hash = "153d7ec4efbff9f8181888d2fa761cfdc88c5321970f424091786eeb40b469c0"
 
 [[files]]
 file = "config/enchant_giver/config.json"
@@ -210,27 +210,27 @@ hash = "7682c42f751b0a1c7ea4b9b939eb1ecbdcd637fd3b3f308ff83be4fcb3f9b6ca"
 
 [[files]]
 file = "config/enchant_giver/enchants.json"
-hash = "6e987bf704a6c6716919984d08984f22bad4a31caec9e3f78159f9a54ca0f37b"
+hash = "e361d5a113b1c6400cff76a440a6f6f80e9850c77a74a06a3c21878a769d4c12"
 
 [[files]]
 file = "config/enchant_giver/example.yaml"
-hash = "e267c7612c2517b0e71c0c956b69d380615f09b53c2855b46242933c5c1357bf"
+hash = "0bf28e10efe214ac8d2d4cbac000183065319c87fc5159ff52a6ff1c2c2f68fa"
 
 [[files]]
 file = "config/entity_texture_features.json"
-hash = "645998dded95554f412669a5350b576195ee350842a1a5f67e6c7eb446397fe6"
+hash = "f021b8c5f2fd91a528eea78032ae5402c4c0c9c66f0b2bba0675204c047e8a12"
 
 [[files]]
 file = "config/entityculling.json"
-hash = "0c78e42bc9ee8629e05830c89b882382dfa24c772c9b5a16d91225e1c63b11ad"
+hash = "1cceb8c21c55f90bc8c18962f23409bff3817dd0ad27bb0721da125117655107"
 
 [[files]]
 file = "config/environmentalcreepers.json"
-hash = "583a09ecbde56522fd059ebdb5cf16a672a2a097a3b72404f99adbcdf3a4f0b9"
+hash = "4ee022b2d1f457acb8e03317405688249f9c85f569f3242f0589dbc6a55568ed"
 
 [[files]]
 file = "config/expanded_trident_enchanting.json"
-hash = "3d6ba6a3134c2eefc9dce5961a601a8164ff0327ec09e04b677074c373f25f83"
+hash = "7ac9623dee0e5068169662aa8cd2f19e34d3e91beb59591c2292271a560d6864"
 
 [[files]]
 file = "config/extended_drawers/client.properties"
@@ -246,7 +246,7 @@ hash = "b8350863f3a7b08cfc2953f902a4e5419e72c7780e9dfb93810f7909415e7f34"
 
 [[files]]
 file = "config/fallingleaves.json"
-hash = "2a013a43c19de688bb31a30d29b8b51554037686000c2377dc8f0fa457b2931a"
+hash = "f4165a898af4e1e798e9c11565db84a1310251e4d7d598155de19a4e47da2ddc"
 
 [[files]]
 file = "config/fancymenu/assets/accessibility.png"
@@ -498,7 +498,7 @@ hash = "bd0616dbd61e601519cb98f4394f7dbcdf0f68dcae0a747f11c084ccc7af0130"
 
 [[files]]
 file = "config/farmersdelight.json"
-hash = "b2606eb3d93a91367310e2f36955c7b9d6436ebbca757d88ee4d660b3dd217e3"
+hash = "f6066e1cff489c142e9f269afb968e48f17ce1d5ecd2366149b53258ad4f7c12"
 
 [[files]]
 file = "config/fastload.properties"
@@ -510,23 +510,23 @@ hash = "647c97bf8ba08a082324b85ed87ae43356109953b4140fe57847cf7b97448ecd"
 
 [[files]]
 file = "config/fixmyspawnr.toml"
-hash = "ec576a828535af896381f224c23dba80de283f5ffee79c866e87edfd8edc0e07"
+hash = "19d1487f5156fc536cf3ded5996a7f7fa99204158ab4cb082d1d4dd3eeb0bd32"
 
 [[files]]
 file = "config/flywheel.json"
-hash = "2672a64e4b68c9dbd5ef35e592df846103e6cc15f9f042c2c5280116011a9c1b"
+hash = "2242eabb9a79367c0c90f28b104823ab1edc3d20cbdcceffe15fc765d03c19f0"
 
 [[files]]
 file = "config/forcecloseloadingscreen.json"
-hash = "1e822abbeacb632b8614ab25af8b331328adaecdf8df48e5344a10ed11b521c8"
+hash = "1701be8f939969e216f00df8f78dbce330890e22d62f0744608a4d1db5528bd9"
 
 [[files]]
 file = "config/fpsreducer.json"
-hash = "94860f1433e6124b52ba84b46ffac245f839fbd467202ba844cdf072534ac723"
+hash = "a4e2448f86983bbe7a93db51d8b47325c76a6ce9577c2dc1dcc041b742c41ef0"
 
 [[files]]
 file = "config/ftbbackups2.json"
-hash = "02bac0460fb466b71e4b338b150ebd9909c0419c30cad80e73289390e14bbd1b"
+hash = "2e9342ab877b040ba2858f7d119eb9aa7189e91cced22615d825c36cfc2f5977"
 
 [[files]]
 file = "config/ftbquests/chapter_groups.snbt"
@@ -538,15 +538,15 @@ hash = "041467e81248a452607485b53e971ee42b8816539fa140ae8f54ef2226653aa2"
 
 [[files]]
 file = "config/ftbquests/quests/chapter_groups.snbt"
-hash = "e57d8311aec9f524911ed1313cabf138bb7fa5a2d3ba985a00a2a267ff35ef78"
+hash = "739539b4146abfddb28d18027abc040e62af3634552c3c8092d021545f0c08fe"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/6.snbt"
-hash = "b66952c50a70fc3e44f866bd1e83e4fde750c01b84f9c6be603b749fa5c20c04"
+hash = "644e3849afa423e8e23444fd4a7c70d2c1ed83b222b34aea9a52816fba66bcf9"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/6_raow.snbt"
-hash = "dd32b781e8fc9953fc7511d931d1b8ac37166f06aad9a940f9f18ab45f0bd208"
+hash = "f2e59b2bd0cf452abd7b1392167dd53b8f3f1ecb3388ba73b3e6d7144664e90e"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/assorted_goals.snbt"
@@ -558,7 +558,7 @@ hash = "210b4f41c1d2bb7952aabe1b69f9152c9de1fd0683498283e1287dbf0fe1b8d9"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/astral_storage.snbt"
-hash = "8e3bf883dc7f1bea6d707f05e76fabe98c74c07b4b8c845fe1e1275ec98b7c15"
+hash = "6efbd16869a065a7229f57b8bbdee11300b146f0a0954ecf34ce3852884bfe41"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/chapter_2.snbt"
@@ -566,19 +566,19 @@ hash = "94dcc839e2ce315f460796cacd7b8c59dd14e0fcd35c6082961bcdaf6c46655b"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/chapter_25_the_automation_matrix.snbt"
-hash = "b743a03941ad0f0544a1a7cb6adc5871c5dd00bcaef3e262d5fc8b9d8506b3cd"
+hash = "dd0e67484e67336b26ef10a667f87e75486c06811241503ec6c5f13ccefe592f"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/chapter_3.snbt"
-hash = "84701f880d49319cdff203d6ae20a5fff66871cfb703fa705240954b22087e98"
+hash = "8176247997195b1d5057d70f69d39145edbdc9b8c5a89517f09ed679711f9cf4"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/chapter_4.snbt"
-hash = "40081d8e5a67cc304824421d0c049defebb4cde0bb4fa728827f7487a4e83256"
+hash = "871fdb3b29b1624f6a06c3dd0dcc7232a58874c26f92e74307bb4928872f3f1a"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/chapter_5.snbt"
-hash = "3886f82a5581c2db90c4292a9579441de46272be772a8d27d84bab9c6f41f156"
+hash = "9dbb2046493910c3cebcdc8308c95e58946110fec2f60f46b45cb18fffddcac2"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/read_the_questbook.snbt"
@@ -586,7 +586,7 @@ hash = "f62f89c44e907735dc3df42e64169fc8d4437ec8ba0bc3beca3bb270b49fa252"
 
 [[files]]
 file = "config/ftbquests/quests/chapters/the_trophy_room.snbt"
-hash = "fb39bcf6dc2c7122799eea7edcea4c98d34d8462bfbcbb417836bc2e433262e0"
+hash = "a0653e62a5a6c20028563329ca3c518844c5d5b0baf9cce0f26c5a56fe5a96a5"
 
 [[files]]
 file = "config/ftbquests/quests/data.snbt"
@@ -606,7 +606,7 @@ hash = "96807f6f363b01cd58ea1738d3aaa4ef9cb806b7e4e58e550df0b86493134468"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_3.snbt"
-hash = "ae734f80f6c7f4acc5e5b8be1dbcecbec06c3c948b091742471809f782d61758"
+hash = "9cc1cf327cc890c031a2b90968de96c3917c6b4b03c3bfb1ab5181ee42a72c4d"
 
 [[files]]
 file = "config/ftbquests/quests/reward_tables/chapter_35.snbt"
@@ -626,11 +626,11 @@ hash = "92f7175fd337d1e07141dec25f764af9f15568c598e214041a11bf19fb974a50"
 
 [[files]]
 file = "config/gearreborn.json5"
-hash = "0e844f78a1aa76c25f98070e7fc70618b8493c3bc60e1fa0a77b49d63af60da1"
+hash = "21948792051300ccd544dc4a65be0c8547641bb4a31188d51d925440c5606257"
 
 [[files]]
 file = "config/getoffmylawn.json"
-hash = "c25a82169c3fc4b0282ec3c36c3527d08fd213a5f904b26b31a2a7d0f38d15fd"
+hash = "ce1c739dcf20cf4d8ca3e53ff6ee6541d92ff46a16e98a91d4c6042b5bf0ba62"
 
 [[files]]
 file = "config/global_data_and_resourcepacks.toml"
@@ -642,19 +642,19 @@ hash = "c877584c6ef81f6c454a145b31ec40d1e5c4a437e27a48d36456f7e3b6df26a6"
 
 [[files]]
 file = "config/hwg.json"
-hash = "447133a49745694554813adeab27f89314833564d90c04a3b19e9172c4f80431"
+hash = "23afad5074a341fc742d1b70c90772b138b27c4f6fa90ab87c28d5c3df6a7e5e"
 
 [[files]]
 file = "config/identity.json5"
-hash = "25b9b45e7cc4584027be2e68b6ad18f2d9952186050ba84889edcf82367a0989"
+hash = "9248ac2f48d721c46b0f583d8c02d2edaa36852a2e84313717a961a3970fe7e5"
 
 [[files]]
 file = "config/idwtialsimmoedm.json"
-hash = "b3321141597844bde10ec1edf06e9d77a5083da9410639c178a49c306cbed40a"
+hash = "9ac9229a041c078a6e9c37bd1d6f9f5eae5cc604f53be93c88c22c56b4eb8542"
 
 [[files]]
 file = "config/immersive_aircraft.json"
-hash = "9d26d584e55f2514c54a131d6dd1aac8326cd94dbdd3a3729cbcbd00e1b3c9f1"
+hash = "5f0e3719b00bcd7557290c05aff005a4a18846f25d6aa8df37f152a0d6b5f3cc"
 
 [[files]]
 file = "config/indium-renderer.properties"
@@ -670,31 +670,31 @@ hash = "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
 
 [[files]]
 file = "config/inventoryprofilesnext/integrationHints/exampleIntegrationHints.json"
-hash = "ca413dea02cce69c69dccdc525fb0ec013236876eff2d142772c68db3d772d3a"
+hash = "f0c885470e7ecdbed0a9fdf7cf584e84d8dfc200ca38a44e9bfaa773ee8800e2"
 
 [[files]]
 file = "config/inventoryprofilesnext/integrationHints/player-defined.json"
-hash = "a8c4db80b9012f91691e07246ecf0aa48756194bb0b0c845447eba8e5eb6ac1b"
+hash = "db4a3733dec056d3efe71885fa6344f703a887105da3e94a9da5d4966bff70c8"
 
 [[files]]
 file = "config/inventoryprofilesnext/inventoryprofiles.json"
-hash = "3963c7ae962141f69866f0aa762081e4597c8b19e59352b734a7a52dd6f98339"
+hash = "530e59bf186b1022fe8c7e00b2223a347f825b0094a1e6abfb4219f64fa7e1db"
 
 [[files]]
 file = "config/invmove.json"
-hash = "f07273670fb6fbd2012d7a63e2453826f00e42dd82efb3ea82a4d81894f3b410"
+hash = "cc5251e1b3ba19e8d085c3af2ef80d1024e2f76b055588662df0012e8c5872a0"
 
 [[files]]
 file = "config/jade/jade.json"
-hash = "9890d61c1b8651cfa8f1edc7aceb7302e73c1a2c7487752077025748a3c0d8c0"
+hash = "2987b4bc69561507641e6f80e08c541de4ced3d25680f083af03ffc92d490711"
 
 [[files]]
 file = "config/jade/plugins.json"
-hash = "7b310af89d2d4d9dbe8dd7b08ab1c1c072b5fe0636e99b83e9183a7c90bd38ec"
+hash = "bc0a7d4b15f005197b8e5f94f7a5fcea8fecbebc4a3bb15c817f13d8c572c925"
 
 [[files]]
 file = "config/jade/usernamecache.json"
-hash = "585124d7f3e9886890f45f0c32ed46e9acdd2e6dd98b972811148d9b2ec0be71"
+hash = "71cd889fb7aa0533a96eef5179f364010c37264e57104f4dd07c6b9589b26e23"
 
 [[files]]
 file = "config/jsonem.properties"
@@ -702,23 +702,23 @@ hash = "e71c4f9228082c5334bde5a764c20977993a641e8eb28f4189df4939caf1f8d1"
 
 [[files]]
 file = "config/keymap.json"
-hash = "b5cd3141401cbfa2c7a6885b3c3476e88b5959579fe50e6a219cbc2d289886a6"
+hash = "aef7b12df59c613f1eaf486ede36b948cdeca1357b96ff2b8a25ab3c06ba4b4e"
 
 [[files]]
 file = "config/konkrete/locals/de_de.local"
-hash = "79a34cfd15c2d9c06498dc221be79279507d9b57666cd44f8d2c2cf95d3582ef"
+hash = "9cf580b889772edd244b5ea7cf42439bbae7bf2834bd759b819052d8f147e5fd"
 
 [[files]]
 file = "config/konkrete/locals/en_us.local"
-hash = "fdf1864fd049b3f1b9af1f8db6c5125a627be7d06a451c778da3329843d3c39a"
+hash = "7e47765e16c56722a24ff7343191913b00ef2c8493b7172c641d61c8b583b0d4"
 
 [[files]]
 file = "config/konkrete/locals/pl_pl.local"
-hash = "d38a7776e362e4de6082078d803c1c9358d9d40526edfe4bdfd29c552aef76d8"
+hash = "29e0e9f6e599f34ce351814cd4bbfa1bbea884122aff4b5072bff105d94f6862"
 
 [[files]]
 file = "config/konkrete/locals/pt_br.local"
-hash = "dca55a2792451b31424cd5c24037141ec57cdca51955d062dd908fa9ca6a3e9c"
+hash = "d53707bca34d3d11ef17642d819a4444550bf5d1c3557d0d8c19c5d47e46bbc4"
 
 [[files]]
 file = "config/lambdynlights.toml"
@@ -730,15 +730,15 @@ hash = "013ef037f36a275fbdb17fb81eda29952afb5f590d984cb7093c0fbc2b18a366"
 
 [[files]]
 file = "config/libgui.json5"
-hash = "6814fc05aa8d6664712b056cfd6cb51cb4bafeabe3f274b9cf5e19e27eff406d"
+hash = "2a7280f834ac47d463d9f3491da6b5d9aa0eedc0e8e3854ddecc9c35535c1d18"
 
 [[files]]
 file = "config/limitedchunks.json"
-hash = "2c31744153b3361c8f9ccb73e7746a76a943af3a847c5e280abb9f75ca71b848"
+hash = "49abc21f0fe57bdf691027e512de66f3dfa2a253632bf7f4ce0478fa44eb90d3"
 
 [[files]]
 file = "config/lithium.properties"
-hash = "4f5890cb55b35047fdb433efa30060827aa9415e0850220f85b2c8ad663d6722"
+hash = "b099d76bcdc3a4ef7949b91189f05470d3301fc66f8559b9dc159c3c2791509a"
 
 [[files]]
 file = "config/liukrast3dskins.json"
@@ -746,11 +746,11 @@ hash = "c25d09dca430c65f1ec3bd1c6174879a5c2ee77dec4b2f1ee0d1ba97e0c2e489"
 
 [[files]]
 file = "config/loadmyresources/config.cfg"
-hash = "549a26b9b8ab9e2df0a427732a737c5dbcdb0b6790ad7ea9a387dea789abcad5"
+hash = "d7a9b2712d17945f21a3a938bdb49cc5448e3aa53b2c084670163fa8eb2f297c"
 
 [[files]]
 file = "config/malilib.json"
-hash = "a4976d6a5206a02939ee0ad164b06eb0bd0530dc5ffff42c9372327d1f5e5b64"
+hash = "3bc7ef7d1653cfa6e29d31d5ae6b72e2d4e2d55fad73556608e548163369e4e4"
 
 [[files]]
 file = "config/mantle-client.toml"
@@ -758,15 +758,15 @@ hash = "e9d5cd56ff937a246da15d01f8fd246378f52d0860978d2a907d95abfb605b42"
 
 [[files]]
 file = "config/mcdw/mcdw_enchantment_settings_config.json5"
-hash = "910de534ff85e571560ebce631eb1454ae18bb710dbef182e1669e44d8dc373a"
+hash = "da9a8004b5a4176e8cdf025b47c77d1df5d7ec66afa0442bdf1295f0bfd26dad"
 
 [[files]]
 file = "config/mcdw/mcdw_enchantments_config.json5"
-hash = "e6cc119115623e3cfe870295dfe9fbc26318eea8bff36f7129c9a532413d9e77"
+hash = "715cefae56fade5f77912321e6e2d4925742d69fe8af393ff9dfacfddb67beb8"
 
 [[files]]
 file = "config/mcdw/mcdw_items_registry.json5"
-hash = "3c96dfa196f16a9cbb6ab3adbb299a93198ab545ccf17a5a5560238896579f10"
+hash = "6cbbde4259b7edf4498136a1fc9624b30b600024b2ec13562ca76805f3fe867f"
 
 [[files]]
 file = "config/mcdw/mcdw_loot_config.json5"
@@ -774,23 +774,23 @@ hash = "5a8d8dc085dcc8e29c17c212702601b40a31a66f824538f1e863c4e9ca8c0957"
 
 [[files]]
 file = "config/mcdw/mcdw_stats_config.json5"
-hash = "5de0dbcf4fe30911c37906bba39cd575310e475dfbf3334215ed55470d5e440e"
+hash = "0f03e6d31733bd05d4d0f08f8c6ae8a83e5dfd010b159307f255bab6463442ca"
 
 [[files]]
 file = "config/midnightlib.json"
-hash = "6b52769b3358f87b591871a4444f3cef8124a9dced0da1755f18db2f47adf4f3"
+hash = "79b03480075019add02a296f14c5e2a2c6910158a83c311b3e02e4ac40176ba8"
 
 [[files]]
 file = "config/modmenu.json"
-hash = "768cfcdddc8d3b7fab711e8af0ff50abbb328030358c672e77a1e2879bbd7029"
+hash = "e042ae5ab6c2ee3c416ed455a79fc32451fa2e4718dea2d54b90dba1a6ba3ebf"
 
 [[files]]
 file = "config/naturalist.json"
-hash = "3176b1f126168a4ebd7692cd40334630552884a1c4e727449d61a057ae100c4f"
+hash = "26b45fcf0019b91eddb7947e3e65dda7a416c220cd6fcdd42ed3739c8d796e9c"
 
 [[files]]
 file = "config/nbttooltip.json"
-hash = "48ae858a3bbbc6d6ae761de1abd17c2bebe75b3bde9738569085aad0fde7caf6"
+hash = "777088cb8481464126b014365d793f765f1c54080f2a332ceeb5241aa466e697"
 
 [[files]]
 file = "config/noindium.json"
@@ -798,7 +798,7 @@ hash = "9e06c06b91c2efa83e972df6f80e4ec0ffdf777dbf0e420a658c8fd7aa63dbed"
 
 [[files]]
 file = "config/numeralping.json"
-hash = "c316060546fec42755335e9b57a5a12073f245ee8ac3ce87b08001f15848c608"
+hash = "3eae48af816e347a1b20e5d55e0f0ded1e23907d0c01623ea2af18d392e3b2f4"
 
 [[files]]
 file = "config/packages-client.cfg"
@@ -810,7 +810,7 @@ hash = "22618930c0faa0aa2e152ac7874e87cfe483de2a3c8f578c447b47eaeb6c4a33"
 
 [[files]]
 file = "config/packed-inventory.json"
-hash = "8e9929da9fb98f3b346947b7c3f21654cee6226024655bb203e1da366b34b60f"
+hash = "015f747e2b641deb32e5edb63cefccb4a0568f5ce8981873409e5bbdc1eb05ec"
 
 [[files]]
 file = "config/pal.properties"
@@ -818,51 +818,51 @@ hash = "a5aae5f854cce001eb17d11672dd09b2ab3a023d213d02fa330a97ac2efb69e9"
 
 [[files]]
 file = "config/patchouli.json5"
-hash = "92dc9dadb34707462bf5574bb597430b3b34c65eccf964a31680d402f0431ccf"
+hash = "b951e75e040e81d67e8e0fe1329c5df0ca5d38fdafbc50f58e0899a92493b387"
 
 [[files]]
 file = "config/pfm.json"
-hash = "5b9866fad4021a10f785b05f0c0687b341cde0e0878280e7dd4ffc9314b89604"
+hash = "af18f5edea3086031ccd4129f33c4c9880cd502e2598f16ae62b31f4815e3373"
 
 [[files]]
 file = "config/ping-wheel.json"
-hash = "32e811f96a0b09354e2cf42c3a6bc98f2989183c40e3334f68f591390d5591fe"
+hash = "edfc3ac4f3f56ef340d328370299972120e9e7ac0b71a66c1272985abe3ed425"
 
 [[files]]
 file = "config/polymer/client.json"
-hash = "0ffaea7bbc04b16ad2c776d638973f0ad75d66c402579f64c006a514312312d7"
+hash = "f4a1febaadfde03ca21228b4e5f4119e17d49433c218baaf834a19dccdba7d57"
 
 [[files]]
 file = "config/polymer/server.json"
-hash = "2eb32742860a0eeb4d227c64dbfb6cf1eac7905b53f14ba4861a53ba80407753"
+hash = "d4963a41d3960071458796a3193f15e5a508d5c539afbd84a228ebd3e366032f"
 
 [[files]]
 file = "config/probablychests.toml"
-hash = "b3024aabeb43786bc6d1ee6309684db7c99445bcd39101795273b6aeb0275610"
+hash = "8c517967515978fcc22e4ea2ba6851dc1ab360a367cd76da185b3ea7d9c44315"
 
 [[files]]
 file = "config/projectiledamage.json"
-hash = "8c3eb2a4150a8575e522c02acbdd88f7d6a387e9caf07da4683d6df4b4abac29"
+hash = "16aed0c9d8b6addb4c5fa34c93ddd581b76d2879489a6e2e32e574ad2a7ef5fd"
 
 [[files]]
 file = "config/puzzle.json"
-hash = "2c954434ed389bc48dae89476b8f5d464b0d606aa74d2252e921d383d4df6bd2"
+hash = "5624f13bb467d82cc6d203b771f775fd99ce1c2ff5471449f1ae38956068d570"
 
 [[files]]
 file = "config/quarrymod/machines.json"
-hash = "8eb8897e224f31df158c9be94a8f2cb15c0eff8b95cd6c32f78a6b620682ff99"
+hash = "6b404ba769d72918e936a25521caab42da84435198810b66f393b6b3e6e25867"
 
 [[files]]
 file = "config/quickconnectbutton.json5"
-hash = "f48ef9718fb9afbe1a79e383692573a468c15c4fe5266ba9e8fdf5c079ab8cef"
+hash = "9e013506ba97d1906958b06767add690585387078e64b3272d0c9e2e6ee84f5b"
 
 [[files]]
 file = "config/reborncore/misc.json"
-hash = "820f40848e6daeb5d9c1998f04082cc419865c84b968cbdcc6c2e39798bd1f71"
+hash = "7579a55cae9da9d5f3fb19a0eed45308e164bb209c3e1603f6982b36a22cd0ae"
 
 [[files]]
 file = "config/reinfcore.json"
-hash = "8741b4717e0703f309e846ff34e79e59658634989808c44387c69fdfa6326453"
+hash = "65bb8ab33310077b8d10a69b82f88f00e8430dd922d79b1174af51cc5593904e"
 
 [[files]]
 file = "config/rrp.properties"
@@ -870,7 +870,7 @@ hash = "0cb553542d801655ca8993fd0a3b0808fccd3712f2c9fa029be0fef49a9ffabd"
 
 [[files]]
 file = "config/screencopy.toml"
-hash = "b55cac5a91b83d72d19eb97fff81556b9a438f76e7a98b58497a44869cae22fe"
+hash = "e053a93f7e325cf849568e5dcea67c2eeabccd8bd1acd573ef828f28e46d2fd8"
 
 [[files]]
 file = "config/servercore.toml"
@@ -878,7 +878,7 @@ hash = "1050f11f35764b02415b48adbd8d05c92c0f79aef0c0eab2ffddc68c0cdba68b"
 
 [[files]]
 file = "config/sidebar_buttons.json"
-hash = "d12bcdd59a36b21e0aafaab84c9ef6749d8aeab3e28e814571625a58a5db3a87"
+hash = "77682936c4c2e716776753d6fdfaa05a9e1eb95d007164195de940992c0ab709"
 
 [[files]]
 file = "config/simple-rpc/server-entries.toml"
@@ -890,27 +890,27 @@ hash = "ec9b5fc446fc95e735a96d5c45b866d447c47978bdfa1408d416661a67c9a25f"
 
 [[files]]
 file = "config/simplerharvest.json"
-hash = "3e8e57664e564edbbdc290dd61c32d4d44396cf5f9eafecfdc2a26dc1f7c89f8"
+hash = "cb23a1f3eda71f26dd5129a53f03ce66b4931f31eeb84a06fe3b5105dcf8b827"
 
 [[files]]
 file = "config/skinlayers.json"
-hash = "9d270411f3b126d4ebd298e5b9da1056fa0f1b5f8a5283ccad1cedb71039f202"
+hash = "6a8d5eb950a91e673307173719c438acf22726e24a4cb9acd06d3ed8ccb37b62"
 
 [[files]]
 file = "config/smoothboot.json"
-hash = "8e25c7d1b862b4f7106940f9f9df89210c6782b132d024bf6c25eabfeecb685a"
+hash = "eeb5e1f7517eb78af5ad4e4008f0967a9ac385191b9496620a8e0fb6da0b9378"
 
 [[files]]
 file = "config/smoothchunk.json"
-hash = "228d16ac3ebb3efe67596f25498f97eb4a626ac108bdc0deb2ddf0bb5c32cde9"
+hash = "0507552c037fdabbc894875eb74cec6d8f12fcf60c8e2ff92f407103230673d5"
 
 [[files]]
 file = "config/snifferconfig.properties"
-hash = "1bb1975c963b34b8dcfab7d22226158d7fb35aac6008a40d66e2423172d19868"
+hash = "a8910270021d41bf623623fb410417534042029ff906b97ca426be918bf09805"
 
 [[files]]
 file = "config/starterkit-fabric.json5"
-hash = "a59673859bc44eb8d7823e2892f8849b27079d1df9643ae82b212c7db96668d9"
+hash = "302847b94263a82579c985c330fc8398d9461f35e1ca75628b805b3a1e89fc84"
 
 [[files]]
 file = "config/starterkit/starterkit.txt"
@@ -918,11 +918,11 @@ hash = "be1fe3556b2833c58147560e85f504446d4e7dc22cc67c19b523d7e83414babb"
 
 [[files]]
 file = "config/structures_compass.json"
-hash = "2c7598e2bdfd0a4287ede2b71d36e2b19e6b73e0fe80fd5d53e52b2984431a47"
+hash = "69a42252aa39b08457487d6326a7d9992a972dcf604be3b65ab457f784e86ab6"
 
 [[files]]
 file = "config/suggestion-tweaker.json5"
-hash = "9fcf7c8f6e9b7a5678796ec5be38209a7157d92f1cbe247cf84ae94000327927"
+hash = "95a653a5edbff246ac6d724a40786c91de418b59d7c853ec8d9f279f76f84680"
 
 [[files]]
 file = "config/tconstruct-client.toml"
@@ -938,7 +938,7 @@ hash = "5d3080c37392fed12012745cd310b63da09af575d3343086a6d81b95d7f6aa61"
 
 [[files]]
 file = "config/techreborn/items.json"
-hash = "a0c5f14ef5df4608779ab368154bb8dbc64a03a3b145e3a5853b23708206d217"
+hash = "23bf8c2d9333715eef8485252377836a6e8658872d75591deade5d9f286dd322"
 
 [[files]]
 file = "config/techreborn/machines.json"
@@ -946,11 +946,11 @@ hash = "eebcbc795601e339fbed35622e4926c24cedfd21bab553883b20c13636dbb626"
 
 [[files]]
 file = "config/techreborn/misc.json"
-hash = "7bae659c5fba632e53356eb7b75e089676d1976f50c756852b638a1b9e3d8ead"
+hash = "d5f0c026186b1a4b2019227927c9128255c80cf43fafe40b9278da9067c1ebcf"
 
 [[files]]
 file = "config/techreborn/world.json"
-hash = "45ebff7565b92c147fb9ba2a8473259a961fed3a323ba277815bc521de10e66b"
+hash = "5d239377c49bbb314df81c7f20ca773d66878ee48c11a995ed8e47b86d37a2a8"
 
 [[files]]
 file = "config/terrablender.toml"
@@ -958,11 +958,11 @@ hash = "11ef4c2666fa094b456310710c2b5cb8babbd71982d4d187c9a80ad4011d8014"
 
 [[files]]
 file = "config/towns_and_towers/structure_enable_or_disable.json5"
-hash = "18b5542e887ad26b3194392bd8acbbf7cb229b4dadab530d12eccef7b2e71629"
+hash = "a8419304f07c7dc50ac8b0df33b49d7d1197e7c22e378f44793c87432d796ee0"
 
 [[files]]
 file = "config/towns_and_towers/structure_rarity.json5"
-hash = "52cf62798fcdeb73fb5a4ec6fe6013e9ba8e23221516f8f83b7204fcf159ed07"
+hash = "bf6a59b6619e082b22479a0d88776e4a9ae595346e8ee1c4ce757714e56fcd16"
 
 [[files]]
 file = "config/travelersbackpack.json5"
@@ -970,7 +970,7 @@ hash = "886506c1d1264d21e82fd245d7b6b60cff9d8dcee6d8ae1f63325f610afc75c2"
 
 [[files]]
 file = "config/utilities.json"
-hash = "a14e8e53afad1bd09ba0489034d4b103f9cf74ba41d0cff9632d044387dc038c"
+hash = "49613a78e02a59736f78530e1520cf894cade8c695c542817d169d54b2183d1c"
 
 [[files]]
 file = "config/vmp.properties"
@@ -978,35 +978,35 @@ hash = "86bed33ffdf57a331aa8a7ead511314a727482cd94e465fda4abb9c8acb068ba"
 
 [[files]]
 file = "config/waila/blacklist.json"
-hash = "640800920130d084dec5a3a7f52c10e18d72ed7faca522b5bcb6bb46d0dcae9b"
+hash = "209a03c71001076d29c04ce9f48e498ae36e01d18794e42363feb5a7aec79116"
 
 [[files]]
 file = "config/waila/megane.json"
-hash = "cf94b66ca41f2b68db8ac4d7d2836e2ac0736e4675a45d7424a1ce63ed44c08b"
+hash = "8762547113bee266c36f07065e8d63a15b5216fdaf3ba93c87d4b947c916949b"
 
 [[files]]
 file = "config/waila/megane_modules.json"
-hash = "079a16d105bc6d43598eeddc12bd73e4433f7bb2855f181e04f721cab69d58c3"
+hash = "dc36b4e798a9eea3b2ac429cd9766fa6cf67e42975356c8bfb69045ae948b1a3"
 
 [[files]]
 file = "config/waila/waila.json"
-hash = "c88deb74ad6cd02120b5ce730ad5b622b3f3d4266ccc1dc5d710a0433b4e4493"
+hash = "d81a1d769e03d7d6352d866bf18ac5b6e9ee4f86f8b9ef8ad717f94e8ae3161c"
 
 [[files]]
 file = "config/waila/waila_plugins.json"
-hash = "3ed5fda2efcb8a62518e443377dc5a9f9013e107559a873288f4978074c20a63"
+hash = "77cc4e97f687e0c43a9cd01b8892d09b5c0ca97661fed6241dd07a0b8996f6cf"
 
 [[files]]
 file = "config/worldedit/worldedit.properties"
-hash = "de26da12b6540bdafcacca898a85c73d54b836d8803085b44481a5f897ed4c09"
+hash = "889d33e618af18e8011b615af99f878746dd38194a36d2e73535683abcf1852c"
 
 [[files]]
 file = "config/worldeditcui.config.json"
-hash = "9221a1c42d4d25101c09ff8980ea8babda5d2d0ed2471f0d2b5ac76bc2c9ea10"
+hash = "15f61c8e5daaa2a5a73efbca00c5927ea15ea974323a8a22c242557f4f286a6f"
 
 [[files]]
 file = "config/yigd.toml"
-hash = "697103a51b2201adc12d3dc42cc5a224feb0c3c456fca40f6a2e453fd7180245"
+hash = "1876fd45256526d1f8971ddd101741ee2a02c34d36ed42324f82e47f55b39c20"
 
 [[files]]
 file = "config/yttr.css"
@@ -1050,7 +1050,11 @@ hash = "2b2ea57b59fe7389ea6f84b7b5f1fc712da26e784a41aca8691945743c2ec7f9"
 
 [[files]]
 file = "defaultconfigs/ftbchunks-world.snbt"
-hash = "205655ef2cdfaafba16d41f767a1f2b8afb6e632ca06eea87343c5b61ec75e5f"
+hash = "8bdf892e2f55ed81d62f2b263e2d01ef0bc87492e47beb90dc211b5629c5cd82"
+
+[[files]]
+file = "dummy.txt"
+hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 [[files]]
 file = "fancymenustuff/btn1.png"
@@ -1067,6 +1071,10 @@ hash = "8d7ce46d8038ef37e526605538913133dba45657144c228080d1a8ba1e55436d"
 [[files]]
 file = "global_packs/required_data/AstralRails/data/ad_astra/worldgen/biome/orbit.json"
 hash = "3929a62dd2b8caacfad85750b3eb34029bebc1ea4bae1b1159f1e7a6ee1e120b"
+
+[[files]]
+file = "global_packs/required_data/AstralRails/data/astralrails/loot_tables/chests/carriage.json"
+hash = "27d32d978ad1cbb3059ada9f34af1dea86f57dce0321509b18463cf4625e48f8"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/loot_tables/chests/dungeon.json"
@@ -1482,11 +1490,11 @@ hash = "81942b621f69a5ba7bee9d00c250829d3edc9028976da55438c800611eeaaa9d"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/structures/contest/overworld/carriage.nbt"
-hash = "99f22bbce30818fb6aeaaeca054748e48c4bc5effb7dc1282d61defc4da8c8d2"
+hash = "ae045bbb0a003fc9555dd82def5d981ea347a7629979cd302b2b2e871a96bef6"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/structures/contest/overworld/carriage_ruin.nbt"
-hash = "61c83685c5870cbd7f2ddcb8449e5b13808f8286845dc4fe6c9a0e4358c22648"
+hash = "5478f2e90fd75f5b86704f0509bff11b17bfa198e3290c0fefa2f559fbc3d750"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/structures/contest/overworld/fuelpumps.nbt"
@@ -2286,7 +2294,7 @@ hash = "e06688970f49a40dc474181526790466d3239e484ab7a0d18a967eac0731fbd0"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/tags/worldgen/biome/has_structure/heartstone.json"
-hash = "56a417ca177180bce71f4a182dcba789f7bd59b0b9362ef859412778fce4640d"
+hash = "6be712aeb032eb3f264963d83165599ea63a74cd51b8165857f4dae324af04a9"
 
 [[files]]
 file = "global_packs/required_data/AstralRails/data/astralrails/tags/worldgen/biome/has_structure/mars_moon_debris.json"
@@ -3382,7 +3390,7 @@ hash = "678f01057cd46a796eb0f6ef999087b724d6e67e7f1f2176d6471cb91d567c89"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/earth_orbit.json"
-hash = "3d69f321f4424c32839286561b8ef37eeb284d145e15d48e61465a36294a3350"
+hash = "e171a5536de60be119851c24d954724c3e85580dc064371d3a8180a7d1613681"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/glacio.json"
@@ -3390,7 +3398,7 @@ hash = "2f67bb2d8d4b59b477d623f91227af42fdf1a0b2e056db647f0bce320262c32e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/glacio_orbit.json"
-hash = "87b237e9b0e1dea09e68b5f3dd6c4b1472b5a432cfcbabe60c5f8b3640e07675"
+hash = "121a8491f3d9648d4968763947320e298e6a1f9a9fa89c4e16e4e1f843d7020f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/mars.json"
@@ -3398,11 +3406,11 @@ hash = "14d5d722b98cc7e8bcfd17d9a7764ac9b600b16135bfec2042230d23139791ea"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/mars_orbit.json"
-hash = "5fc6b1973368e61520b6e03b337fb9aff1d8fc5380f85257b0cad1427f1cbace"
+hash = "6b7fb53678bfc956a245b3afb97ba49439376ce19efa800524a4cf0c6eb73957"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/mercury.json"
-hash = "eaa066219db29b8e0f340d1ff65258a90479d4378d36c9a7042b6665cee68df0"
+hash = "82ecf3f8d875f2f1c5884c2aa65b23e68812d63da1ca64e56d4f355c423b82d5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/mercury_orbit.json"
@@ -3418,99 +3426,99 @@ hash = "a1194ff86dc658c29c4f16e9b644878a7c4bc131d7de1cfe82327bd79f2f705a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/moon_orbit.json"
-hash = "a1194ff86dc658c29c4f16e9b644878a7c4bc131d7de1cfe82327bd79f2f705a"
+hash = "d88522b2aa07afe46bee0fa3b603964c5248a901969f07e751fd88b388f7f53c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/venus.json"
-hash = "91248c5d2cc43d2ad405d123255c557b6674700142a98f6acf34f13e09f573d6"
+hash = "f16302a239cb1437da788a64cafaa284a0b0505064b8903f8aeaa3acad4d3a48"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension/venus_orbit.json"
-hash = "a9f43ca0c25669cee2b004524b2f5de7042cab0dd9f943a570f49fd83bcb8bff"
+hash = "17f2590d19d0a6ee972318fdeb982815616d0bcc387c5c9a40913202800e4d74"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/earth_orbit.json"
-hash = "fecba95b9a0a1316f81d9763711f92a2ad1b757813e4df39fa554f7b881803d3"
+hash = "447179d9e97c81a57fc2788b16d01ded40ada38e6f3e52434633ad0cf46a7021"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/glacio.json"
-hash = "4de62bff334d36d9ec7765991415ed1e2d02ef58229bc50f0a08ed3733d18cca"
+hash = "49452515176da217109e4c3d7999d333294bd068989bf381812babed1c4a55fb"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/glacio_orbit.json"
-hash = "0237927b7695027fb875cde7071f64098731ae1057aaf3f1d2155a983e3a66ee"
+hash = "87b9f7e7ceaffaa96e08ab72ba38141272b85ab15d26e72b00b3c52229d59919"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/mars.json"
-hash = "c059795886889a8300b8c5734a984ec03be131c7dce8888f410c0c922130dd6f"
+hash = "c2df21e57dc19820f5dbb0eb78474817e3be76901478c9b9442853054ffd4d2e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/mars_orbit.json"
-hash = "51fe810e1c4bfda6882189d4baf8c6263327f6609a4292e07c1a976c3e6a1aba"
+hash = "d53edf8e5e7bf2b4323e7b82232acb510b6a75ee12de3d65f98afda57ed99c21"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/mercury.json"
-hash = "15bdc4c153867320daac40f479da63ea4e0be32906d757537ed64919f15c8a4a"
+hash = "6663a904511e997ed0fd82dbc0313bb797f02737fc5a0b5b6c4706886f0b8ad9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/mercury_orbit.json"
-hash = "c067bd2edcb2f710251bc4c4efabc511a53d4a9f6d0a8b4c1364e34b0470e577"
+hash = "1dc069e60184e6c9eaa3cf0be5846fe8b164b4fb6a2da875b42840bb3aec825c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/moon.json"
-hash = "f940ced840ca681eaa4f489aee2c39ff4fbde4f5e75114612d522619043e86b6"
+hash = "a2dab6ecab968aab6bac2122ea89dc2d637aeec7566d3ff1322c4865ba9d65bd"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/moon_orbit.json"
-hash = "3cf1a9c3a1c2e46555fd8b9f12ca2bcf153aac4faa16baaef9c48cc7fa92b9f3"
+hash = "9a29b154c90e7db0607f541804c162992528d925c2736119058e7e0cc1bc308a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/venus.json"
-hash = "3f7d1705a5c247c02a6b3e6976cfc9260f321545eb47ee88692eb382f292e541"
+hash = "b4c9c43f61188736127099ccdd57130c8f95484cb788692c72d7e14e5cba3307"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/dimension_type/venus_orbit.json"
-hash = "074feef9a4200224053ad81d968313662fb3fa7f36a15732d96cb8f7864dc4e9"
+hash = "7079ec177c158317be72c12c25c877497f0222bf409e504995a1a0e8938f86b3"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/dungeon/moon/dungeon_chest.json"
-hash = "88d0d84c995eb226c3b7adbecb38dea5e7651b0b8ce5233decd4d3b9c16e1ad1"
+hash = "d8f1d5df4f7dca8e9ecff590ac1e678ab15e456c7a4e7aaf0dfd73b1c455553f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/dungeon/moon/large_dungeon_chest.json"
-hash = "c35c6e401d5cbb52f2683f974949c05525bfef1e8d401f730047aaba453a1316"
+hash = "1f52be29b40c0d94c1edc1e6a31eb003b892d34bf415e436451c03f3c09d7adc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/meteor/meteor.json"
-hash = "6ac0d54d665641251842604e4b2ecdafac512e2c958eaff74b4e879e4e766925"
+hash = "f45982a2019bdb8b445f428e2be8f745a2804af28b007ba32228bddfb060139b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/temple/mars/temple.json"
-hash = "fac86cbec6b5520710f8378c532734011df543ad06dd8b069f3eddc68ab6e868"
+hash = "a13ddad12b7fd61a616a9e5cf690f96ecd775d99e3d11ccc5aa2ee02ff933302"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/village/moon/blacksmith.json"
-hash = "82469f9412c6344fb33fde97c7b96a0e2155975d8023fc4e59830f4e13d3c6f5"
+hash = "ef621a2c22ce79b49fe3e6b64e848e364efe5333fdd3ec206ea08e71b7b6d080"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/chests/village/moon/house.json"
-hash = "4ea1759ee8a69f9744950751905c9919e42e2ec74a62514e647ba878adb883ee"
+hash = "cabef19b66c380965b050bc0e33073764d7d6f636ac004c4d6c39e457a2ee95e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/entities/corrupted_lunarian.json"
-hash = "26d44b81b42946cb7a286dec849d4f5f61cb0ffb9e6627b2759611b1006ba25b"
+hash = "52d4e7c9617004f7d285a50e10d381b9c7dafd2995347e1f22ebc6905da0e8d3"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/entities/martian_raptor.json"
-hash = "ec8c954596aee70ca782c8465299a341d96866d0ed861330af07024c0e82803e"
+hash = "174c11c6e0ca2cfd1c9c5731451dc2f0d3b2a107d77755b508ae4136ae8b63d7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/entities/mogler.json"
-hash = "8e89b7ec0d046101600a0f26e1aff346cf713bf15c956a28f448aa322b329295"
+hash = "23b7e045f075f324983b14752f6ad39a135bb1b11a6854abbe73fb0a1feea167"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/entities/star_crawler.json"
-hash = "c734828a220fcff2d047e1d9ce4a189736480382f458a03789b9de6fda1877ec"
+hash = "d63559415de417b6d8ddc489dbe4dfd14661e74d58456026425e8088939d3dd4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/loot_tables/entities/sulfur_creeper.json"
@@ -3518,7 +3526,7 @@ hash = "6c981c451930126d4bf1f24cc215c48458c3b236d644605615c80c6b7ade8ef7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/earth.json"
-hash = "071e0fff10dc05d65ed62129bc3ed73e41c5eea9d52c928c3ca19fff256504ff"
+hash = "27cc2b0b9ee5bf1de099cbc55d2422be36f1d6010f29cda2aefd8f1e784ec1ba"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/glacio.json"
@@ -3526,11 +3534,11 @@ hash = "6f549af126a3ae559376d86704cfe712b80bc361df3e4f1f3118c635e53cd43e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/mars.json"
-hash = "33e70b2c999690f8a5a6218e38ed10d8bd705072eafe2d8d709fdfc347f33f07"
+hash = "1e20902267986d2539b1b11da95029c0b1e372c1796aa6d190c19e37ffa5ff25"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/moon.json"
-hash = "af866669b34e1f71195ea54ed442adc59f41827642bd139bbd710772de072a6a"
+hash = "7897ddd4d4dffbe4ddbd903a8a0970f952c3839c2d534be6c09f4be6a9b363b0"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/moon_debris.json"
@@ -3538,11 +3546,11 @@ hash = "2e4f184043319036f6e4d0efd15b02d5f4b55c462b42433cc39b79a17e4b70dd"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/the_end.json"
-hash = "b9991c2e03232a0bb1f161c0312f16aea4ccac1d8dae391199963f2729232da1"
+hash = "aa7831ba1464386a8d4711984f747f31cccf40fc5c1b9936ad0e78b729f62b55"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/planet_data/planets/the_nether.json"
-hash = "93e94cfba70bf74c20610aad3fb97fb98343dcc7345d1d25c4bc42fcb0f536c8"
+hash = "e7161720fcf4bf16ea05a3400b1e08b1a6566a8a83242b496c4d6ec934188467"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/conversion/cryo_fuel_from_blue_ice.json"
@@ -3566,15 +3574,15 @@ hash = "6c597219e696a58abea815a6753280e46c28d3f4cbc692739c41ac484e43c514"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/conversion/oxygen_from_oxygen.json"
-hash = "865ba9dfc21964667a710a2772f846fd436976587a00022860bc48787ac52cc6"
+hash = "8409ce70519c84d6fbbb8821897a8ae0fa92baa30d5962a1ade27f152bb22ece"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/conversion/oxygen_from_water.json"
-hash = "48e1c6b61d5413511a598ebe6fd15f00c43523104190a9d2a391b35b4bb746fa"
+hash = "23a42e71ea36448ac34ee91d07f80b68ccac655d78566affa27515298f85f97a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/nasa_workbench/tier_1_rocket.json"
-hash = "8ea87663f0946b289b6863289615588f1245397c42d2027586f2d23f9774e43d"
+hash = "3d544b9dcdd20110eeb2e4b702dd7aaf62de8bf6cd1a24a1e0f6c7b871158e25"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/nasa_workbench/tier_2_rocket.json"
@@ -3582,35 +3590,35 @@ hash = "0f861120c469b5bdcdde4e5e6bb54aa7a634b7e48469d1f5c239d9bb807ff1e8"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/nasa_workbench/tier_4_rocket.json"
-hash = "be7f980d5d172d11478b9bfdce81b30331783b8f593ef6eb97a121b4a441a70a"
+hash = "21057c44ba123b40f249bcff5e97539e3e593c8c912e7e129f55642cc46ec176"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/recipes/engine_fan.json"
-hash = "9dfa0bf4d0d185ef7e67bbeb6e608a77bb9f71b3ee5ce7d8fd0e2896a635caf6"
+hash = "0b765dceb1e727b5901de149672fb26a2fa7cbd880f439f7459f4ab2ea8499cc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/recipes/netherite_space_boots.json"
-hash = "caee18356783e1f1888c81ba113ab8716ac9331fd186fa13a4b357d8f677e3c6"
+hash = "df70cbcf33c7f8e7e8448de7c5f016aacee7391bb3ef981b54ceee32f6d15def"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/recipes/netherite_space_helmet.json"
-hash = "c7d18b684b814e5b0e4deca8750cfa02a2712889ea55f34788b6e51aeb6a2db3"
+hash = "049206866e22939ef837ac47cda6cca7f043f2f1327c04a36b3ff2a860757b8c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/recipes/netherite_space_pants.json"
-hash = "6a7b13b9b2759b91b0d35d077fa3af0e68ed68581870522888b0d4dbd12441fc"
+hash = "fb767bd492658df5fb5b0babb9f63eb9e7fc8533f1f4057dfcb3eb34e380ec56"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/recipes/netherite_space_suit.json"
-hash = "2a18b58a4193945f99e0ff6a800de579afab13d3c59b6a2cc250194ebf8d7812"
+hash = "63d3d43853dc99547c9e9d3a3fcea71843c61ef066e830e2e2f24884f8d568dc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/recipes/space_station/space_station.json"
-hash = "f4c0e79814f3795579f37fbb87c67207ea4163d7cafc678fe58df4c25135651b"
+hash = "63453e6b4bcef75881316e89a8d292ab017835fd18caa3fc64dc884502b2c88b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/structures/space_station.nbt"
-hash = "4c663f0874402f2ddf28d77b1c553a649833aec2a1de950dc4aed522ece36597"
+hash = "21b5fc334268bcb3fa3afe4ed40bce3bb3fa20ce4dd2cb9ab5603b2eca6df4cd"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/structures/village/moon/lunarian_village/fluids.nbt"
@@ -3622,7 +3630,7 @@ hash = "16955d8ca4eeb5d2c2a9bb66f0cccc6cc7f6ad4602e570f418447e9c58ca633f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/tags/entity_types/entities/fire_immune.json"
-hash = "dba08d644d19b4d6b7f5540f1ecd051cfffc1e6cb6d5533b32d82037f010d456"
+hash = "22694783624167f90199e90f83f6457199519d9aba728e1c8458e66f48ee3538"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/tags/entity_types/entities/lives_without_oxygen.json"
@@ -3650,7 +3658,7 @@ hash = "b7c816cdb272a04686bd3f048928ad54b6c49e081993098fd0bd91e5e8985a53"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/biome/infernal_venus_barrens.json"
-hash = "857a96aa18f9dcbfc8f85cd21ef915c5659daf0e46503930c097965f3c2a98e4"
+hash = "2bc6f53cfc4f91b5443859b892d31e6eac5cef46fcde7109b8c693f13b483504"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/biome/lunar_wastelands.json"
@@ -3674,7 +3682,7 @@ hash = "a829d2c916d184cff7f55458ab4bf331d6d4a4c04e0db6adf1cbf6462d427e68"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/biome/venus_wastelands.json"
-hash = "109027092cd61f72bdc187e1d31109463dfee51b9263fe095b0b5d33d5106a31"
+hash = "4ac36544ca6431491cbd35604446476813a9e70a32f91ddc0cfa7afbe3d3cffc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/glacio_coal_ore.json"
@@ -3698,107 +3706,107 @@ hash = "0c621ccef1323c0ddfee526b67047ff8da3e88f630f41f39e7be14603c89018e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/large_infernal_spire_column.json"
-hash = "6eb0a675de0a7816ffe20f2ecb09c68985fa008ae5892996d6a6ede25c8aa731"
+hash = "392f373c7863ce42e675c9aecab5fe36263c5b7f3e4a15969bb7becb9fee7cd3"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mars_diamond_ore.json"
-hash = "8ecf8e331b916a79a6aae55c142e96f1dba269aa506672d79c144550c7d4379d"
+hash = "fdcf9656b6fca19d73630e469c04563f4702051526dc69b1d7c1f64d9ab7e884"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mars_ice_shard_ore.json"
-hash = "449589e65b4d5b76f9047967dd4628e2491abd6fed9aa9643db5c1a62fe37b81"
+hash = "8bd1df7cfed5d27b672b8a4096f3837eb3d16b0c4077381dda9b08da0ff9753c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mars_iron_ore.json"
-hash = "7d67865a9b08dc41478dd569a8452eb1942677079f3fdbbf70cc044ba225e157"
+hash = "d7b44dee62d164bcc1411f9dc691a737e11f9bc73acdb0b6b7b5ce8367c5c773"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mars_ostrum_ore.json"
-hash = "c504cb34d26080232f8307021121d45a18ecb9d2504fc549ba0665cce1c154b8"
+hash = "d8b715000393e989f30369e860d888fbe396878e15d7943d2a30dcf9f9d4bf4d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mars_rock.json"
-hash = "f634bf126431ffc3eb94a7c28c1d551e49491101406e3ac4b14744669d6e0f77"
+hash = "fc123fa9f5ab8e2f8a7dec3baacc38c451faef161eec1593f131eac029618a1a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/mercury_iron_ore.json"
-hash = "82d7476bf137f20ac46e1d91ce931f36442e10eb6e77534c7fd1533c5b9a06aa"
+hash = "71a769c5f08b7945354fe77c44e6efd4022d4d5d56b47177c351fc6df02fc994"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/moon_cheese_ore.json"
-hash = "7d295431c7ebdb2162df027915e58c8fa4b8b9e3445ae1fc89fc110c62c217e0"
+hash = "c826b35430e3a575f88a027c35dc55dddfd49c31713b7005065d80b28adfb553"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/moon_desh_ore.json"
-hash = "e9f47340b87287a572928f4d7bb741bd49b5f7f8c0fbe03cce5d82561c4216d2"
+hash = "9be4472b613c1daa8ad0e1286a3da77d678bfd96512884f35db6a78d2eb8b963"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/moon_ice_shard_ore.json"
-hash = "39a49a18e4bc1fc00e3e289323b31518f3cf2d619b5b405a8f2debb795990522"
+hash = "e694fae95c103ea4a86365ac1fa0c84d1137e52b7ba3e6ff6d072ee6a4d72ba2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/moon_iron_ore.json"
-hash = "bf242ae8c42fed71c085d1d334e78d71d7a16a3b9553972ca05be2aaff4457dd"
+hash = "cef0f7ecb49464a018cd79eca256d66bb3d83674bda2e7a62bb6208a9023e338"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/moon_soul_soil.json"
-hash = "2068487a09e18c42b3b6860a39fd615948a3b8be79040c80dbebf8be8db1512e"
+hash = "f9e22dbd424be499c6b11b380444eb648bd5b70ffd6909a1a633a2c46607055a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/small_infernal_spire_column.json"
-hash = "7929ef72a5780ed915902a0b600268b1831155a5a9373472a93cbe7353905c73"
+hash = "49c5c626e76bb507caaa27db054f70da5df4db85e993965468698e760ff12099"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/venus_calorite_ore.json"
-hash = "28b70102c15a47a023a1532201301cc9d50e9ac041513281b87b681f005f18ba"
+hash = "1d13eff0cb94be5ea3bd7ca295dfcf8102079fa382c04d2698c764493f23157a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/venus_coal_ore.json"
-hash = "b8598fae160269be764725f3fdd6d56d306292c657f7db9d6cb073d33c23ba68"
+hash = "e6c9a5ff83fa3ea01738293cb96f3c4da8850b69b29bc46902368044eae745d5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/venus_diamond_ore.json"
-hash = "149d5f382f8283ca34c1f420f195a65954dd0ba3e462b2a502ab894339e35181"
+hash = "b3dfb8705939fe3d1128a9aabded3aa2bd47726faacab8296a8b41a182ff7e91"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_feature/venus_gold_ore.json"
-hash = "57b43d865c02923e786a2e123ec1e72486bc21d2227d100b375ee670e69940ce"
+hash = "6b0f782582042b57e5b6ab5eed4f8c1348366922000d7e36b9920d72bdb86fb9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/lunar_tower.json"
-hash = "dec4fd5b8c9dd36b1998e3fd5e63c529cbc50b0426e588a5052ebcd5fe9d7e3c"
+hash = "18fc0f711ade66268ae536985a0bb49d0517e8ccf3e3b3b600dd50a12daa871b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/lunarian_village.json"
-hash = "c6de53e9b346762cbcd219e1bdb5262c80e786b3975acc57b99456d8ce4bb00f"
+hash = "5b15ae460b95bcb1d6976308a216547a57c0818d7f2dec26f847a5caa26b73a4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/mars_temple.json"
-hash = "17c2b6b461aebb738052a3f7356406263ea9cf90f944d7c804899075457719aa"
+hash = "eafbe2d4c5a1c96f0b502c3e6ce8688492f59995fcb54cb2cf5048e73c4d2288"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/meteor.json"
-hash = "2431349bf9bb38f40c7a5266fa5382a7424a465ce2cf8f384ed6c44b97ca2932"
+hash = "0afb818652ef138849ab1d6ef3126823b87db47117535b15ebea71cc28e0235f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/moon_dungeon.json"
-hash = "51797d16739f64fb8f6348f3467b080ca0f1bab36dfe8b0731d4e307584379c9"
+hash = "d599530f33c3153b9ede45626dd147dadf98f530edfcd786f102928c63e113a1"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/oil_well.json"
-hash = "b2c141f3f065060ba33e55e27c05b8f4acb5692a1b4c46a974a924f9d44f4019"
+hash = "a5fd864469e4449fbbe57b45b35b6ccda36be7fc327c624d3ad08645d705c8bc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/pygro_tower.json"
-hash = "4aca565c2fe41f6ba6760e292595ec92fc9a5c5823504cf752a5373f32c96479"
+hash = "0c773d159d5631630371c0316527e99b43614e1f03abc599a119f4de7ca08700"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/pygro_village.json"
-hash = "60aea624b418a973dba07d730340669373e1f7fbca3606b0a003c3958e5a6f7b"
+hash = "2da4c5d71395212abaffabd530a6d7c99cc377a75ad4c04d7933072dbed5f9f2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/configured_structure_feature/venus_bullet.json"
-hash = "a151af7790bf0d78754fbd34e0abd9ccae063545dc77ebcf5ac3ec59ac154373"
+hash = "06d3a85d5ad1e72ec16d412ff7d3873c7436180514d19ef8dab2b3773b68549a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/placed_feature/glacio_coal_ore.json"
@@ -3826,55 +3834,55 @@ hash = "9ff0dd6be11684f47a2a71ae2c4f16adfa411685ec0b577618badb2dded6e57e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/placed_feature/mars_ostrum_ore.json"
-hash = "8dd0dcd218ae533150bd9498375eebc9845827b8b86c21be6979aee42c3c9870"
+hash = "942444ab4e06685a160cca677303c811f14c93e26b44ee773394932e3d94c435"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ad_astra/worldgen/structure_set/meteor.json"
-hash = "6ec5d60ffc82d14b24b378037b92c648e0bb83601d3b799073d41450e6fd5894"
+hash = "a3554175ef6a63a9c247deb3980c48d55711ac63f0b006df94c92ab582377296"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/calculation_processor.json"
-hash = "c4fdcb27b06cf134f82347e2b7a5a8afd1fd4461893a8dbbd145f9199aaa892a"
+hash = "5b62f024288455a680e67db5e8bb4f29b81062ddf018393f40f98128282e79ff"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/calculation_processor_press.json"
-hash = "8133c7d2a98770179ad2571b2c9777ee39336f2ff43eb7ec8a23c5d96653e34b"
+hash = "2bca97803cc6477837290a4208f99a4b0adb439552e2b0e9109dde2e769b93f2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/calculation_processor_print.json"
-hash = "a0174ce0880373428cc95686d4cef80b2eb71eb42851cc4765443a45bfeb6913"
+hash = "b4dda08b7dd6245dfcc4630c9ee2c9a886bfdbde1b91bcc0a5826eb7261e30f4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/engineering_processor.json"
-hash = "56e6e15d65c9914fd40db912282e7acd4421d6c101dcc9659a118da88b6aeda9"
+hash = "6da9dc82b415811448969012c80e1ddf4846ff8d0d975a94a3f507cbf0f5ca72"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/engineering_processor_press.json"
-hash = "0879fc6f4fc7b16eb414cd9e27b3600f24c776259b7c9cfc3b683b0977088e8d"
+hash = "a53ea2dbe753415fd1c9253f7b3aad6d8924e2ebfcea964a4dbb65f8b871ec27"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/engineering_processor_print.json"
-hash = "2cc9f9cb2a3e9080eee6c4de9a2baf9cceb4e77ee67fab0afe1071470c64ca9c"
+hash = "b34745b844d308f96582c344392a23fa3a096625f89060936a72aeac3e5a5209"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/logic_processor.json"
-hash = "cebc000f51e5025b41317e75b6c470ba0fafd446cbba69899b54836666439fc9"
+hash = "7e34990fb3e4d0f7cae3f28c24df8f58ca3448e57c5036073bd939895499d1af"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/logic_processor_press.json"
-hash = "5084425e828275269a0c38dedcda085e468224f65c98729f75f2775441c7c3a8"
+hash = "870af1f5bdd7df2d3ca26ded1e4346dd9af01022636af008a8eb991f9878a570"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/logic_processor_print.json"
-hash = "a2af2aaf6da1bcb8e4a429fa671c1f6bb999db779f040e366f446f69f210e579"
+hash = "d03dab8b8a4e39e18ea3de1899d2cb95f6a8b1e2905ea49081819084a655cdb1"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/silicon_press.json"
-hash = "b93c9d831c0741db379afa383ac9bccaca245965b0eb11eb277cb41c7dd2559a"
+hash = "298db71285a13728929113d1b81cb397fd9041dbbb43a6bf79918741aa9c9e1b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/recipes/inscriber/silicon_print.json"
-hash = "79797dd675708ebeb57c9eeb8cc90d15a4e9c93eacdd1b6b8ae24d42e677608e"
+hash = "cc043ec2bbebd63675ccbec13a0e9a07b8d32632d690bf58cf3e5d50c81c902f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/ae2/tags/worldgen/biome/has_meteorites.json"
@@ -4078,75 +4086,75 @@ hash = "6c81443492c6a55a707449255b5b97f8ed663665d36a664ca868dc526e2760d1"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/blocks/bronze_blocks.json"
-hash = "1ad7db9e0b3bfa841cbe223c6d4411ae75c630dd97fcece67813076714ff9781"
+hash = "9eca7d75716b32a5c268ed2853d41823000d8fb6ea5a0876f5c6a414b7175446"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/blocks/stripped_logs.json"
-hash = "c87ee3df5700dc7da487a3e006ccd314796a54cc5334aa555f81801ce62c665f"
+hash = "7da68cbd3f7861367a5564edee423c25fd92f6805251dbb9ef46ad9d28968a8d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/fluids/molten_calorite.json"
-hash = "14305d5e907c5defc3f944d69de54829224d3974dd2819634db0de68bade77e5"
+hash = "9499c6dbb0ad586c6ec3087729feafd49068abf882f39c169f2eac93e7cc723b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/fluids/molten_desh.json"
-hash = "d061b2f719c0e9f13038f1767a0117e7afd8cebd9c0e29c3bb05bd0a3b29c187"
+hash = "fa166b615544889592b1f8c6bf059b580585461663e2538be4a70387f303fca8"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/fluids/molten_ostrum.json"
-hash = "958899bd6592f9d6e94ad9d5009f0e31434f7169ffa17c1dd84338b42b124fc7"
+hash = "0bdc57b864519dad5725b91c670ede47e6e76d12b596a7e04081d47b4d757817"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/brass_blocks.json"
-hash = "53ec14af7d5108d56b020deef85dd817addb5e680687469c226ffcb48454481a"
+hash = "a444151a3e261e18ee92caa001e984054d0404574b69abc2dc98c858f7ac743d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/brass_dusts.json"
-hash = "4a6ce8f87c1c3c40671ac03d1ddcafc5f43b9350c086ac0487aaf32f7eba3f24"
+hash = "61b72f9ab96c91592bec10d08c0380e48a989fcec9d53c21f4b0621aedab2919"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/brass_ingots.json"
-hash = "7710b0ec4ff8627da203f52ad0ea47fcf31e2a6717db07220ddef70d210fdc53"
+hash = "8112f5793005918d44477fea26551b827b9ef635b6f49ea0249710e2d1c3be38"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/brass_nuggets.json"
-hash = "5360328caafc4332b8c5547685c44eb9b8b7a44c7166c0bf80a8a85bed683890"
+hash = "60f3f4152ee29b64d56dae71dfffadc706706b5b7a9a762a328340814a017097"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/brass_plates.json"
-hash = "681d29c5f37365c9d8a4addddfc69c596773e249e79629a117059a3bb9f93b07"
+hash = "805e382a338642121a6ad06542767e14f47de1c5f0a51946b5c80583b5881f54"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/bronze_blocks.json"
-hash = "ee6e5a0e49eee6cca6b0e539895fa7efecf750f94fa429eb39535a9a04840652"
+hash = "4e31e63af5feb573a94a5c6e8be7fa34ca61a78d21209afb160c5655a2f80eed"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/bronze_dusts.json"
-hash = "f398cbca71ff4302bf835a9c4a5787ddb7bc19e76247c408ec187c35692d0337"
+hash = "923e1bc853ce1e7a9814b98a289cd2f6dd3b36614729706533a79bd1d6dbeccf"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/bronze_ingots.json"
-hash = "a98e14e6f5fa35daebae8b1c3def854f3a9f7d1033f0ad85aaa718c7009e55ca"
+hash = "06bcb72146415b94f550e2f328e52d0cead8ba79edfc8f25405eca3e21cd2b22"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/bronze_nuggets.json"
-hash = "4d204dde1caf8a6e3916585a4cb8dbf8dd7cb84294bbc71111924d97082b734e"
+hash = "e2aa82b15c0f69fbd1fe7e391bad372c1ccd8640510959b73c30e88972697c7f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/bronze_plates.json"
-hash = "0d139d0f84bd60b9353e65bf770942546817633c82be4b3ad11f268314616b69"
+hash = "d06d07302e127cba625d1619c26e0147f51785ced0ed4697312db6aacdc0d55d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/copper_nuggets.json"
-hash = "428bec9c995d41c9100a733d9a7a69542d0a79a4219825ce6b743b44325badc1"
+hash = "1608a6e3f8931706b768d4e10ea3cf50058b959257ccbe4bb307edea6b13d1f3"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/copper_plates.json"
-hash = "904ec95967bbd495009f356b408adec332c9ce453f118aa6e19ba1931ff9e3b6"
+hash = "9b8894c3e563a08efae36c35fb147ffa021df0ed9d2411476ad6ff8b60b8a49d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/gold_plates.json"
-hash = "633da1b486515d016cb08678d1e49e2d951d760105f078070b133832b19e6834"
+hash = "fce905e19284f5d8adb6b3ac1fd5a1046a51787e9b43209d4b96bfd50e25f649"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/ingots/aluminum.json"
@@ -4226,7 +4234,7 @@ hash = "4249ab9f5d00347d46b3cf1e75a25a1befba59b952f9753564debd006011f91d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/iron_plates.json"
-hash = "6b3183059c79c351127ea4d437f928114845efb8ac7eaba83fdadfd0734b2b71"
+hash = "b23473bc3d938eecabcff6a6f8028b73588e15befb88c181b0b0307f6c14defc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/nuggets/brass.json"
@@ -4266,7 +4274,7 @@ hash = "8b88e9a5d07cbc71769b70a8b82379952c2e38ce094f17be759c05d937c98a73"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/obsidian_plates.json"
-hash = "f25add05b88e0997ec073d1f611986cca7bcb373c03d15b3fa160c8461f22da2"
+hash = "937370cc70cd3bbb89d4e7f7a759eb429b7de04e79aa0953f856dd7c7ff0fe5e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/ores/lead.json"
@@ -4370,23 +4378,23 @@ hash = "8ce83542530d38595044c8f513e9b09ca735a17645b8c280316fb4387df2867b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/steel_blocks.json"
-hash = "6d4aab766e37ca34ffaba5aaec4842c5143b0abf594947a693ccf94db8f096da"
+hash = "483ed2e1b490a3bc0b12220000527701bab5c211b9c459dc166f2fe452513402"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/steel_dusts.json"
-hash = "d0eb4f131491cdcfd88f264f1476316af093535859a556f61a9de7fc5bfbc90e"
+hash = "96c91157b80cdc1e174d0400bb0e69987bfeb414174fc53d7ebc907b2ae52527"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/steel_ingots.json"
-hash = "44561e6accdad00b64553a9ebafc850eeca97754f940d835bd903ee1d2ba8570"
+hash = "49d1ce9e4b7c2e34ab89f41027732a198e91d432dac2fe0792598fba4f450a0b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/steel_nuggets.json"
-hash = "820aa772b62b11da4e4d196b2427ee4aee04d8b2cb275e8ef68cef9e109d7935"
+hash = "96720f8798d896202305882feba1f2cce6197679f1e35a1d1fec6f5923a616a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/steel_plates.json"
-hash = "43a3f4c736ca4a339dd0c80353b88acec167767d0d8bc3c6087af55f84e53566"
+hash = "abcfa836c0965bb64a712e5639d3942e1a3ed669878ccf4fb56071f58048ed74"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/storage_blocks/brass.json"
@@ -4426,11 +4434,11 @@ hash = "a385d9dabb936df4a1b319020125d05dfc24ee902aea6c0f08c03279c02ab790"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/tools/axes.json"
-hash = "b2469f0e5ce25f3a1adf476c65081b78ca0f730bc4e3af522f363862d65706d3"
+hash = "a3895ab3e9ac93b62c218e23a8aba26db4e768e87ad1b92384131972c4964cd0"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/tools/knives.json"
-hash = "ed280392e4a8cddbbe58fc98435d808887f9d95ecbd77e449a706920d4881157"
+hash = "bf5ce1dbb09a11c1ce1b4cd6e0692662140c2c10888ad813199ce5a29043ff47"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/tools/pickaxes.json"
@@ -4442,55 +4450,55 @@ hash = "29e8db24ff1c4204851beae8f2e9072e544446aff898e5145af29d6d86ef2cb9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_blocks.json"
-hash = "b4a6305bca61603cff296f02dff70689f1709303090857e1dae73198639919b2"
+hash = "35876e3b51e0d6cd7acafd51c9e07e69db410ff957ce4969c79432462bd724d5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_dusts.json"
-hash = "8caa63f22531424ece085b5f21b6d531f46d4c9f4dbee6051f53f92fb8ab79b1"
+hash = "bf1d4049e78aaacd3f92341da408009ce5f5dfe6ba5075357d36edebf4b4ddb2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_ingots.json"
-hash = "0342250daeb428d90c902e4ffa27fd2f6680c98b9aa2b3582240de904a41876e"
+hash = "df4b68b9a1a204f4ff6706e6797fca18741c77d71576455accd153a98c26d1ef"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_nuggets.json"
-hash = "e7ee2561ab4abcea421a6ba97522a750b54d9309e5508c9f16b9299233c89883"
+hash = "3449fb71cc127f0f6f924c7d84df40e37cc1c455fa25513c68a7848ee5154fa8"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_plates.json"
-hash = "c1c0acbeee4a05697fe23d5c7d79484df2bc88a4c9ccc00836e38d5416e1abc7"
+hash = "e66ca34754c56c20306515b1b31b54917e19a787b269a5f67eebe2b19f6d201d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/c/tags/items/zinc_small_dusts.json"
-hash = "96ce980edfab27d149c50ac9b7d340483320eae74ba54c1c39b1b133fc4bd09e"
+hash = "03eedacd2c9c8b618d778ff1723200ac22338dda19f0ab4bd9cb36126a0224ec"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/alchemy_bench.json"
-hash = "2a64c179988ade87333d712109057e26c1872f18c14fb3bbdec1b5e9d813b564"
+hash = "f22ea4a5a25c72016f7e681d99016e1a6657c39e4c5d04a801221b2f7eed4031"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/botanist_workbench.json"
-hash = "960a107065d536d37b6751e01a819571f3d6480f112333b045e882fffcdb4816"
+hash = "e80cfa36618c7f0b06e009ac9e563baefebe29a5fb0a34bd94b60d391d3b170a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/carpenters_table.json"
-hash = "5d69d15852654c2c3796f3b6c1c88d8b85972262ae41ab1a2071b6ab6064e52b"
+hash = "5c482b267bc1b3924318de629bb541cfcbbc5129a3ebfe0ccbe999749aff1a6b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/glassblower.json"
-hash = "e47fa8fadb1b39f1d52ba627a8ee00ca7b5b7be3644282d8bab41fecf1e4866b"
+hash = "c7a0def2be034fcb99af74ca888aede8a088528dffbeee2912597e57c9ca1ec2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/loom_table.json"
-hash = "c75cade5a08cd90db489f57df7037cb55a8bb0a54b3ff5c4edb933caa9e8650a"
+hash = "c399165706fa6bf571cab5dda714cff44957e5697f77570c898fa7da04349d50"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/mason_table.json"
-hash = "f3d74769fc863ae823e432674e2e392ed860458071e503ad08404aa5ae4d4ce1"
+hash = "19aaf485bf96ec48948c3af10fa983b34699fd9dd4b0ba3830e9a892f3164b2a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/chipped/recipes/benches/mechanist_workbench.json"
-hash = "4ab18f9956bb12363b6679098ade63e54edead82c06c3f001ef24562ce13fa04"
+hash = "ddcf6cb5cd6eb2530a523090b4b581589ed92feed99a222f005404ba15d62349"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/create/advancements/andesite_alloy.json"
@@ -4814,31 +4822,31 @@ hash = "76eb84830b0b2a91468d9a5590d3f7c4cf3bc0ea55fd23f1404ce49997c5f3e8"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/create_recipes/recipes/mechanical_crafting/airship.json"
-hash = "dd393d0478fcce4554e9d4e0193a7f1cf288fb012cfa15d626ee699138f82a24"
+hash = "1017449e08d3eab977bb39c6e14fa657705403d9dc061db6112a28e7f2f96aef"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/create_recipes/recipes/mechanical_crafting/biplane.json"
-hash = "079764d67548365e4dd7670ae61525ef45adfa8a8eebacfccfc5ed0057492304"
+hash = "bc1ab78691c287b13e333b09abe02ea9c2274e0e57dd7cf57ac990fa89eae3c3"
+
+[[files]]
+file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/compat/tconstruct/blaze_blood.json"
+hash = "0b92ff07857b7bf3ab296c0e5cdfc1918e4f9a6225a8e312384352f8754704e9"
+
+[[files]]
+file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/liquid_burning/biofuel.json"
+hash = "57ffb6106b0329d61b23fc530ee904df4729a5b324bba2d85a0694a1c4bf2129"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/liquid_burning/lava.json"
-hash = "87c7c57ad41125a0b0fde5ba4c5e6542cad37e72fb44aacf83a1b1ea615f9cdc"
+hash = "b708e57da8fb5abf350dba34c95d52bd9ce052cb8fcf3dbea8667fa0f2dd3dcc"
 
 [[files]]
-file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/liquid_burning/superheating.json"
-hash = "505cd2295e3cd4f56fcf189bfacec9059316d731db9caceb709d27a03c989696"
+file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/liquid_burning/plantoil.json"
+hash = "d6eecb0bcc169fa1a1e9b9404685e6f7368b8a4e8e61f9aebeb476955962e521"
 
 [[files]]
-file = "global_packs/required_data/zLaky Core/data/createaddition/tags/fluids/burnable_fuel_1200.json"
-hash = "9bd219669625e367d66b4065b854756d04a657986783a348c659efc6c47c7ad6"
-
-[[files]]
-file = "global_packs/required_data/zLaky Core/data/createaddition/tags/fluids/burnable_fuel_20000.json"
-hash = "2c15195badf56c3c7771baeab490a81c0b9f42b55fecb3cd96c3e49227a7cb4c"
-
-[[files]]
-file = "global_packs/required_data/zLaky Core/data/createaddition/tags/fluids/burnable_fuel_4800.json"
-hash = "fcd4ea3346fbe0a2c8a4b06599cd4740066782f0bc0d99aab02becd78d492b60"
+file = "global_packs/required_data/zLaky Core/data/createaddition/recipes/mixing/bioethanol.json"
+hash = "48068a23083af9dbabba59208269a7071be988d311506397152f612b39e47b8a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/dimension/moon_debris.json"
@@ -4969,6 +4977,14 @@ file = "global_packs/required_data/zLaky Core/data/createastral/recipes/electrol
 hash = "82c5583859dc190e20a4d462a993dcf0cc2f48904b324870a6ea39d7dae083ff"
 
 [[files]]
+file = "global_packs/required_data/zLaky Core/data/createastral/recipes/liquid_burning/hellfire.json"
+hash = "293e6b494b237186a7b73ef07705b5df0f54b94cb24065bdf3cae5bf20fd7df4"
+
+[[files]]
+file = "global_packs/required_data/zLaky Core/data/createastral/recipes/liquid_burning/nitro_diesel.json"
+hash = "3f298412c581b08832b39fa00fd200bd240be2090c54e1678fecf6a846a22d97"
+
+[[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/melting/melt_test.json"
 hash = "56c87e341065d490c08314939ce5b95709ed44810c3a8a51142c985dbdf5f50a"
 
@@ -4977,28 +4993,32 @@ file = "global_packs/required_data/zLaky Core/data/createastral/recipes/shimmer_
 hash = "82b720afd7d10ed55fc36a35885b10875a8997c22edea6793155ac1b31eeb758"
 
 [[files]]
-file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/cobblestone.json"
-hash = "a2bd23f210aa5afa4e4cfb6a043ad9d1a8fd4cbb46f0af106dabaab1b416dd5c"
+file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/andesite.json"
+hash = "a9c69441dc2ed78b16583598060926eab6cf74c00e224b8c4e45bde20ca8289d"
+
+[[files]]
+file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/andesite_old.json"
+hash = "83090a4a6146265e0bce4a27636d43e2dddc408de3cd7f32bbe748a1fe0486ba"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/glacio.json"
-hash = "754c3b96ef4d03ac011350e4ff48193ace648bea27d0a2bb32ec9f8bc27e89c8"
+hash = "3a7140c627e18829d7b69859f86f1cbe08c866598aa2f5077c7d3fad3f4f0155"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/mars.json"
-hash = "8940bfa2c46c153c9e534728e22f29acce02e911788326ff760b14424ccfbf55"
+hash = "a3ffb4d607933dd7da02db7a146f3b222ef2146b0e661939b29daeebe35ac5d4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/mercury.json"
-hash = "ff4cfade739eaa3ae7a876f5ccaca3e6c982db652ee4ad923527935c8978f051"
+hash = "ab2045409011ec299de2001c5d04172ddf3a57d91512f7eab8ca8e5483e41205"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/moon.json"
-hash = "30963f654129f60d7dca6805bc7093670b7fccdb5005dba1af65afdd6daf2f36"
+hash = "bb6e155d4ee38027e3f78fa294c04b95bae4d3990060f785eb8cc82710897f88"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/recipes/stone_growth_chamber/copper/venus.json"
-hash = "efb6d44aab260c0572ede32eff2f13a339aed24f8ce362e9925c4e73363ec0ed"
+hash = "79c385c0cd1e7c213f88e2c207d5fd9ed03349bf9e052fcdb3c37643f10b78e2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/structures/electrolyser.nbt"
@@ -5011,10 +5031,6 @@ hash = "e86cb6ca45464fec7098bab2077f25ba1e1d4f55e9108ebea39da4d50ff5bfd7"
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/tags/blueprint.json"
 hash = "b0349377aa9a22dc9980a3d05556967170d122b008a596c9857812e3190857a6"
-
-[[files]]
-file = "global_packs/required_data/zLaky Core/data/createastral/tags/fluids/superheatedfluids.json"
-hash = "180430cc4904b925ab244bdd0d46eeb47a1de9e1297378a55a02140875292d7d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createastral/worldgen/biome/consumed_end.json"
@@ -5154,11 +5170,11 @@ hash = "2bad8ebd83d130259d1c810dcadecb5d40c9294872bf26576b4692811c5b8612"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createbigcannons/recipes/melting/melt_permafrost.json"
-hash = "1bfbe39d1ce7ca8e638c53c36b863fa78b6267d814a0642a3b05f13ea74ea485"
+hash = "85cb4f544458d2dae77db4e6a02ba29ce88739700003010b6a7cd6d80f14627a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createbigcannons/recipes/melting/melt_permafrost_hot.json"
-hash = "c2f60c1d8eecc58a04c8c7dd329e8f6adfb3612c2c65be0d96f46e3718f3c0e8"
+hash = "10697331efc223aed5c60e56a398e6fbc52a639e305e5fa47be804fa40646093"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/createbigcannons/recipes/melting/melt_steel_block.json"
@@ -5394,31 +5410,31 @@ hash = "bd28d8916c097efdf97f5bcf153887048dce6ffcabedac0ee50f28f29238f9e5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/cobblestone.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/gravel.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/sand.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/silt.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/slush.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinating/stone.json"
-hash = "563397b2489574ca583794f9e969d5f1cce9916a07ae61c7704467217c9c6b29"
+hash = "2e1e0cbe8e53c77730403f8e185584883fd0941208213e50feb5157ba03b975a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/extractinator/recipes/extractinator.json"
-hash = "fa43a8b2f2e44671f802e8eb0bc60c3b27a8fb7424280c7d85953cbbb89a3a1a"
+hash = "3104aefa0d4202a82b4fe54f769adb2f8daeb0915a741a6d62a1b4d97d7c32d6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/farmersdelight/loot_tables/inject/chests/abandoned_mineshaft.json"
@@ -5502,15 +5518,15 @@ hash = "b71adc1eb6b57d8c62fed14b71cdcb693f06f8de7183cfa98a5d9b3240f1fdb5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/immersive_aircraft/recipes/hull.json"
-hash = "6abdc314ddc1f51fd690e9fd846ee664c706a50440e62add0e29f72c0b1d1140"
+hash = "d576b31d3d5ecf9d509f0c4d88427049e221e8e6f1f5367c6644776cdb112757"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/immersive_aircraft/recipes/propeller.json"
-hash = "59a97f903b4731efec43d2ed924051ae38260b9a4ad10c6431f1929ed5e52990"
+hash = "9c48623b8415c61147758d1f11ece531055ad6d1eedd8c7d42d1f9e4b4f40f30"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/immersive_aircraft/recipes/sail.json"
-hash = "44ccabaaa495f50cdb3cfb732399f2dbb6c93a1195cae6c997593e5c49ab63a4"
+hash = "276e827bd75a61dd38e20b40e5543222a94aff6e720d8d01852a214940b8747e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/outpost/common/armory.json"
@@ -5518,47 +5534,47 @@ hash = "a365ba5f4570e79b58a87d45cee6ecdab0492872ce0af2f219c0d04834f4a57a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/outpost/common/food.json"
-hash = "6a83eefd8d123fde90a039223caf32e5089873d6eb91f43200e592f2acacc55a"
+hash = "91b1ec288173db6bb5bbcf2adba7c021a7314a0fba06e1b14bcf30092028425a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/outpost/exclusives/outpost_beach_barrel.json"
-hash = "9149829eba872538eed10563876378d06a054bc2684d6be0d0d0188a88d27cb2"
+hash = "a5a9a4ddbb8f232be16753d8626e9f199c8d661312a3acd39d619ea136e95c21"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/outpost/exclusives/outpost_mediterranean_barrel.json"
-hash = "0d32a22b46eea21d4bb26f2ec975867c0628ab7adb19c99e2d6b3afd818a1582"
+hash = "6e8681214226a3ac5dd2bb13b4ae9727ada2d175a43f5600dc1be1e8b133e3a4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/outpost/exclusives/outpost_rustic_barrel.json"
-hash = "f6a63b2b8a5b8354e27f97135f8737917693a83f961390cdde60fe3a70055e05"
+hash = "4bd5ab08533bbfb8e3454c794bd68974946434662ac1646ffdeda78246b1a586"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/exclusives/village_classic_blacksmith.json"
-hash = "249b3c52f35d63e6b60d4fa3fef0a3b0e59d1324e11ee8c89247b87abbabc48c"
+hash = "f417b60e78e2ec451922a8311c4cf3e8d71a32e495ffcbfd2a8a3645157cc2c7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/exclusives/village_mediterranean_house.json"
-hash = "e89b139a290356fb816bc73df2f7bc13323c9122efc1e6426a7f44b87bae7a7a"
+hash = "e9e334bc71e7b5c7fa7e7ce8000723957aed08d7796ee5ee7f8835ff16d856b5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/exclusives/village_wandering_trader_hut.json"
-hash = "92fd5ca7d9d27b0031f0befcf33e2798b6ca4a8975e27d8036bf0bccc5e574c8"
+hash = "94d53b1344b075fc37b4a042f85a93c96be9a613fbfa455e9ea3e9b1e484791a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/village_badlands_house.json"
-hash = "abd8b7d1061cde70b4bea818c4dce2577ebbdf67d18f3e56c2c47404b5dac532"
+hash = "0bda799f6badb3b18349ef369aa9a6a5c14dbfe34c0d95df7a231f996fcf24c4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/village_jungle_house.json"
-hash = "9c6f22000207406bc393625eda42598813f4782da91fc6074b9ed1399981b33e"
+hash = "82c88ea56e3c0e19c23152d25f848c121db0383c556f9b190db150dd3e93fcef"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/village_mushroom_house.json"
-hash = "0c86d6566b6d7dd120cdfffc7f5aec0173f98b9c767fa3bf35e981dceb1bc60a"
+hash = "69f839c5ce87306d5b2404754d7a0f72129578c1d5c8ba0fd3e1a6f7f1105227"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/loot_tables/village/village_swamp_house.json"
-hash = "7a059538461b973f51aaa3d6a2e4fcabc71d8bb402bb7c9d264da4fe186225e2"
+hash = "d3797f165b5fac416b6a46431b65f0a61a6d00698418c6e302c55934fdf4c1a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/kaisyn/structures/village/sunflower_plains_farm/town_centers/sunflower_plains_meeting_point_1.nbt"
@@ -5570,7 +5586,7 @@ hash = "6e2fc4a20ade80da75d0c16e7b0662bddcb257d36bbde95610c26591a4b10084"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/loot_tables/blocks/amethyst_block.json"
-hash = "b7d7a21ba0465311157df3e490c08cf075534a2283a48d14cd47b35eff255ec2"
+hash = "5be9931d0d0d6e898d1e1e342c297f1b81f670d0493e2f9c3f390034236c2f9d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/loot_tables/chests/bastion_other.json"
@@ -5594,7 +5610,7 @@ hash = "65a25c221530f4a293b8971a5c3c63dced1ab61e57f9802062fcbac03a66f927"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/loot_tables/entities/wither_skeleton.json"
-hash = "bded4f54a5c9b3ee738b6ae8951f81f112403612ac81fca4c79c572c98f7b726"
+hash = "70c077b826305a8c24c16cf518a680e79084a44a71270deb0a6e4ad44f19b8c2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/loot_tables/gameplay/piglin_bartering.json"
@@ -5606,27 +5622,27 @@ hash = "27d458405feeb9069aac97d0d946c84b91add7f1c86f03d71847d01eefd56087"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/loot_tables/loot.json"
-hash = "7127dc6583a94423aaa556142c4519e478fa6770685f057e5742bd15161c718e"
+hash = "2f6f597e208e4145f2228446b49af7890ccdd9e4c95291eb861c613ef3850047"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/recipes/mechanical_crafting/trident.json"
-hash = "86e5405524a58926073ca8381aac02ca8c2841c6b41cf86c3e00a7b2618c12ef"
+hash = "5138b8ea1d1a64b2d3b3a7f7512471c045e9098c960d3b97a392fc719be9cc48"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/recipes/mixing/wither_skull.json"
-hash = "98487e257a24705c3c62af413c54d48ac194d66cc0b94687b175182e7d5ca678"
+hash = "7eb4b0f1a66f4d8ac5d21f66fbbb0e0e36434d298bbac98201a3d882c697bac9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/recipes/wither_rose.json"
-hash = "797fc534cef7e0ebdd725d5ca442c2370ebe4e56b5d7fb6c5761755bf6f272e6"
+hash = "56bc8c883efafd2d4f20c0d92d9743b212edca8bb049066e912204cc05d60375"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/base_stone_nether.json"
-hash = "0f1cb58e8a267c16c14e0bd4fbce9a069b6e0db11dc0afc22e028f1fa9482ca6"
+hash = "cdc94c17b9bdb24ec4911fb754140d195cbdc4ffcec0d1fffa00bf01fea21ef9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/base_stone_overworld.json"
-hash = "39a590a03ecd5dab659c72167eacf6cef6649c2afdaa7471af3ffe98f0bcaa91"
+hash = "0bf478b2c7d1fb0239629bc292bb4df6281c658c0c0967e6bd6d4af9c70687e4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/dragon_immune.json"
@@ -5634,23 +5650,23 @@ hash = "98da64b5a29cc026d331492030a626ff4a19f835ef0ba78710ea5f076c380d91"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/glowstone.json"
-hash = "9b3695bd879f09ea2aa63f8e2df9934562e7081128ee6f92b49e3c2ccb8257bd"
+hash = "1ebcaf93e9b9a468ca9baa8404bb142474d28804cec86418e254086b154d884e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/infiniburn_end.json"
-hash = "1cceb1bcab84ea94cccd6fcfeb6fc5c6e46555febeab16b6639e8fa207062b97"
+hash = "9c67474144be988fb7dce8650d1faf4a267d614bd42ebca6bca3ff9c6484bbe7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/infiniburn_nether.json"
-hash = "acfcf23319c18c80dfcd47003217fdad2e35e45ee055b86cbfd2bc16f7126418"
+hash = "2567f7e521f69c3ca71168be23d1f60c24058aa570e7bd8e76a580e2274b041d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/infiniburn_overworld.json"
-hash = "f37995efb091b57847cc5f3944dbb523a5147e20ccbd95a76bc27e34efb19595"
+hash = "984844fc373bc444c193a32d1db9f9c02bd414b3862636b5686b7b46a06254c7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/logs_that_burn.json"
-hash = "13cf698c0167f24f38d4b8b3a7f627cffb68f4732a025e491505cb5af17092ff"
+hash = "85f6c1788eeef2708c1400d4c60181ce21db20e4b74e4aae27ddc6c9f8972f9c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/mineable/axe.json"
@@ -5658,23 +5674,23 @@ hash = "197a58b103f0e9681447b2974a6d3ec21d8b4ac0a127acb25287f6f29e61c829"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/mineable/pickaxe.json"
-hash = "39ab534d1e0d47bc8932bf42d6e72a1f1914e2c2e66291a0ff1c643bce35d94f"
+hash = "f445ba233db9a547d9a7075a6398d388e974954496f027253aef372fe90eb815"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/mushroom_grow_block.json"
-hash = "da524055f7c58593ba83e7a2fa49e38d973ea5bf4975294195cbce3dac031881"
+hash = "178a87efcb6d710975aa0fbb9f3c310673dac35d3f25e36f9096f3eea5c2f521"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/piglin_repellents.json"
-hash = "7a7d8b0f302cb773275b8852b7bf7055586e8f240d449ab874cc7a644cb61640"
+hash = "1e814c7ab43022636c129ba6f5bc46028fa538bca26ec485e56d24baa68d8960"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/blocks/soul_fire_base_blocks.json"
-hash = "883ab621860b68a7e265d3ab79b5ecb269bd4662b566b1285087b513a107ad61"
+hash = "e1198122be9500f9bdb85faca41fcf93eae469c6efc5f9a3831ffc3552078e08"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/entity_types/entities/IsImmuneToZombification.json"
-hash = "7914c7d4b151cb06d11c9f2be9a2b9c6e22adeb5b3afbd61f82b1db50d077aeb"
+hash = "f38825fff01f4f454965d9fa20c44872e91449713332f6b0d52f6c0779524fa1"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/fluids/lava.json"
@@ -5690,11 +5706,11 @@ hash = "f3cfa29cdf694270bc7ad70218e67789184dbe19143d265872beb5b435038258"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/buried_treasure.json"
-hash = "e1150dcb01e66d4758880815cf8275f5858c34ee1193eee61fc48464ac63c4e1"
+hash = "ecb9ccd30ad2c560475ea622527c6bfe44b32492dccf2458fd331a9bf9d011cb"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/desert_pyramid.json"
-hash = "887885c2e821f0c1a650b2db6208603eff24bf1fd56749a848d669947c9f76ee"
+hash = "dcbcb783de5a767aeace2554ab73efa6d545d8e9f88f13b655a02e4a8e464a13"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/end_city.json"
@@ -5702,155 +5718,155 @@ hash = "c28dd8e8d30224fbe9e459d24d88770339ec1e63696211fb0c618462c109dd7b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/igloo.json"
-hash = "30acb05f47dbed648ea2573d4088bc624e436f1510ab8842445e5cc0f9dc88d8"
+hash = "d383096836507d6408c97cc203882bd5cf6d05c1a953e6404c4b2d5f932330c9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/jungle_temple.json"
-hash = "81d53bbdebea76207c686885017fbb794383f297a4f3c834b69178aa89314904"
+hash = "418c666ca12b2eddc33add9cfe76cb734b87d56940542589b91243c607448872"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/mineshaft.json"
-hash = "befc64979a36b6f43388119f5dd28bc95de7f02435542eca09eb83b8618e7508"
+hash = "5ab524c5b7f3695d2c700d6130c4a1b88ea6ea30be0277d897aa2752702c7d16"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/mineshaft_mesa.json"
-hash = "8c0f58da0be4248b20e9f6aa0562d744265c93ac42b8118794858ac113e84f50"
+hash = "b8bb03572e0a02edf970d5261315d368268d3bc1f69dd8372671c4ebcc04da7d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/nether_fortress.json"
-hash = "c6f0ef40955722d6166690f1c8b6d1ef61a3a533ba89934579984dce0ee53bd6"
+hash = "7fa554dd3875d8649b3366f90ea460347f2ae9d2576ee3ab436228d9aa0932ae"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/nether_fossil.json"
-hash = "582c5dd929ae4ddd7c4bfd66c4bb5256de46cd6b8d9dae9b8c8e0b18e8ae7f20"
+hash = "60e788f552e4ac8f4cb2c653984ae31e113fd111de594d72d4ef2d56d5f8be2a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ocean_monument.json"
-hash = "6980d48bc9791360355b55468d3c00652419fe2c4c69f8723e404510f33e9c5a"
+hash = "937981eb3c372b62b0fe4f8800fd928ea4849015aeb5411e6d0a6549d0b643aa"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_cold.json"
-hash = "18d63aeeb59a57a53c74399cb3be807eac2a18ccf03bd98f5fcae8c6e225c3bc"
+hash = "0fd2db894c21f60c86834092dc6853bffc468f0549705ad0543dc8ae4b5d9b29"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ocean_ruin_warm.json"
-hash = "2c2e394f2333710bf5907f71db913952f8ecdb58518930e58dd943977e195137"
+hash = "e2cc741f1b53c4384f2740283316b53cddf65cb91720335c9383b4dedcb50eea"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/pillager_outpost.json"
-hash = "5ad2f70aea4a2fc8868f958a887f034aae0b97b39b31baa85e9bee8060e64086"
+hash = "f822bc4983fbfeb38866fe01120ac12bd879460b2d59bf6998ba09a416568d7f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_desert.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_jungle.json"
-hash = "16838fb383f52f959dcd05f079f9d48be984d13e8c73a1bc0d686f27f77a837d"
+hash = "daf682a790e4c1092e7fbad3fda8a440de25ef2d2f5ce1c3020f8bab82e163ac"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_mountain.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_nether.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_ocean.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_standard.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/ruined_portal_swamp.json"
-hash = "436389d83eca6fc73ed033c2ecc28c4a9cda68e0fcd5d11bb66a8bb438184633"
+hash = "1cd58c441402cd82ce6ee5a54ee0d7a782852bf57996bee6b9ea6ef5ba1634a6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/shipwreck.json"
-hash = "aa6aea56b88b5eb0afc9be13dca79e0d0d56ced749d2482d08092affed9cdc1d"
+hash = "a43c5551b8279c575ba4bd4307fe955ec35c758ed94b7debba121dd23011f8d7"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/shipwreck_beached.json"
-hash = "e1150dcb01e66d4758880815cf8275f5858c34ee1193eee61fc48464ac63c4e1"
+hash = "ecb9ccd30ad2c560475ea622527c6bfe44b32492dccf2458fd331a9bf9d011cb"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/stronghold.json"
-hash = "11c651406fb398d60d6997014665841f7774c20d978dd60aee75d00d38009c3f"
+hash = "2e0332844a7343df7eb8951373f5c153ed33c5a27e8b907905761c20b829cd2b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/swamp_hut.json"
-hash = "e8ef07d0ee4d0524cea9044f0992346345063b2b0b67db5d5a40550bd2babab6"
+hash = "582e59b7eba9a761234131768b5dd59255eac2b13cc9f1262d22ec69b4cc9d38"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/village_desert.json"
-hash = "887885c2e821f0c1a650b2db6208603eff24bf1fd56749a848d669947c9f76ee"
+hash = "dcbcb783de5a767aeace2554ab73efa6d545d8e9f88f13b655a02e4a8e464a13"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/village_plains.json"
-hash = "86cf75c4a8b9076409ac5dab41a44e64fa92c50d4aee19b250a1e0ff78637366"
+hash = "99316bbfab99dab1f7bfa715ebbc73b1d2f03eddcff1f90dd6ffab7b31ecd189"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/village_savanna.json"
-hash = "6fafe4f11e5e9c5c4d97b8d4cabc61147da5bbe0504b5175787371b167de3722"
+hash = "5057e8bd5f2f9b4b85c58ce31ef52e2cce46de430452c90e6d3146462d7b7c8b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/village_snowy.json"
-hash = "22d718d5d7cdc2d0c8f5e4f2746634732857daf85a9911f2de8d5b6a960a731e"
+hash = "6f06b86840f557e66f14666e1d3a0adcfc6cd557220462f00c9379fbea62ce71"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/village_taiga.json"
-hash = "7378c28db11d8b428425c65ac22f02ce7f4bd6c0258023e68d284682b63ff28d"
+hash = "385d25d229b7ea2203cae23e4f392aeec7e0eef4fee7fb673f4a181f73873243"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/biome/has_structure/woodland_mansion.json"
-hash = "4006845d43de40965171b5793f5e1f993c9e2bf170dec79e2ea2e52aa917b503"
+hash = "1097bcc7ce1f7d7b02f806444705a6ddc947772d36e4e0ad089d7e6e3020cb5e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/dolphin_located.json"
-hash = "2fe71a8f233837a495943ac1bb958db931534743f3e78b11359f1d7ac3fe0a72"
+hash = "e2e58176cc7d9d7b2da8024419049a3c6a168891d2cc22687cef3b8d688cdf70"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/eye_of_ender_located.json"
-hash = "411fa3e5c3dcd7b65ba285f7dbdf223df880a0fe8c35b7a98e17694495c7ef07"
+hash = "85d5dcbf8078dde3e153155bbf8b691db51419584997daecedef3ef4c0f98eea"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/mineshaft.json"
-hash = "90a8d3e66046b0fe776cc80a2ac80c62786061b0089b97ef19df75187047168b"
+hash = "279dc4e5f243a23034fdfe5dd29106b665d48dcccad153b762482740b2afd275"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/ocean_ruin.json"
-hash = "78a16aef5580b3860426f3b1fb510668324e3128ca9ea9279fb3ade2857a23ca"
+hash = "914a301205b7fdd678ca89b0d8ce636a9e226155679488013e30abd568ffdf8c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/on_ocean_explorer_maps.json"
-hash = "fcc195b327eb0eae7df412f92e7e5c4169091fb91f54e2e1d444258b3dfe3d86"
+hash = "745e3e3daee6726617781f25e8896089a7fecac0298dd5deebfd53a35e122eaf"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/on_treasure_maps.json"
-hash = "415ad71ede2d34dbde6f2b645d8c09e0fa16f42763f65f76596e329a51d5fa4f"
+hash = "d9c6a6adb74f1f9edec7d6df071d8af8bda888d3090293c6cd9922a51cdd31e0"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/on_woodland_explorer_maps.json"
-hash = "da8ec62c4682f1f30bf8b0461aa2f972e9f4e8e7f0992ab8b88ea7f114f289a9"
+hash = "ce6d805d822f9a99fb3dbe22557f6ba5f3d32c5af4a849a94761285b116d4186"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/ruined_portal.json"
-hash = "9555d6da26ba8a8da934a610abb05c1feba5819c023d9bd715f94d45c426f233"
+hash = "b9f1e68ead647b63c926af8b2023b564b9754ca56748c335673e04a586ce342f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/shipwreck.json"
-hash = "6b23667878a108d8d05488367df647cf1dffa4bf31f24740637017ebb1d330f5"
+hash = "62ee3c572db9a5b81a7328002ba36f8e02e03a0c605852f78e439b50a4b969e3"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/tags/worldgen/configured_structure_feature/village.json"
-hash = "0464da03c5990e2a4bc1dc67e2f833c776de78aece0f494fc15cbfe1fe7be72e"
+hash = "555fce940cbf1cf05dfbc6608adafa1242e98d01820bd4644acc5c07cc9e2591"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/biome/basalt_deltas.json"
@@ -5858,19 +5874,19 @@ hash = "beac64f208a88c1a2a1c6129dbe327b0677a513f163b181dd4694952b0723c81"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/biome/snowy_slopes.json"
-hash = "6057a0a69426646520815af737ff610a33349794fffd1710d59e72e0ef519ccc"
+hash = "a66134a17c2a3a7b31736a0fc192c56ebbb650d2df5385cb5da8c5e097bd8312"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/biome/the_end.json"
-hash = "947b65ab29cc09580c71b2dead9cca06ca062ef08873941090262c13da6cfe69"
+hash = "151ff8185357e973a3cda81c6b4835562af960fc7bbdebb2a67f0aef2c67be03"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/configured_feature/delta.json"
-hash = "08e754a11ef52b008ebd73c3d30f0df3d57fbbc5a7a27d14d8d99806fdaa9908"
+hash = "f208958ec9a736119afb3ce546169dd6a06a0a95d3f15f3b4a94fe938f7e581d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/configured_feature/lakydelta.json"
-hash = "3966ef8fadab204a4f851003bf133546684bb454dee818a1e4ef8449272ee788"
+hash = "9f1439e6b6d120747a6d0763343ac26ba8a8b356fd25c87cc616d865e652422c"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/noise_settings/end.json"
@@ -5878,15 +5894,15 @@ hash = "508a4a2c95fe35ad761e5b1667018d9d67080dea3582cfb1a74221f6dd9d3f95"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/minecraft/worldgen/placed_feature/lakydelta.json"
-hash = "e9a827baad45278f1fb45c3eff5b4546d00992f31699fcf1e049d92e658756ea"
+hash = "a0022ffcdbe1d58129978eb11756af62fccbd602ad6b21ef8ea681105db926cc"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/reinfchest/recipes/diamond_chest.json"
-hash = "f3d276c6775ba70235fa0a1666f06853b6a434f4ad103790aee97eb19f5e1c05"
+hash = "c493afb1c2c6eb28ae174277a604de76822938241e3f704c70a19048f22577a0"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/reinfchest/recipes/gold_chest.json"
-hash = "db69f8d397d0e68c37e01b8e869b852872da0f788aadd7e769d00e5d45388c89"
+hash = "1fd951363d9e60a11e03926e2e33b97433689ca5cb077bb91444141ae1d5218e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/reinfchest/recipes/iron_chest.json"
@@ -5894,7 +5910,7 @@ hash = "67a0588a7aa9b2e191e7f1c3117cb500c01483802e3b39b33e3a85e6b46f7f6b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/reinfchest/recipes/netherite_chest_smithing.json"
-hash = "c1f4b7b179ce779f211e9520ba06a834ff34bc4afdab7c97ea7b514ddb74034e"
+hash = "829f0fb8524ac00c9e57be1ea0873494908175ec824f104fbc1e3d3c8a9acf17"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/subterrestrial/loot_tables/chests/cabin/music.json"
@@ -5902,15 +5918,15 @@ hash = "a365ba5f4570e79b58a87d45cee6ecdab0492872ce0af2f219c0d04834f4a57a"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/loot_tables/blocks/deepslate_iridium_ore.json"
-hash = "fab42789dd5231bd6f879f0c8a746034efc8b08aaa19647b3960605c128016e6"
+hash = "c2018af298adeb9090905fe8e2a177a6e78bebb63bd51070db581aac617e38b6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/loot_tables/blocks/iridium_ore.json"
-hash = "d5aef817ac27ceed94aa2b93ce88c1129c223ed77bc0d59a1f8324c5ef230cfb"
+hash = "144354ff6a43ac3004ed931c57bc888888a632899f9c44f064fad8739dbaafaf"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/blast_furnace/efficientsteel.json"
-hash = "210ed99401e656a4f69f411a5b59d3b7ab165bb8b9420eca4c80fb743b6d83de"
+hash = "eaaf080a93284d204d22713e2ed67d1c7d5b26d2cc700611af7eea0d636714df"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/centrifuge/soul_sand.json"
@@ -5921,32 +5937,28 @@ file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/centrifuge
 hash = "4ff2e24e7b6d52557c273dfc1d345da748af0d544bc53825bc54ea90d4193c20"
 
 [[files]]
-file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/chemical_reactor/nitro_diesel.json"
-hash = "c4a1ac52c45464a86ef8f4e3d192244c87d5c3f68d2fd153c60a479f2a78c745"
-
-[[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/crafting_table/machine/distillation_tower.json"
-hash = "be0d3debe0cd4e88b50d14a8fafdc699846a87cf3eaaa2d6b5ab46796e2d0a11"
+hash = "6124e9955374887a6f531f4f45fb24062c2802711e94cbbeec352376fb7374c9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/crafting_table/parts/nak.json"
-hash = "6f5db60ca45f7719ae034ca96f948f5f0585fe088bd56321959317921e90db84"
+hash = "8ad78115be0e98ae79a5019c4f40a3e494e482f818aead694f3e5f786223c6c6"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/distillation_tower/membrane.json"
-hash = "3ff21b4cc2df1719ba875a5b45889074cb882a2ee70601e09da4be7696b32eb5"
+hash = "b5d986b6cdb7a834323ad4e3c61ebfd13a182cb4c69997669c5ebeede6eba7ad"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/fusion_reactor/particleingot.json"
-hash = "7aaf38b0db721614e8170ef75465a5975eb8319ca27dc34d0e872499995b76be"
+hash = "e7606ee4d268e17229ebb5014d3b0a2fef81c27fb0d9ed6ee878a7ad9329d191"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/fusion_reactor/plasmafluid.json"
-hash = "52ef720d251072d8a6d773cf57c152128cad4346f61328cc3ae1c770dd8ce70f"
+hash = "b1365e337a39f669735ffebb78392bd35cedc1da5cdfa445ed249c09e9a31a7f"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/implosion_compressor/diamondfromcoal.json"
-hash = "f47f5c16897255257024894b0985c19befe607c2d239d097c6d849ed6e53d0ca"
+hash = "6f6a0cdfca44e9c68c3ae73e728d7c336d0a66a56da9cb42a60584af12845987"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_electrolyzer/cinnabar.json"
@@ -5954,39 +5966,39 @@ hash = "2bc757c8280e0af7c32a6c0a30cc289e8567df5d5af0acd121f9f83a3aa9914d"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_electrolyzer/clay_dust.json"
-hash = "86a47df19663ac74d93b4c5237f47968d9c518e4b1f69eac0170f00eec1f7c2a"
+hash = "41323f2c7efcca6a886ccd55e2f3390393858eb185080cecb69b1783d3239da4"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_electrolyzer/sodalite.json"
-hash = "ffe5fb8a978a46e9e3beda141bc21e5926994bf0b3e39677acb7788e666ad1ee"
+hash = "fb77dafdc1d259eb019ae948995bb8318ee7c6e99a79a8552413a34c986f3484"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_grinder/iridium_ingot_with_mercury.json"
-hash = "1f420ed5de88194f01870363ab2a6d8e8e97c45ea1c5f7fb878f44f25e11267a"
+hash = "bfcb327a1e77bf8e086b13828770ff7bb9331a8595a38b2b409dfe633f9f5906"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_grinder/iridium_ore_with_mercury.json"
-hash = "e48d79f6acbfe4d597c537630e0b471e467d1d31dab6e057acd87001db920d6f"
+hash = "6d9d063de3e05c8344fdae82d5f8d9bc9bd060498e2d0860aa5b949dc988ac3b"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_grinder/iridium_ore_with_sodiumpersulfate.json"
-hash = "29dac61a31acf1f0c7e9caefabee2f9838eeeabeaed32d978f74698427cdc280"
+hash = "f2d0949d24e3cdb65688b26af096f3854815ead24844a474d03388436038dbc9"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/industrial_grinder/iridium_ore_with_water.json"
-hash = "c036df30cf56528f53c418b190ddd46047f72d474ff4d31403e82c8e7851d4e1"
+hash = "72580e7e79e73507e8f24700cbbb280cae35aa27195584e4023d393b499bd2fb"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/recycler.json"
-hash = "8a5706fb32e6a69629cb98af564cce20aff6637be81a98cc6e5020fbe24665ee"
+hash = "5f214ca883bde602a7b95e5b7075a3f98e75052109a2921af3ee7ed14ade90c2"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/solid_canning_machine/bio_cell.json"
-hash = "1d943a995547fb63dd1ecd865cbe503ed928ffde35f840cfdf5449e7afbe7577"
+hash = "2de7f5aff9109b7b7cafbb3340c84e334621e7047f124d221d700e258ad07ed5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/solid_canning_machine/helium_coolant_cell_60k.json"
-hash = "4d77e747965269fac6184f97acabf026da8813737df645abd1b52dc7257f56ca"
+hash = "d68148c4b000cca78e9fcb74376183212dbf651e589f24f14a51027cedc81534"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/solid_canning_machine/sulfur_cell.json"
@@ -5994,11 +6006,11 @@ hash = "b74a050398f2e62fe6aa40cf6861ca054dde9a6d4f02f65eecb77c6f06db120e"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/recipes/solid_canning_machine/water_coolant_cell_10k.json"
-hash = "0a1996e08994b90208ae7e2f4210dc1d4d78c530af8eb462721ecaede7c9686b"
+hash = "bd592aa4436017c661ab4f9cfff158ac8d942760d60f68271bdcb65c2ac64087"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/techreborn/weapon_attributes/nanosaber.json"
-hash = "e809708878fb599b5285de589e07bfaffa6904b270dcb0e60851b4ba1149db55"
+hash = "ca0345df780d16467b0a1f8d300c35b235f39d0bd4161b3e41c7422fdf2bacd5"
 
 [[files]]
 file = "global_packs/required_data/zLaky Core/data/travelersbackpack/recipes/[do not clean, kube refuses to remove these in removals].json"
@@ -6266,335 +6278,335 @@ hash = "f6d2b57bcee592bedc32ed0dd6acec6a5b5db0c5936c83c6517f33a73d7ca6a9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/andesite.json"
-hash = "c53cd15eef542f8ddd636a7abe5f642cc9573a7d5a56f0e1d7487d4974723879"
+hash = "fb91b9d15dc6f89fe328704bee45ffcedbf6153e2d0ce6b433543aea010f8a29"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/basalt.json"
-hash = "2cfc25450d38885f00bd18e65d47708cbc5b3e8c949882d19ed24a2c4155f084"
+hash = "0b7fc218119ab1d015825a75f1d35d81a9efc750119f471d305b15584387b49e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/blackstone.json"
-hash = "bc5e06bc82b8aba3ba9374b83416ed98eb6977432c2acaf42f4a7c665f400861"
+hash = "7b23edd3e2b9bba6d073dd94b609b8867d3fd48cb720913124875d395973a8a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/deepslate.json"
-hash = "a2e6f0e128e6d3f32f91dfd06fdc685c586ba44f7ae2d142cbf8571821d9be10"
+hash = "4a0d835106d7c991867b46b6b921986a0f306e2ad05f5c56c009691745755b77"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/diorite.json"
-hash = "ee962f9f87d9789ca8bd94882b3df085b9c0181420f4ca45c637ebe10d5cc8a3"
+hash = "e75d70638088df3c884928209fdb3a95265051aab076fee9b7a91b86af5bb59c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/fence_gates/wooden.json"
-hash = "17c56b171b4500563f2ca5ecd4db54beb9c7f884b745c5424c17e0dda9332835"
+hash = "67434a31332ecc148418352793569a5b4bbb45e579e17ce7ed3004b018e02ac1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/fences/wooden.json"
-hash = "ae098a75e77b7171e2cc2c84140712f6222cec2bef2fbedaa5ec1479b3db0cd5"
+hash = "0e273a253f34bda33a81c36c0ba4d5f6bac3c0fc9ab143c62abf1f6d60f580d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/black.json"
-hash = "c3b3fd0e16c6831eb6480129bc14f98c40e93a18622af153dbb48dd10ff1b82b"
+hash = "c9e1291782a3e34330f43f588fa6f8b97d7cab8f81f06b63455edf5807d3c093"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/blue.json"
-hash = "c796b6d9d4252b7d1d8d01b9b923c90b3e620962c763ae5fc7d4561a982dfa2c"
+hash = "421b02c0efb06d0bb63a574a256c24590963a5ec61de3e24c8d5f728e93cc215"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/brown.json"
-hash = "83c5fa6272142933825b5fd33b620a32b748b180e4faceda28ac82ac2a149fae"
+hash = "0c4d433a55f5e564d69b2134cd0130c87f2731c5d3cd1d96828bbaa6a7cb2dd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/colorless.json"
-hash = "2b073269cdfc92920e0d5cc6b8b78cd2c7ca5a92c670083d6c80ed9a6f9feca0"
+hash = "42e469f0a18dc2510a79f0c6d4f1c4ec396e72509702ba8c3de9da86126df06b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/cyan.json"
-hash = "21d4de9356fc0b0a50a0ff29620b05a41a13afb8a83b27837b76494f6019ebff"
+hash = "a1446b55e68652112d798765b7deeaa9607247e6d15661ee32b0f4ec406563cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/gray.json"
-hash = "0ed4034140219dd76d49526066ba942c9653bdce1d0c919ac67eb0c1e38989d1"
+hash = "916c07d274d434dd058bb74c22505cdcefe79eb8cc0f26d32bfa8a1b87d75936"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/green.json"
-hash = "2ad8c4648d890d9c2d1be3bba739a3e1e83c9c119c006e8147ac94eda0f6a1d0"
+hash = "e52fb0bd732a968d8012c20c15b1994d24dfc2424a07bb22ef45230a5cf018f1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/light_blue.json"
-hash = "7fe685dca3aa7f3012b23f97cfdc9b0e186d561d06f97db2f6a18594eaf765a3"
+hash = "ce1cacc28b20f071e41e75555223181b428b32c0d440af53b1d7dcdafc946a81"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/light_gray.json"
-hash = "02b812f9d6331fd9990471de63280e70a3320a6714eafac969b4fd421ce28816"
+hash = "9f2b8f8f2c8072c014fe43d415323bccfc023355aa3feb4ea9c887a74916d71f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/lime.json"
-hash = "c84a339a59a189a53cf21554ef6a15ae1e50e030d57c5b8b61335abf3ab9cff7"
+hash = "bd0912427265209c4e3fb43d7cdd769ebaaa87c4a24014b695e742f006590b30"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/magenta.json"
-hash = "300920f4e2dbabb71765eb3820af82b93bc608993250a2cbeca48d8a6c49334c"
+hash = "3ef0ac5e717efd9cc7bd8c275c2fd130ca5cd0b6fb4aa401feac2a4b101fd7a6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/orange.json"
-hash = "ce053de54f3167b5a8da590eb3a134c2cfd015c210d1f148aad45f4994c9b0fe"
+hash = "8e4f4387c1c99fcb5c2ac7efed0a233be4f66670477efef89bccff11a1a56eac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/pink.json"
-hash = "5cf08d82e9b95c2ee6cf3b25ea0b80fcd38aa8f55204d315fe504a57340b3a58"
+hash = "3b356291f0eea8e927833b2c1615b5aeb6b772db8c568aaebeb45296b1600f97"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/purple.json"
-hash = "5e4852055525892dac79d16e49e9dbbb732955def2a87dd04bf6746bf1a5f899"
+hash = "108afafd030a899b3e91a076abf0715fbdd4eb1d1c747e17e64ef89db0d451b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/red.json"
-hash = "73905276e83dbcfe5cef249683a4b89132cb72f193ed47ff9d94c9b540ff813c"
+hash = "728fbee7a6f5cf050aa53f5f2f5b5569846bcf5e78de3b1a505d350ce3850eab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/white.json"
-hash = "3b4c1274cf9d629b07073cbdf2cd3ef84cfd3d3ec3aa07ecb7c1cf15283cbaf6"
+hash = "c3210a5da8af50054bf96955fc69a089b64a7445986f9927348f91827b97a8fc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass/yellow.json"
-hash = "887c902472a673ae8cc28169da3c2a90eb5223fb45b25e4bceaf2ba0d7c06c9f"
+hash = "850d52089d5287abc7461219f66a1e418aaeb34f666004a1a4af140f1aa0c268"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/black.json"
-hash = "662b9893f10281c7a44547776dc3636e29b90b982ce655c5184e0371951342ee"
+hash = "466f1da48583f1922d3fd1580cd323a23d47a896315ff79d4cac5a5e67e087d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/blue.json"
-hash = "94494305b640e3aacb80e49a3882a6eb28c6c21f5c0baf703944005ab558f7e3"
+hash = "d0b98f4468d79ab6e5454f928cb721d261e6460656061bd6fb7a39d04807dffe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/brown.json"
-hash = "7c142e30f0be686f7464a02ac66bd8abe887474777bde9580c9ff2434bbe4ef4"
+hash = "26824b859e16b3fc284f2ed556aad9fba97d41b87c26c8bee642a03766ed77de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/colorless.json"
-hash = "79dabe7912d5ab5c1cdac9779c5ab298b6869e7ef8d970dbadeca39547a2f790"
+hash = "336769d6d4c092fd02a07fc4976724aa9adb7fd85617de1ea3be45481c67a1eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/cyan.json"
-hash = "c76856cac200a6c982c1eaa83126d16533ef99615c0f7fa6d335a738ac1c4402"
+hash = "baba80b42c1fe2f8f56c2c16d96bb060a8f8b4981e9f536b6950e2096e2739bb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/gray.json"
-hash = "80b39588a09350d4627eb7736813d4105bc08d9fcacfb4cab2d3e59675ecfd6d"
+hash = "73d20ceb652f6a332c8aa93a287b9745ffad8273afcb4ae46af5051690dc45bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/green.json"
-hash = "16bbbfe979ab5d9a7e410e8eeef0eae1a99b453e40a944e072886e87edc9dec9"
+hash = "43dfcaf474a7286f57457cc34189dc8b9b53ce23984b6cfed8d1e4e4d08a1ec8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/light_blue.json"
-hash = "efb7f4ed068fc0ff27c92961c2f913dedb247a7caf08bdef668f91157c66f191"
+hash = "35bea022276fd3019dd46251780fad1ba23fec8e2cb31088a03ea84619152689"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/light_gray.json"
-hash = "bd4ec062bef9963e6435b5468310ca68872a93c79670537987f4c5fb33dde912"
+hash = "02595f3836bb0e55af782a21b8e76006aabebb716199d95a7520a731fff7d0a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/lime.json"
-hash = "b0bd0a84302acebcfa8e49f55568f9728462096cf32234b21e231e7163249635"
+hash = "66c5ad4b74799d054b5c8edc4a5f25d855767616e668518f3ff5be83069d3c7d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/magenta.json"
-hash = "157607532283d5de8944aa81841caed6890e56f78d4994e4dcc9fadf61ce0a58"
+hash = "805357c76d000f9e15b958dd7e73bc655624905976a7d750aa7d31bd4b9977ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/orange.json"
-hash = "9f2435fa40e23fcf7869cfee2c4627813c712ddeb10b5f3e5a41499cc0afc87b"
+hash = "7b9ee108dcfe25548b3eb65d95d7255280da48003ee7e96dd2414945fc9dbd4b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/pink.json"
-hash = "60722d1fd12deb5729a8471d83e9e611e0fba3358860ce5e80165681952ecb32"
+hash = "24a828968f6aa3f11f3abbefe81b0be3a30c9560b86e79e9f77739517b102045"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/purple.json"
-hash = "a968dcb0c5fea2889423c49b2a1ea5e8baba78e5e5bbbd7ff9a1b3700fe4c984"
+hash = "003435559515b39f375e3b27e67436f2004afd4c821df13286eec763018de9c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/red.json"
-hash = "86c3bd9acaec029c5bf639b7bd18360372c702a8c2faf00ce8a8fd6dcc1a0aaf"
+hash = "77debee4fbbb4883f118aea56eef4522da66bfb83f7bb23ed0dff035dfa05268"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/silica.json"
-hash = "d4ba61f5e84d9f76972edddba8d4d6f6220cbfcdac623d09bbc89cc181751d74"
+hash = "344e7f1f4de837dab976cba25bb12f0c098b6a6bc84c318b92335d01e91a72c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/white.json"
-hash = "8d83c0f1ed8a28261b9610606e91399a39d7895399630034e2a1fabe822db1da"
+hash = "0a9e032e30df70ed01a0c516307662e0475b41f922e17c576626a3ff9a0467c4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/glass_panes/yellow.json"
-hash = "7dbad57acda7f21822af8d7b04de33180313c53cad4719ce489e3ee9c001117f"
+hash = "11782a9a805aed01d2c8b19d2de61fee7062f1ce208993b35c735a8b4ea5b822"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/granite.json"
-hash = "8f75e980eff29c6a8b900d3dc6f2b5fb9a4578ebdc1ca33f2eae68c53b00c15b"
+hash = "70ac1c093c1283b7d2cfabb875188ea601f6e7617425a9f7f01a48a6b23535d8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/mineable/shears.json"
-hash = "cee310351eccfdf939dc8b3fd1946fc30cc995e6502ce523afbf2070a9384a9e"
+hash = "1b2d402c977efafd5cb5db3b6b4ca2ca5e9ad5dae62cc9ca9ba30b488414b382"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/mineable/sword.json"
-hash = "75f69a73b428082011af06337c86de95a65bf68d2c7af5d47206632c4538bc72"
+hash = "371e1dfe7efcb99ceaa07384fe168176b9ff172c5f538802ef7630450826dd8d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/needs_gold_tool.json"
-hash = "4f8c2c981a047d980d1019d8ff36122a0609635e5241fbf0fe04233e5cb13905"
+hash = "9c832e6fef112f6935a2ca1cff8c591f5b798e0b903b3da0a84e97a770c71b8e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/needs_netherite_tool.json"
-hash = "ec976ede8aad36f25042b723e504af3e6baa7a9480222f28dcf927f7ac8125fc"
+hash = "9f9624b4b0797b91b0c1de01f7848864a2c3fadb17480ccac42d6a6213646e46"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/needs_wood_tool.json"
-hash = "118f274e6382cb20215d16ef50d6b223055313413fe399a8b9bb2f0b3c6053e1"
+hash = "a329dc17f2fb6b2f99ecb5c71d0db1e372b7edf6b4b264926c80cb4aa0725d4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/normal_stone.json"
-hash = "1a7aecccfa448914114cac777ad8816b406e369f6ae1d844b9a1a5391a2eff0c"
+hash = "604fa8ce1696c58a1969b827c835d08460919f46ee018f2264f08e09833f97b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/ore_rates/singular.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/ores.json"
-hash = "ff23c89824903aba26178e30bb50465ce807f9e1cdb4031a92bafacb840a8d08"
+hash = "390f0c382499ed29ee6185c8a3968b83cb7c3f4a1bb4d1988af4a469fd33cfe9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/ores/cobalt.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/ores_in_ground/netherrack.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/stained_glass.json"
-hash = "0108f8d858d426b8591ec5f80ae842a54c687e23e4234ae6ea51c6cd67c33be9"
+hash = "6d67e5da679d29b395e674f93e15e4d5cae728810228256963fd9709c34ac88b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/stained_glass_panes.json"
-hash = "06f46ea061295fe5e32ba63e143da650de20a90490e1cd634bc5060b455f05c9"
+hash = "d947bb512c71d16e568c45f1902fef5e096e225b453052edf1f715dbb8cbfa49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks.json"
-hash = "0e31609167e26c78305df16dcca791185b56eb53141da5ac3bc7ff8da37e595b"
+hash = "193e9d9647db52b725a31e6307110d22d3a11ad8629907f98b18175008e20b50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/amethyst_bronze.json"
-hash = "863edd9e7d6269861fd3e65a6e8c8a13b7a3c19d3d9167f528de185e27c48c7d"
+hash = "3f911c61294f53fdd5e4d4eb8454d9b8fcd4a1f22036dc2bcf26a1098382e16f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/cobalt.json"
-hash = "b04af085bab54978faa2b15eb55a3814ad738a9f3738f1d1f839e84ec99cab26"
+hash = "3b03b6e1b27afdfbff8e48a9580c7120f19a5e93e33689dd38d6d1e6b43b9f7c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/desh.json"
-hash = "57ad324e1a3ddd818c787c874dbce3882d6f5a2a933b5e5299f7e453c827be82"
+hash = "cd6a0a53a59bec6328d406b9de6e51d5679b08c6fb57241a8097eb18b645d3cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/hepatizon.json"
-hash = "66a3745a12db74fce4d0d25c3d729a85365cdd914e63d16b57756c161511d6c4"
+hash = "66efb7ac476b259997924596cdabd347fe1a1d141cfe144575add4e25ebe1ec5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/knightslime.json"
-hash = "ec976ede8aad36f25042b723e504af3e6baa7a9480222f28dcf927f7ac8125fc"
+hash = "9f9624b4b0797b91b0c1de01f7848864a2c3fadb17480ccac42d6a6213646e46"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/manyullyn.json"
-hash = "56969ab6116584c34ba9c313674ba5cc0154f5d5144a085c36b8aac064c194e4"
+hash = "a784e45c46f2fcc4121c251ce820564696f78a511d6ec3e7c063c5619401b893"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/pig_iron.json"
-hash = "31e7a9c140dedab3227137b322a6413187f59653419e52f75b738c5dd35cf7d2"
+hash = "729bb31568f8dd61ae4959a78c7c294fc0c8f52e9dcb0d3443f8636688900cae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/queens_slime.json"
-hash = "96735a65bab68494433f4baa6d216d86f75e27d3adce5980df8fd2ab4749ef7a"
+hash = "b6acfe81b7e004a99674fd9b9b62b62636e2caa8af4b60920488a33c06ad138a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/raw_cobalt.json"
-hash = "66ea0987db6e75d57ea075bb4fb490068c2fd37a8198b4763d7ad0f25a1da1ab"
+hash = "245f683710b0aa34e6b7f0f6dbcbdceea52147618ac05129d3790a07e263e711"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/rose_gold.json"
-hash = "13fa098ad43cd0775910c9a5b81d56de4918e9ef96b25f81db617e79058cceb6"
+hash = "5d4a2792d88dabb7a0e3f88199ad65c7f210189dda3a3f369d35c7ecf2ce50a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/slimesteel.json"
-hash = "32590e9d53724240f7e5c7f11565c4bd2d7f297476742d2077817567c203e4b8"
+hash = "444f9007a0ad1b335eba744fe2b51e228b7025e0819b697ec36874af828df245"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/storage_blocks/soulsteel.json"
-hash = "9441e7d50b306d427abd3e288467b86f0b4e6e03be4d10cc4e98587cfb758a4f"
+hash = "d663cdf624d5f17b90525ccb03a7b98e0a4f3aaab9a17d3fb9c63d4700b82169"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/blocks/workbenches.json"
-hash = "0fd557084c37fcd7e108a50f6b4691a7ec5568d098b67d18f40b8b9ec6ce8378"
+hash = "d68b4f38bb5bb3496fbd055bf98d6feb1949f942a6cfad939831f369646bc287"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/entity_types/creepers.json"
-hash = "25872c3a34f3a317e7bd31c7fedfb1bcaf7123cb169486281c4d8df4edb5a1f4"
+hash = "232f0167133008bcc2414e213f72f03253a355c1dc224f9f50bc6c4609df7386"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/entity_types/illagers.json"
-hash = "294d1bacc62ea86df9fd1512f545c2a1af6a254451cde847b3fe87d897750712"
+hash = "dab3ad97d3567e5f690ce4821b769acf303745b3edfa92024e27bfc2500e91f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/entity_types/slimes.json"
-hash = "291dbaede5b2b1fb70b4228ae9375b4126e061b649895e3ae6b9c896bf9270fc"
+hash = "631aa3327cf43d3db500b646bc6461a8314d13c58a8b66ad3d3708c10771fa95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/entity_types/small_armor.json"
-hash = "f1b2982eb46519f71c5c90161a3a8904a7fb339b1626645c58e7b657b8607493"
+hash = "313b315ab1831c5a0ec47006d88756a8e65eb13c4bee67ec7796a301cfca00f4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/entity_types/villagers.json"
-hash = "5127aab05e8e547a6834271b427a8724a99947e6913dcf1f4859a8dfce21362f"
+hash = "5a544cc2a3e175f98b750aaff521999a835cbde0fd01c373514ebf05274a9724"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/beetroot_soup.json"
-hash = "a17b20c6cd6de1198208f76a8f85a1bc20d6cbeffa44c709ca87d7870254ef63"
+hash = "e4ecfaec4b43a40dbff59fd34243b3b9d01779f4d573d1a804b6d38d52ea19c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/desh.json"
-hash = "d061b2f719c0e9f13038f1767a0117e7afd8cebd9c0e29c3bb05bd0a3b29c187"
+hash = "fa166b615544889592b1f8c6bf059b580585461663e2538be4a70387f303fca8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/ender.json"
-hash = "bd095e544e8e46ee0940d1f875210a4df6b44e96790eb7950ba8c55bf0f51232"
+hash = "920baea8d896d291379b41811fbe3fea76dba59b8d574f2f28ae47f1e2a9024d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/honey.json"
-hash = "b61c5ca84e86f3629bdd47b697fa9dae5372468a7d2f6768f89ae4354e5b156c"
+hash = "ef89c17b8bba8703df2ddc754c83257be07337186b5f58e941891ffb72026d99"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/magma.json"
-hash = "0119f8895d143d5af1eb390d679d0192110a289a1d8bc224013521b5502e26c5"
+hash = "6135674428156bdc0fb6639b48fde12a90675718ef54f7ee8d7b7d4cd308be59"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_aluminum.json"
-hash = "f796c7cf90d42d522ecac1c9a3b79fbc7052a57ecf3feeb99dbd6c12ea8b5140"
+hash = "aa425d59e393325e176239cd6b51dab2428a125faec107456f1f4023c8e22644"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_amethyst_bronze.json"
-hash = "5924f305d9b2eaeccbae916418b44c4f5b83fecc1a96458a0a6215f3aa8c42aa"
+hash = "af1c08bff3d6656580f0bcf43df333a5ff1efadf19d2496df4dcbd1a6e0ebec1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_andesite.json"
-hash = "17b547162ba493638fccee02171acc09f1a6051f891ae350d3ef3e52dd6541e9"
+hash = "cba267cb40e42c20e3d0d3c2d3b1a8af76eea3785b5b8d9b2bb9a12c35eb5962"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_brass.json"
-hash = "fd228ec797cc4b2177c8c54f8f53c7a88496ef312039397f0baa87ddbb40a498"
+hash = "88fb2fe7a52495983284f0d069c720004bd0553c0a32ef892061dacc94e5c2b9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_bronze.json"
@@ -6602,83 +6614,83 @@ hash = "fbe53963363835e3deb5426ff845b942c7f07d24b5dde1a0999aa08f352df226"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_calorite.json"
-hash = "14305d5e907c5defc3f944d69de54829224d3974dd2819634db0de68bade77e5"
+hash = "9499c6dbb0ad586c6ec3087729feafd49068abf882f39c169f2eac93e7cc723b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_cobalt.json"
-hash = "45947b1c04dbec3320a4183038495521999c25b74bdca5cacdcca9697f6be456"
+hash = "8295e5b4ea5268e13a91983d2e0bc013a1a613b1ed9e1069bfa8638df86d9449"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_constantan.json"
-hash = "73f4ff26ca917309bc12d1c98753cc451f129aea65e6bfc5ee43e753876e602c"
+hash = "0d3d966a5f2a2b72facead2fbf88c0e00f727af14f209fbd854b16aff6a712ca"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_copper.json"
-hash = "3b4a87f24b9bbd1b99561c738e464d2e9f7aa6e878e4cfe795d85091517f6435"
+hash = "23ba50cd5ab9a7c95ee4e0fdad4956e6e8ec7161052c7618fc9e2598dc8e4b0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_desh.json"
-hash = "d061b2f719c0e9f13038f1767a0117e7afd8cebd9c0e29c3bb05bd0a3b29c187"
+hash = "fa166b615544889592b1f8c6bf059b580585461663e2538be4a70387f303fca8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_electrum.json"
-hash = "19f4f1406957bcd06f30209cb3a845fb84489213e18f347b2acf7ed7d9ec60ab"
+hash = "1f43636239d1a6a0b87acf6af6179f34d7aec5775c94624cf4b1fc50b555ee07"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_enderium.json"
-hash = "ca3b9a0ac57db0059edf7296e7ee23beecc000c444f24330aed076a869ed80c4"
+hash = "3b78549b4fdf6fe67c068b93af8004e5eda2afcba902fe2d1373e4b8cdf55a54"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_gold.json"
-hash = "64966ea3c2d8df2906d933cba63016dc85c736562a48535638182d31b88faca5"
+hash = "5afa3af6b05a5227cfa2562f1fe90928f606ada511984f1c1241512a591ff4af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_hepatizon.json"
-hash = "21edc7dcdba8f3fa899bd000964624d09bcb7c4f9dd395f7f842458a86282445"
+hash = "316172a03459b17842f340796590cbfe1000e1b6fe424c088a25940ff4758171"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_invar.json"
-hash = "4619162b01088e72e2b9811d0e86d2086dc2bd34697e9ffbf79481d3c46202e2"
+hash = "e7167bdb28ccde828b31d326a4d63c73cd2c81d83aeec6cd6c96aadd9d1dc081"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_iron.json"
-hash = "a57a4b01bcd33ddfc7b4f312c759f0d697ff852fd6941b560a18c31c22aae441"
+hash = "7c0b0b1d8d93f714b2cf82fad116384d2a06efcd3dfbcfcbbc446949b773c29f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_lead.json"
-hash = "0efb598dbebd2e33477101a8ede73bd6f029dd0e8d07e752296bc67a92b5a777"
+hash = "3233afb61560900813423f0d6fdd93fe49305b798e3ed57a8cffd366b78cbdd9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_lumium.json"
-hash = "657bc36984cd1eb309b5bdcb36c8d19653df430c7c7e2f18b49a874c542458fa"
+hash = "5a0d978943f9afb677942ae4ff5603300c01cdf893c83fdfe73cb34cbbd1ac28"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_manyullyn.json"
-hash = "9f58935db8266f2d639a94bccc57b9301292beeaa5da72740ffa73ee0159de99"
+hash = "55c0af9248ece194e22a538e8d32fb60668ee3334302d6e0259726e3cc720cc8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_netherite.json"
-hash = "637098b1ec04699b45c713f878aa3a4412b7eab664c219b9f3aadaf476839557"
+hash = "53bc3a973e4f3a33bd5801f8cb176e8deb9c70ef189d318cace93f291f1517df"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_nickel.json"
-hash = "8170d623cf8317607e696deed6546afd9034968794523ca3b688a7f2341f6b9d"
+hash = "a1ccb8418658c087770491ec9f17c63c2ec677d934e6eddf056038d85e07ca20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_osmium.json"
-hash = "337a9430e5100c1605890bb44316d768dab4c09a03f0fa70af7d2cef972d3811"
+hash = "9b77261c76acee0c5b60fb377974f4af815f22dff176273a2fdb05e9948ece56"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_ostrum.json"
-hash = "958899bd6592f9d6e94ad9d5009f0e31434f7169ffa17c1dd84338b42b124fc7"
+hash = "0bdc57b864519dad5725b91c670ede47e6e76d12b596a7e04081d47b4d757817"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_pewter.json"
-hash = "4102fe6c6bcb1a71b43bed2f7a60209837daf33f23351cdda99e8dcf736f60bd"
+hash = "e35b649b909a5410dacace9afedc5d8e58b7e199b376b6068245b6d68c84e6b2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_platinum.json"
-hash = "2e5530130b15eb808bc839138199a1b6d1ae655b6a8e44b3e055febde178814a"
+hash = "7932c296b52cee3be6ef681e4296f2f124fe9842622e7f792401d09cb0b6432c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_radiance.json"
@@ -6686,15 +6698,15 @@ hash = "0e0dcb0f9d99428d095a289de4db330f2fdd3c283744cdbd01d44b27837102e0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_refined_glowstone.json"
-hash = "6bc1dee736bc59770f73a2a1505e3a5ce40d4912197f1c2eab7b17924d5e8e3c"
+hash = "b3e357aa9fa516213477c288487d849195d89ec665490ad67821ef4be4659cb2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_refined_obsidian.json"
-hash = "709945329aeca2d6c1619cda7cc6045ba93af8862baf6965190876e6a3d84b4f"
+hash = "76bce048b37902a8c6f89058d66efbba40e2647b20a0c202acaa365b2fb210e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_rose_gold.json"
-hash = "6973deb4c59a43c1e4659b537d86a31ea23047524db952c7caab78b7c48dd94f"
+hash = "662367a2363c84e2daa36fcbfaeb93e196cd7b54fa24a615a86c911dbb8caa5d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_shadowsteel.json"
@@ -6702,11 +6714,11 @@ hash = "86ed0a8d47d4558c577cddb3e928d59734271e3661ed517e8f87cb4a3b9ebfde"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_signalum.json"
-hash = "cb23542cd8814f37ec9017c8ef30655af0e5d90aa62bf7708194e0c50705b166"
+hash = "58bba14c202856550034bf9572634e9624d41c3c34be121320947150c080b6c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_silver.json"
-hash = "38186322c1fb7032f385c76d3f65548fc1e8ac6ef48a7fee6923a9bc226dc133"
+hash = "015ef94b81721feaec58bf8101e2c91a3ddf080e59e75be7645fb184772396f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_steel.json"
@@ -6714,279 +6726,279 @@ hash = "3a66cb8a6c2196bf9daa698a78e4c31094e9ea3e5be4d9cd31ba134c23a92c68"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_tin.json"
-hash = "43d87ea75193a3ec54947976dc7751ea9c6204d9df689901223f1d4471eb234f"
+hash = "e5295e3fd51ab8aac797e250a587a25b211487f10b4370cde1a08ffe83b06903"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_tungsten.json"
-hash = "72c6c00c53443a6a085a0dff6c9e0d6347cf319bdbbda0c40560f6e032344ec9"
+hash = "698fdab5095b9cb39fd2fa9a14abd3fe75ad9e5de74fc8b330a6bb5657ae7d60"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_uranium.json"
-hash = "8b75a6fea8d5a0a4ea15158a8d0a7957fd1922f2edf52b1358a3f69502608139"
+hash = "b7224b275824e69900c4e9f9a51a7e8ebaf50553166e9a41c50907f9c286c13d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/molten_zinc.json"
-hash = "9b28a41a992bb7d2b4122748639a3f32cafb5e6769ac2f13a982993878965164"
+hash = "8ae0ee8d0a94ab1dfc6b5c7f1efe7144df049a5c7909b0b6b0a7e4510303cc90"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/mushroom_stew.json"
-hash = "3ad7f88a7943679233028df8040f31946674bc2cb6ff1b8d0d1f267f3749f878"
+hash = "245e0a44077a74ea11bef6910457af7c289b57a659b3342a20f2310f9b22172d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/potion.json"
-hash = "f437e0ebbb8481b22cb07e7228570b088c83fc7e677cc827d4975961d9bb48ce"
+hash = "f52bfb54c1fa481530bd8d1fbada80c6f4d49e70f067e185e31a050bf7229721"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/rabbit_stew.json"
-hash = "e0dcfc3f0957fbf3bd60c0f2e70d17a94393be37d9556bbda605ce717b6a7bdb"
+hash = "4fb4ff50f40d98410df4f2df75d77730f2054ac13fb2ef6ed960bab7e94ee94e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/fluids/slime.json"
-hash = "76c54111f3557b5035010de8e1c12305da5b73c7ab2fc38e880c0dc488cc7308"
+hash = "9ffa2268900d39b4dcbcfb7022b7bc977c16839dbe12b60e3b7663256917060e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/andesite.json"
-hash = "c53cd15eef542f8ddd636a7abe5f642cc9573a7d5a56f0e1d7487d4974723879"
+hash = "fb91b9d15dc6f89fe328704bee45ffcedbf6153e2d0ce6b433543aea010f8a29"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/basalt.json"
-hash = "2cfc25450d38885f00bd18e65d47708cbc5b3e8c949882d19ed24a2c4155f084"
+hash = "0b7fc218119ab1d015825a75f1d35d81a9efc750119f471d305b15584387b49e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/blackstone.json"
-hash = "bc5e06bc82b8aba3ba9374b83416ed98eb6977432c2acaf42f4a7c665f400861"
+hash = "7b23edd3e2b9bba6d073dd94b609b8867d3fd48cb720913124875d395973a8a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/books.json"
-hash = "bd3d62c54b25336fff7eb285810f753d6e39ea028cdb67d0703513cee5d22672"
+hash = "872388e6318ea98c84315ff1e9d045322c9adca6e7e7b993ba6e0cc74070e28a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/books/guide.json"
-hash = "c797cd22317ee988fd4ba019bfb04584edb7d46acd51ad71de83548d0c7177e2"
+hash = "93b0a3f9299e8777bf3b8f51e9f103725ed28e472c0537412e6ed9fa1e9724f4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/bottles/lingering.json"
-hash = "96cdce1f595ed460b39e9fabed14959073406c2137204c84d4f1b2e23b33d6af"
+hash = "958275cf2c4fa8eafb20dd91acb461ceab171b742da1a8016d6942fc110f83bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/bottles/splash.json"
-hash = "30de47646572395f584990966946a1851cd512977b9bac33dc7348226e0b5d5b"
+hash = "ffd816d79732f6c4578aeb6f5ca5efe379737e104ba2be30be4cb364fdbbebb8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/deepslate.json"
-hash = "a2e6f0e128e6d3f32f91dfd06fdc685c586ba44f7ae2d142cbf8571821d9be10"
+hash = "4a0d835106d7c991867b46b6b921986a0f306e2ad05f5c56c009691745755b77"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/diorite.json"
-hash = "ee962f9f87d9789ca8bd94882b3df085b9c0181420f4ca45c637ebe10d5cc8a3"
+hash = "e75d70638088df3c884928209fdb3a95265051aab076fee9b7a91b86af5bb59c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/fence_gates/wooden.json"
-hash = "17c56b171b4500563f2ca5ecd4db54beb9c7f884b745c5424c17e0dda9332835"
+hash = "67434a31332ecc148418352793569a5b4bbb45e579e17ce7ed3004b018e02ac1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/fences/wooden.json"
-hash = "ae098a75e77b7171e2cc2c84140712f6222cec2bef2fbedaa5ec1479b3db0cd5"
+hash = "0e273a253f34bda33a81c36c0ba4d5f6bac3c0fc9ab143c62abf1f6d60f580d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/black.json"
-hash = "c3b3fd0e16c6831eb6480129bc14f98c40e93a18622af153dbb48dd10ff1b82b"
+hash = "c9e1291782a3e34330f43f588fa6f8b97d7cab8f81f06b63455edf5807d3c093"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/blue.json"
-hash = "c796b6d9d4252b7d1d8d01b9b923c90b3e620962c763ae5fc7d4561a982dfa2c"
+hash = "421b02c0efb06d0bb63a574a256c24590963a5ec61de3e24c8d5f728e93cc215"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/brown.json"
-hash = "83c5fa6272142933825b5fd33b620a32b748b180e4faceda28ac82ac2a149fae"
+hash = "0c4d433a55f5e564d69b2134cd0130c87f2731c5d3cd1d96828bbaa6a7cb2dd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/colorless.json"
-hash = "2b073269cdfc92920e0d5cc6b8b78cd2c7ca5a92c670083d6c80ed9a6f9feca0"
+hash = "42e469f0a18dc2510a79f0c6d4f1c4ec396e72509702ba8c3de9da86126df06b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/cyan.json"
-hash = "21d4de9356fc0b0a50a0ff29620b05a41a13afb8a83b27837b76494f6019ebff"
+hash = "a1446b55e68652112d798765b7deeaa9607247e6d15661ee32b0f4ec406563cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/gray.json"
-hash = "0ed4034140219dd76d49526066ba942c9653bdce1d0c919ac67eb0c1e38989d1"
+hash = "916c07d274d434dd058bb74c22505cdcefe79eb8cc0f26d32bfa8a1b87d75936"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/green.json"
-hash = "2ad8c4648d890d9c2d1be3bba739a3e1e83c9c119c006e8147ac94eda0f6a1d0"
+hash = "e52fb0bd732a968d8012c20c15b1994d24dfc2424a07bb22ef45230a5cf018f1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/light_blue.json"
-hash = "7fe685dca3aa7f3012b23f97cfdc9b0e186d561d06f97db2f6a18594eaf765a3"
+hash = "ce1cacc28b20f071e41e75555223181b428b32c0d440af53b1d7dcdafc946a81"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/light_gray.json"
-hash = "02b812f9d6331fd9990471de63280e70a3320a6714eafac969b4fd421ce28816"
+hash = "9f2b8f8f2c8072c014fe43d415323bccfc023355aa3feb4ea9c887a74916d71f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/lime.json"
-hash = "c84a339a59a189a53cf21554ef6a15ae1e50e030d57c5b8b61335abf3ab9cff7"
+hash = "bd0912427265209c4e3fb43d7cdd769ebaaa87c4a24014b695e742f006590b30"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/magenta.json"
-hash = "300920f4e2dbabb71765eb3820af82b93bc608993250a2cbeca48d8a6c49334c"
+hash = "3ef0ac5e717efd9cc7bd8c275c2fd130ca5cd0b6fb4aa401feac2a4b101fd7a6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/orange.json"
-hash = "ce053de54f3167b5a8da590eb3a134c2cfd015c210d1f148aad45f4994c9b0fe"
+hash = "8e4f4387c1c99fcb5c2ac7efed0a233be4f66670477efef89bccff11a1a56eac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/pink.json"
-hash = "5cf08d82e9b95c2ee6cf3b25ea0b80fcd38aa8f55204d315fe504a57340b3a58"
+hash = "3b356291f0eea8e927833b2c1615b5aeb6b772db8c568aaebeb45296b1600f97"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/purple.json"
-hash = "5e4852055525892dac79d16e49e9dbbb732955def2a87dd04bf6746bf1a5f899"
+hash = "108afafd030a899b3e91a076abf0715fbdd4eb1d1c747e17e64ef89db0d451b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/red.json"
-hash = "73905276e83dbcfe5cef249683a4b89132cb72f193ed47ff9d94c9b540ff813c"
+hash = "728fbee7a6f5cf050aa53f5f2f5b5569846bcf5e78de3b1a505d350ce3850eab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/white.json"
-hash = "3b4c1274cf9d629b07073cbdf2cd3ef84cfd3d3ec3aa07ecb7c1cf15283cbaf6"
+hash = "c3210a5da8af50054bf96955fc69a089b64a7445986f9927348f91827b97a8fc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass/yellow.json"
-hash = "887c902472a673ae8cc28169da3c2a90eb5223fb45b25e4bceaf2ba0d7c06c9f"
+hash = "850d52089d5287abc7461219f66a1e418aaeb34f666004a1a4af140f1aa0c268"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/black.json"
-hash = "662b9893f10281c7a44547776dc3636e29b90b982ce655c5184e0371951342ee"
+hash = "466f1da48583f1922d3fd1580cd323a23d47a896315ff79d4cac5a5e67e087d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/blue.json"
-hash = "94494305b640e3aacb80e49a3882a6eb28c6c21f5c0baf703944005ab558f7e3"
+hash = "d0b98f4468d79ab6e5454f928cb721d261e6460656061bd6fb7a39d04807dffe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/brown.json"
-hash = "7c142e30f0be686f7464a02ac66bd8abe887474777bde9580c9ff2434bbe4ef4"
+hash = "26824b859e16b3fc284f2ed556aad9fba97d41b87c26c8bee642a03766ed77de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/colorless.json"
-hash = "79dabe7912d5ab5c1cdac9779c5ab298b6869e7ef8d970dbadeca39547a2f790"
+hash = "336769d6d4c092fd02a07fc4976724aa9adb7fd85617de1ea3be45481c67a1eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/cyan.json"
-hash = "c76856cac200a6c982c1eaa83126d16533ef99615c0f7fa6d335a738ac1c4402"
+hash = "baba80b42c1fe2f8f56c2c16d96bb060a8f8b4981e9f536b6950e2096e2739bb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/gray.json"
-hash = "80b39588a09350d4627eb7736813d4105bc08d9fcacfb4cab2d3e59675ecfd6d"
+hash = "73d20ceb652f6a332c8aa93a287b9745ffad8273afcb4ae46af5051690dc45bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/green.json"
-hash = "16bbbfe979ab5d9a7e410e8eeef0eae1a99b453e40a944e072886e87edc9dec9"
+hash = "43dfcaf474a7286f57457cc34189dc8b9b53ce23984b6cfed8d1e4e4d08a1ec8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/light_blue.json"
-hash = "efb7f4ed068fc0ff27c92961c2f913dedb247a7caf08bdef668f91157c66f191"
+hash = "35bea022276fd3019dd46251780fad1ba23fec8e2cb31088a03ea84619152689"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/light_gray.json"
-hash = "bd4ec062bef9963e6435b5468310ca68872a93c79670537987f4c5fb33dde912"
+hash = "02595f3836bb0e55af782a21b8e76006aabebb716199d95a7520a731fff7d0a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/lime.json"
-hash = "b0bd0a84302acebcfa8e49f55568f9728462096cf32234b21e231e7163249635"
+hash = "66c5ad4b74799d054b5c8edc4a5f25d855767616e668518f3ff5be83069d3c7d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/magenta.json"
-hash = "157607532283d5de8944aa81841caed6890e56f78d4994e4dcc9fadf61ce0a58"
+hash = "805357c76d000f9e15b958dd7e73bc655624905976a7d750aa7d31bd4b9977ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/orange.json"
-hash = "9f2435fa40e23fcf7869cfee2c4627813c712ddeb10b5f3e5a41499cc0afc87b"
+hash = "7b9ee108dcfe25548b3eb65d95d7255280da48003ee7e96dd2414945fc9dbd4b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/pink.json"
-hash = "60722d1fd12deb5729a8471d83e9e611e0fba3358860ce5e80165681952ecb32"
+hash = "24a828968f6aa3f11f3abbefe81b0be3a30c9560b86e79e9f77739517b102045"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/purple.json"
-hash = "a968dcb0c5fea2889423c49b2a1ea5e8baba78e5e5bbbd7ff9a1b3700fe4c984"
+hash = "003435559515b39f375e3b27e67436f2004afd4c821df13286eec763018de9c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/red.json"
-hash = "86c3bd9acaec029c5bf639b7bd18360372c702a8c2faf00ce8a8fd6dcc1a0aaf"
+hash = "77debee4fbbb4883f118aea56eef4522da66bfb83f7bb23ed0dff035dfa05268"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/silica.json"
-hash = "d4ba61f5e84d9f76972edddba8d4d6f6220cbfcdac623d09bbc89cc181751d74"
+hash = "344e7f1f4de837dab976cba25bb12f0c098b6a6bc84c318b92335d01e91a72c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/white.json"
-hash = "8d83c0f1ed8a28261b9610606e91399a39d7895399630034e2a1fabe822db1da"
+hash = "0a9e032e30df70ed01a0c516307662e0475b41f922e17c576626a3ff9a0467c4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/glass_panes/yellow.json"
-hash = "7dbad57acda7f21822af8d7b04de33180313c53cad4719ce489e3ee9c001117f"
+hash = "11782a9a805aed01d2c8b19d2de61fee7062f1ce208993b35c735a8b4ea5b822"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/granite.json"
-hash = "8f75e980eff29c6a8b900d3dc6f2b5fb9a4578ebdc1ca33f2eae68c53b00c15b"
+hash = "70ac1c093c1283b7d2cfabb875188ea601f6e7617425a9f7f01a48a6b23535d8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/heads.json"
-hash = "23a5712ec137942d0f8267f1f9d2d3f8fc63524a6ce2b867b820876923957f5e"
+hash = "4b21a570b6b6ae98bd9d4f2cb4dfb03b52d1ae40e44ef7cb2acfd3a27faba6f5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots.json"
-hash = "2a667e3280c89cfbab4e13ab1d74c5b57212ada87f7513560fde77d2dc0e9863"
+hash = "3df78fc78a4f7d7b910972ab1742171530013af365ca92f212bfea7ddeb41ed7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/amethyst_bronze.json"
-hash = "53820993d6b5514b9dc53f0341f1d9ad21d685c22cbd53fe5a077a93c227af77"
+hash = "343877821e992edadad95663b8ab22d500d426cf3592b979a1fe4088d70af804"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/andesite.json"
-hash = "3dce24872e219dc721cfb006ffc58ccf21858b149b0ede90875c33362ec73163"
+hash = "6d1f28d739d40eb29ef660cb5e533cae2f4980bf9ee3c7f5d41026ab98aeae88"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/calorite.json"
-hash = "d1d44a7a8eb171fc6d543ab8a022c5649c0b12980c4e6dc95959e84343b543d0"
+hash = "1072f14ec897e23b3bce9d9a05f40ea67164666772a5854fbb915f52fb58c743"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/cobalt.json"
-hash = "21223ee75a0282fecea566c05878f45116f4eec7f23416a7397c1ea0cfae7eca"
+hash = "a2af8e411f8f5a3631e0b013592e31be35bc237cfe7b9453fbb187de4fd55a9a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/desh.json"
-hash = "069ff471ad75f5a3d147f1d88717aaef79858e77e023577248fad56c7e69a7c7"
+hash = "e1f65e924f3fe13e51c1b533272b523e2bbfd0d70af77110a012eff562a1e628"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/hepatizon.json"
-hash = "dda7912682ccf27670ccb76b857939e8c9b09af7cff34edd502acea043077ce1"
+hash = "821b66af65ab764f2f9425b6fa0b960f42e8aff63be8baa83a56c27298c420e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/knightslime.json"
-hash = "aaaa8530ebc41c285440587be624e3b7a42d112d72f4d26ba21cb42745ffb376"
+hash = "5b5917743d7b7db6018cc2e57678b1e27c487baee100dfeeb43140ea49ef1eed"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/manyullyn.json"
-hash = "f39a3c3fa052f91f2183ed3a987f99fed3fb30c052842652042249a05e7a80db"
+hash = "ef9e20404c69439ab08a876f1c5a2d8bb6d8fcf550151964b880b26dd1b479cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/netherite_scrap.json"
-hash = "511561a35f61cc4747de7be3d328074938c5acb6d078ee90bbe117a78cfa1b4f"
+hash = "f2f281f458765d9ec87dd25121f61c4e73c208310c4d70b9e49f8ead293e7b94"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/ostrum.json"
-hash = "ceda07be722f467b5d86b4e41e67866373eb26a89371bf2d79ccc0a4b3bd7561"
+hash = "f06eba5a9a8b732579f0a1b5391e29141c2b9ccc5b222f29421332ff288972d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/pig_iron.json"
-hash = "fe4884500871498d8f5180f982fc2102472e5ec4320bac9330b045378d77282c"
+hash = "ec8b937b40418a26af07203def9634b31e0dee4fb48f93a2c61378ed07f1ecab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/queens_slime.json"
-hash = "e64d57c8c32b7b9e272545984e4347ead3ec8cd5bbc90569f218aaaa27d74de0"
+hash = "5702a8bf6c9392ba7f80e969acdf4f96206010e7854508e8c73240c4b7b495bd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/radiant.json"
@@ -6994,7 +7006,7 @@ hash = "111430ed62b19a6753e9a724997e318fafc341b1e1da27da00c41e2917be345c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/rose_gold.json"
-hash = "3ed309b98d7572292450287f35b5d23efb2b22f23e0fa05fbb7c73f2da7b73fa"
+hash = "82a7680c7ec0dda596b1162f6dc285d06d1b19495edb9f1c34606ab76909e060"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/shadow.json"
@@ -7002,87 +7014,87 @@ hash = "7c39b94a8bc570792d97c81dc6eae087a4fe945cde563bea316137c9479196ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/slimesteel.json"
-hash = "73065522f672b9617abdc108b63e04b073d18c6446ad90f029e04ae40fe25793"
+hash = "8883e661a3a31b1c6574ccb755a60cdeb93d563f25b5a68e02291898923bd9fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/soulsteel.json"
-hash = "7f10c9cdf7fbdae24da73b3ea4f54f9fd3bf027f6911348d565cf9320069dae1"
+hash = "c64ca71f5713c806bbc50e52c0feafe0510f1e2402214f5d221ba553c886f42e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ingots/steel.json"
-hash = "0e856433d31375cd817b5f04042dc7daa4a0eff29cef4e91ed3dbeff848ab2c9"
+hash = "18a86f398125153e4ec577663130e5705a6d60e605d110754b6bd2e558bbae8f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/normal_stone.json"
-hash = "1a7aecccfa448914114cac777ad8816b406e369f6ae1d844b9a1a5391a2eff0c"
+hash = "604fa8ce1696c58a1969b827c835d08460919f46ee018f2264f08e09833f97b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets.json"
-hash = "dd6715081910206e35c3a2e68b6b6f46e97f7e1654296df3327c3666a2c0193d"
+hash = "81186fc33bc723dd70c493c142ddc231289466609b69d66d3abd5cf6fdb7ccae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/amethyst_bronze.json"
-hash = "c52e8a82a12cfdeecf7dede6187449600a707cb78176fa6561574c2e8ee6c2dc"
+hash = "ccf95a190dda08dff0265a5448ff4fc35160de2249d908fbc2b0e268f47c1ce4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/calorite.json"
-hash = "2a4f4924bb3b83b12b1b207610cd4b31e2283e83c476b15921e69ced83c83566"
+hash = "4ac4707d3632fb263eafcfa9fdcd583d91b1c45d3eb6ada8aa19f9175470be0a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/cobalt.json"
-hash = "51f286160285c241d606e8c8ec486291cb8c9c4a53003e7ee8bf72caac3fc03c"
+hash = "59467eb572e2d9c6894e8b06549c1407a9acf0d91fb2b9107773fd38ff664af7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/copper.json"
-hash = "428bec9c995d41c9100a733d9a7a69542d0a79a4219825ce6b743b44325badc1"
+hash = "1608a6e3f8931706b768d4e10ea3cf50058b959257ccbe4bb307edea6b13d1f3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/desh.json"
-hash = "f77624994640eb38115ff9b7df1db9f80e94dcb4ea0d63769a23347787898c24"
+hash = "cb1f7450de9c950ef6ba145ca8539664901b0d832c9f306813ca3f81a626af95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/hepatizon.json"
-hash = "ce608f1748cbc4014eeacc7de384879438fddbcd019f0e18c09faf7a05853b4f"
+hash = "f99165799a37556955f5aaaa7f3bb0f3c6de8c6e0ff2d417cec02acb000a159d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/knightslime.json"
-hash = "b4ca143f77efc90e00f186eb8d609fed7927d4aa90b843daf218a9cfc065e3fb"
+hash = "6c19a90b8e162043298c59e9095889c25c45d46ee10e8a61501c6f31d97b2669"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/manyullyn.json"
-hash = "9c35665a75c41a7b809ed2b620bf22786e4898ddff4e6535db288a8099eafdc1"
+hash = "4b0d91faa3ea0f08c36a1dd493dbe28c54745d8d94001ff7e597c60da947867e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/netherite.json"
-hash = "5a3e9c1b2ddf932b3978244356a3da5b25c7e2fa0f1b774584109cbe4fa1e6f5"
+hash = "05c701ebf50bf4aaaa7ac2df30f500b256ea1c624a22e925760320461e941768"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/netherite_scrap.json"
-hash = "d8f54c7d459b58a98117790f14e396b5eb390f4736a3d96009ffe1e5952c3faf"
+hash = "89a837a6f85b7359851bd4cc715e4b8d08f3ebfcab02bea7d37cddfda56afe52"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/ostrum.json"
-hash = "02db22cac40b8f30138b7c93feb1a23bd0456293de104502c3aaae62d7b663e0"
+hash = "2a729b5703914cdce032fd703b5bd093d74fdbc0fc0f892ff17446dfd823e525"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/pig_iron.json"
-hash = "8fc8a9a2661e2f8e867d01f41baa4f28f3522e570755c1257126e668052a9ec6"
+hash = "7435c8ce7cf84327b62ba946514b5f09944e12265d0e36cea322c1aaa9e981f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/queens_slime.json"
-hash = "1420c890748261d3ca3cae9a06de43f36049984b84d578ce92ce3eaa6460e8f1"
+hash = "978d282460138ac2a972e8021e652e0d1040e4236d32e5da3a78928c517688ec"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/rose_gold.json"
-hash = "9ae740349aba67a16a6c90fe3fa3fb03344626d302f177e658957439abfce61d"
+hash = "ab3ca885b30cb6f5f136f3e0a4c165e855dd8f77c2291ee7ed717f575dcfaab6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/slimesteel.json"
-hash = "a5474caa2ec68c255b6a001bf0e3c1b5c97d9e52c2861d7807e0dc5a792bcdd2"
+hash = "2acb73a138a59ba9aa602e0069dbef013d494173158da1e1262fd7a91f8fbc62"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/soulsteel.json"
-hash = "3123b676dcf8d4c3aab29b8063eadb82a60123f419feee26866a3d63adbc9ccb"
+hash = "da846c26a26cca5b5b8b5fb79a0b9143ee54a04f6c87ae55d79d6deb1a7c4c46"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/nuggets/tin.json"
@@ -7090,23 +7102,23 @@ hash = "d7ccbcea224ee2509da8cae03abc0dbae768bea39275f32b6c8b6a77671d8624"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ore_rates/singular.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ores.json"
-hash = "ff23c89824903aba26178e30bb50465ce807f9e1cdb4031a92bafacb840a8d08"
+hash = "390f0c382499ed29ee6185c8a3968b83cb7c3f4a1bb4d1988af4a469fd33cfe9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ores/cobalt.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/ores_in_ground/netherrack.json"
-hash = "78a7d80b56640750b62311d441b878a3169f8d54010d12ac6183c9decde3a6aa"
+hash = "808aa92916785a323b0b90a77cd413538432d49b6d85c090d97ad3a7c4e26e0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/raw_materials.json"
-hash = "6e410a67205c18b5e5de79433d199c6b1975439588d2549b7d439b8d28376295"
+hash = "1973cbc325979427e3c8ace5218ff2eb808f71e6b378cc04dd4435f0551d80b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/raw_materials/calorite.json"
@@ -7114,7 +7126,7 @@ hash = "7875ed643e542b4966d0c6b7f0a54edbed66b89d7dad99575153ff32689dd237"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/raw_materials/cobalt.json"
-hash = "9ee83b01b487122c9e8ebf040f10a15cd4ca24678310e8ca2b0c6f251d1b7de0"
+hash = "21484b6e867bf0f33ae42f0723192bda3f2ce0724ca159ea62267a8b79a4cd49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/raw_materials/desh.json"
@@ -7126,115 +7138,115 @@ hash = "1e3b8d5e5bacde6300844b4539e2058ce66420a1291bd673af3ad1ee395c4228"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/shears.json"
-hash = "5337b31980c4658ef60a07240f59b07dc67ae59261f7b5ee915d9aa85678eda3"
+hash = "c7a3649cf841a0341521a116a89e7a958a8150ccb9d995a9eb17da6cea330d02"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeball/blood.json"
-hash = "ec83a8c400d712737b2a9d94885056f8cf9bf8e683af1c929d2cf8c0e906ede8"
+hash = "4424e2d64d8a843ebea43a75889cc12ce7a040549e37286f1e6e6cb5218218e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeball/earth.json"
-hash = "990b26d055d331fb49c496bcb5c3a881168de271b19b91f3ba2df909dc6df807"
+hash = "8495251b4cece6c52c0bf9b48bd37ad0b8d1bbdf3369edac4dc17e8198650b0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeball/ender.json"
-hash = "d6fd27c4eccc1e3a37152c7a6059ce05bf8f767057cd7455baa24d941cdfa070"
+hash = "2fb4e724ce12beeb85bf90be963ab744d21fe11fe91b044612d5f5da54717466"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeball/ichor.json"
-hash = "3fd978ee7f11506503caa55194d83518708f5d5074bbddc8144868328e226ce2"
+hash = "7f733c663a6213a8d96d6efc0443ea7529c2df6e6f708bac38fe3d3729e64519"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeball/sky.json"
-hash = "ef78d22e3ff589f067f6a76621afd6c112db48750add2577c4ca2d394fa84de4"
+hash = "1fc6e139ba5c03c170975f9761da692af72acb0415bc94658fbde25382b6b06d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/slimeballs.json"
-hash = "98cf0a389c30627065c4038b63f2ab37aadb6be0a2253668bd86616470bee9fa"
+hash = "1c2dab121515ec375516e0d52280cdcfd40bc291eb8fbd930e154a2d07692124"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/stained_glass.json"
-hash = "0108f8d858d426b8591ec5f80ae842a54c687e23e4234ae6ea51c6cd67c33be9"
+hash = "6d67e5da679d29b395e674f93e15e4d5cae728810228256963fd9709c34ac88b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/stained_glass_panes.json"
-hash = "06f46ea061295fe5e32ba63e143da650de20a90490e1cd634bc5060b455f05c9"
+hash = "d947bb512c71d16e568c45f1902fef5e096e225b453052edf1f715dbb8cbfa49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks.json"
-hash = "0e31609167e26c78305df16dcca791185b56eb53141da5ac3bc7ff8da37e595b"
+hash = "193e9d9647db52b725a31e6307110d22d3a11ad8629907f98b18175008e20b50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/amethyst_bronze.json"
-hash = "863edd9e7d6269861fd3e65a6e8c8a13b7a3c19d3d9167f528de185e27c48c7d"
+hash = "3f911c61294f53fdd5e4d4eb8454d9b8fcd4a1f22036dc2bcf26a1098382e16f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/calorite.json"
-hash = "7aa505722af98aa0870074102a941160772fab44d6731c47336efd0c40a9bf5f"
+hash = "9894c4c62900032e989061793dc13dd49249871079731024cf031f1943703de6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/cobalt.json"
-hash = "b04af085bab54978faa2b15eb55a3814ad738a9f3738f1d1f839e84ec99cab26"
+hash = "3b03b6e1b27afdfbff8e48a9580c7120f19a5e93e33689dd38d6d1e6b43b9f7c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/desh.json"
-hash = "57ad324e1a3ddd818c787c874dbce3882d6f5a2a933b5e5299f7e453c827be82"
+hash = "cd6a0a53a59bec6328d406b9de6e51d5679b08c6fb57241a8097eb18b645d3cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/hepatizon.json"
-hash = "66a3745a12db74fce4d0d25c3d729a85365cdd914e63d16b57756c161511d6c4"
+hash = "66efb7ac476b259997924596cdabd347fe1a1d141cfe144575add4e25ebe1ec5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/knightslime.json"
-hash = "ec976ede8aad36f25042b723e504af3e6baa7a9480222f28dcf927f7ac8125fc"
+hash = "9f9624b4b0797b91b0c1de01f7848864a2c3fadb17480ccac42d6a6213646e46"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/manyullyn.json"
-hash = "56969ab6116584c34ba9c313674ba5cc0154f5d5144a085c36b8aac064c194e4"
+hash = "a784e45c46f2fcc4121c251ce820564696f78a511d6ec3e7c063c5619401b893"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/ostrum.json"
-hash = "e25e3dbb208722d622671a36876dc35ca2f9d88afadf2a29be8c066e7b0bac26"
+hash = "b2bd7641284bee0976cdc48828a89a5e4d105c5edb76dba8e13f7f07c86ef9e0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/pig_iron.json"
-hash = "31e7a9c140dedab3227137b322a6413187f59653419e52f75b738c5dd35cf7d2"
+hash = "729bb31568f8dd61ae4959a78c7c294fc0c8f52e9dcb0d3443f8636688900cae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/queens_slime.json"
-hash = "96735a65bab68494433f4baa6d216d86f75e27d3adce5980df8fd2ab4749ef7a"
+hash = "b6acfe81b7e004a99674fd9b9b62b62636e2caa8af4b60920488a33c06ad138a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_calorite.json"
-hash = "6e407b06523b417e05dee520cd8e2b7f0c00a4f17f2c411df6ab6e03f0fddc95"
+hash = "2f51cd1a40788ee51f579b19cd72150533b3a74e53f2095a28096dc1206dd574"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_cobalt.json"
-hash = "66ea0987db6e75d57ea075bb4fb490068c2fd37a8198b4763d7ad0f25a1da1ab"
+hash = "245f683710b0aa34e6b7f0f6dbcbdceea52147618ac05129d3790a07e263e711"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_desh.json"
-hash = "b50ee0df273e7353e50d3ebce0d22920a0f025579f251b831065fdb151b0a525"
+hash = "23aecdd690b08596343a1bfa8588e9c2033144da7d342c1fec8f9dc7c85c6cd4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_lead.json"
-hash = "6057cfc2c01fee853fec039988cc47607c4191fe2d992c1aff8a9087912e9b12"
+hash = "2728d5e253688aa326e2c1c7ef47534e5cccef22bde02124dfc3b2f81dda9156"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_ostrum.json"
-hash = "4ccc55f2397980f980132d31db6885350e1b50a533542dfd02e5fc92a3570b3a"
+hash = "8c6b1964a92731be20312768d142e40e69bffb989bbd165cbbdf1ae86836767a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_silver.json"
-hash = "b4fda80d947e43f7a37f1a0f1abed61b629b60b9e8b7c8470579eec8bf3ec57c"
+hash = "c0616cbcb653aa00247e0e02f66daf809088f09d08f14ee3e31e3cce9d1c4680"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/raw_tin.json"
-hash = "002eaf8dc6a377adf7205ef85b8c1a4a624621cfafd09ad7fa7fb4df486b0d08"
+hash = "d227ddc369d9e0d40296979a91802779314149218f5c64c7f68463e85e0f8247"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/rose_gold.json"
-hash = "13fa098ad43cd0775910c9a5b81d56de4918e9ef96b25f81db617e79058cceb6"
+hash = "5d4a2792d88dabb7a0e3f88199ad65c7f210189dda3a3f369d35c7ecf2ce50a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/shadow.json"
@@ -7242,23 +7254,23 @@ hash = "2c7a613316670388ad267d7f2c3554ca260a09a02290ce89cdbde9c3d094ce2c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/slimesteel.json"
-hash = "32590e9d53724240f7e5c7f11565c4bd2d7f297476742d2077817567c203e4b8"
+hash = "444f9007a0ad1b335eba744fe2b51e228b7025e0819b697ec36874af828df245"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/storage_blocks/soulsteel.json"
-hash = "9441e7d50b306d427abd3e288467b86f0b4e6e03be4d10cc4e98587cfb758a4f"
+hash = "d663cdf624d5f17b90525ccb03a7b98e0a4f3aaab9a17d3fb9c63d4700b82169"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/tools/scythe.json"
-hash = "4391aff901c73ba883c78cb1ea0a24bcd6d2b240cce03a708150eec0d7a08fea"
+hash = "c02e7724c2aca78109352ebf9908f3e39693242f6cfe4aa15a8afa467f593c7f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/wither_bones.json"
-hash = "48e72d22787b45f28f8ae60205b4070b6903fb82d1f03bf75889a197edac8abc"
+hash = "be0127742f9dd75f7922fcd9cddc6e94cb9a94b5ffc5b01f1e190fb517ffe57d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/c/tags/items/workbenches.json"
-hash = "0fd557084c37fcd7e108a50f6b4691a7ec5568d098b67d18f40b8b9ec6ce8378"
+hash = "d68b4f38bb5bb3496fbd055bf98d6feb1949f942a6cfad939831f369646bc287"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/lang/en_us.json"
@@ -7266,47 +7278,47 @@ hash = "1c62803796b092e0d18646481e6dd5420a6dc5afcb0dfee4e298b4dd022409ae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/gadgets/piggy_backpack.json"
-hash = "75b6c92cf922f9d25a9198c05bfc15d46ca3d0b3dcabf9aacde1246e602e617a"
+hash = "797fddd42cf7e067f1e6c65ec5d1bf47dfbca6cfee340657424067cba497fae4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/amethyst/block.json"
-hash = "8ea0413c34bb0fcf2f183468e5b03fe64cfe6dd025f1ee33a1f957088c268ebd"
+hash = "c082dc558f3c3840d3b35ce09af8eac1fe3463edf37541f395622bef55ff3a74"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/amethyst/glass.json"
-hash = "76a338c0d63c4a96922a58d5a2077dc5a110016de53e947f67233c4b25b57c37"
+hash = "eb1e1b30dc391294010a428b7744447606493b6679de031d263c11934bb1e868"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/amethyst/shard_gold_cast.json"
-hash = "4b1eccdd5681ccd9afef0261e363088986a6e4b979d7ec23cca3b0a62f02f1c3"
+hash = "0fa3dbd6579dc22f94e0e0300a3feb1a093d5bd4e3b9538b1da4f931f10e78aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/amethyst/shard_sand_cast.json"
-hash = "95caa18075252651e03b2daff1ffd85ed34342eccd0e9aac1d31bfcca071dbe3"
+hash = "eea3be4154760808258eb7717dc69408cf930c1490fe929fcba961c51c1ab74b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blaze/bone.json"
-hash = "eca4e493c0dbfd2246ac59ac731341322c79d4bb3d03322ad8f316b47747e528"
+hash = "812e4c9d26591d7195807c1eb9a780b7477a117d6a5ef10f1d4041a986fbcb22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blaze/congealed.json"
-hash = "d9a4a56c6232dcde66338053531a59c7ebc51076fe1fae59a4fa6886ccdd6f1a"
+hash = "89e3b215768973217e3a6deb08a7d5fca6ea5409129786203adff2ae830a21ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blaze/cream.json"
-hash = "a1cafcc22bd9a4e96e056fad72b67ba23bd60f262befeb37614861ec285969e7"
+hash = "7515baa44837c91d2af365713594bd192de30d2e43bb744855080e62dd5e36fe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blaze/rod_gold_cast.json"
-hash = "b29c2c54e753a293e7c58ff3cfa67d2efc498fb84159c86ec5201e22398fee78"
+hash = "ea44e97b2a42ae4f996c83fbba7cd8f143ba4bbdb45bcc4aad331e257b8bad73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blaze/rod_sand_cast.json"
-hash = "84f0d86c7c45b81730c570f18bb8e4b0ad528cdffd8c617c22b6ca0132837e85"
+hash = "6318966025ac01347d4d218d183cc4e9eda63ac8c1d119a3bc0145e8895257a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/blazewood.json"
-hash = "b15006ac3a8c3e7948ac90ca22b88b6b1928d01d5cedd63be66d15631f9d6267"
+hash = "11c43041506092b859d5086b4ce1ca92b65e8838c61290d4c9686c9417477e79"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/clay/block.json"
@@ -7314,19 +7326,19 @@ hash = "5ab8416f2cc944312481ae109d05ed7ea52b4c66c051ca15a7af0699657c009d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/clay/brick_gold_cast.json"
-hash = "ef91ef07ee41058faff443dd2519bbf6852dca854aae24195daae7bc92ac456b"
+hash = "e4de6be46992a1bcda3059daacc03696aa267d07c0367391457eacfa95fcf23c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/clay/brick_sand_cast.json"
-hash = "32a22f48f0352716eb0f6777fc8633d936a19c0077ddf33f41dbda7ef8d0b46e"
+hash = "3525aa689c21d1d9dee974a30a876c66f75677616faf07e448e3e41e67c01d20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/clay/plate_gold_cast.json"
-hash = "766b5fd7ff98d16320b2d897576cc61bed71b3e48da8716d736b72b183ecadc4"
+hash = "2f0024eebf56cd858e0af34b930087a23e75c588b33da1190c2615ac384c8ea4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/clay/plate_sand_cast.json"
-hash = "fc7e5df8bc65269d5c551673fff0f06de5e9dcb6795530864f2f167a94cb4c1c"
+hash = "2d2f07dc3d2d82e30cf264499f9de28f144de0cb1ca23be90f40ffd460f1adb2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/controller.json"
@@ -7338,1687 +7350,1687 @@ hash = "857569e107f210d86b85c2a308a79110ba70734fd68a467d3c8173b80b669d3f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/diamond/block.json"
-hash = "0fc4a0e18672b2c4429e66fb44644baea113d9f98a9614cb877dad27987b744b"
+hash = "fae82a25657e04eb518b80af6ebe8eb4235c2ce663076d49b879995c03afe824"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/diamond/gem_gold_cast.json"
-hash = "f13d7a2e77171031bc0a7d7613dcca7394d9466d344b85445b7a67cc8a5131c6"
+hash = "5d098231b19aaab2b7b6b509d06404cda314e54995031f154e2592d6cb636dd0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/diamond/gem_sand_cast.json"
-hash = "1c38f7f921d842a3f59579665f2541138ae4225cf27f7e80150192bb6b335c5e"
+hash = "e311305b887277037cbb877fe54d628c0041d1ae1588964769d9c65b133bbffd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/emerald/block.json"
-hash = "168affd75bc8c7a9c290dea6c7cdeaff90615d6989f9b7b63086eb5a70dc18a0"
+hash = "eab520537045c2f39b8368d7d6f90554d6e89fa54e94247d25df30514ae50369"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/emerald/gem_gold_cast.json"
-hash = "188f4bc98f19928a251c88d49fe6fe9886e732a9b426b42ceef5714336a2f908"
+hash = "f613ea9c189bff2f31776bebe449774a6b7feca133d5570aa2a6cda67b41f3aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/emerald/gem_sand_cast.json"
-hash = "1b445d870a4da73e8e33264dfd1787be0a9226b90d655eb79e51c89d0602c83c"
+hash = "d47dfcb3849e010b7f2ea67cd72b62079df9ba53d2ffba6f172048a52a0a3749"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/ender/eye.json"
-hash = "d33b0c07896e79b4e71fe86f97265037ad8c8de1f32afa2bb246c98f947c9755"
+hash = "389f08ec572d8f22299b6548c530147eb998dbbcccb350cc6e00913e646d4256"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/ender/pearl.json"
-hash = "d6978322e6b1e521ef3b4d85e069c3a925fd69965b4f15e01299372c27327a83"
+hash = "4d1f0e5e03a003b989883e61a19b31f6d4d1c580181ec5bc5c8a17dbda8cd58b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/bucket.json"
-hash = "a1c9974567df8729c1fb73b05a61fb8f4678980e6528e5bfa7a48eb97942d412"
+hash = "338992156f1fa403a286b6ef53b78350bf2b3a23df8be715a2be017b901ed4af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/copper_can.json"
-hash = "c28ecd459edb2159ceb41ecf4a9ac430b3d321a399fc45d2cf97230ebc7b4408"
+hash = "e5988925158b6beada04299c56ffa09e340d6efd1dc3b1ae18bc1e24f73cfbcf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_fuel_gauge.json"
-hash = "675982c85b4fc757f14a6b95347e4f3c61135bf1e3a5dedc2b1604dd00377408"
+hash = "25e4737b89cf9dd641e1fe5e2b8f5352edc4e3dc8b45d9b96de0cc393bbc6a8a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_fuel_tank.json"
-hash = "00366294945c29bf68ed306ad3bf357b289c8b297197eb5429f274c57bb1aae6"
+hash = "9ca9ba509a06ad0008a5acf0baaef03f044f8e435630681f22c48745f83b65c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_ingot_gauge.json"
-hash = "8bbf14e7fa5fdb25565cdd2e8e0b756de91a006180579293a541a637e5f5e779"
+hash = "0448eabd857b61c51219bc86c7a798309b0b11db26f8d5a4df34c3d60838ee98"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_ingot_tank.json"
-hash = "ad96c659a39c630c0c688a9204ad6a79d48ec0d205bc72aba93774146a381b13"
+hash = "8e392cebebf29d83611f1950b550e04891212db2a7d48144f922f738bb39c927"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_lantern_full.json"
-hash = "9b73d393d601cb52a98f8fce545db1b769722349164f1ac8410c0f1d110f5d30"
+hash = "5ad05d1aafdd75bcf01bd70be4814ebc4270663e3c7f5176f8d8e9ffea4f9eb4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/scorched_lantern_pixel.json"
-hash = "86e6c669437f4746578855e6b20edf327f847300d6ed9c02aeb84d2493e4012a"
+hash = "3148b22a7a0c2c772273af5bbe271e0de1d891de1f5656178b37b9cfe902c7f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_fuel_gauge.json"
-hash = "f63bc8c9211d6295c9baee9f0db3c4e4b035c3592fda2045a68771b1bef7c8d6"
+hash = "8b7e1e162e37d2d7ff11f9db99c6337a7ce03ded889daa2caff811c1a8e3cf0a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_fuel_tank.json"
-hash = "c7ad60cc1ef290e2646f71e41c977ea712417778eba73502412d8d4d5f32bf2e"
+hash = "35a2033da4df67552816a4a002e7cf3c30beaa2d6d097c4bb7ac671ba76f9ef3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_ingot_gauge.json"
-hash = "796b76a366b79c5ffe5d92e5b320122f71bde5b229e8631bb439340a40057962"
+hash = "c688059ed3bcffabafcb5ed35247aac7d4cbdae9d247a41db587193eca8f0c43"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_ingot_tank.json"
-hash = "c516c869667da414a6e81ca0464333623e76bb389e68a961d3d054bfc53b4e10"
+hash = "a834f18844e2a3930388b17fbdd42633e6143e86bf2293926f8af5be3134a7bd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_lantern_full.json"
-hash = "3c021b2c2b0312ff99d71a7a53aa2b96a9ad4b945947089e9ed214174e8729d1"
+hash = "8f6c508594412404e497c73edc564f1581370418d9e14ac5b61a4d31b52172e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/filling/seared_lantern_pixel.json"
-hash = "6dca2849a23a574a1ce25b5fd745f104cec173e2e2908eb42419cb7095a419e5"
+hash = "48fb2c90b9cadbf50526d2e24e899c37ecd9949967626beb1d166488229afe31"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/glass/block.json"
-hash = "3c9950084e9948cda9e8d8dec827e7c4052aff0d9a3d753b6b6c02c8a56ee6af"
+hash = "802c7f56e4b7aaafca089382e31e04f2968e9aeb68f201160b7b876ef7b5465a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/glass/pane.json"
-hash = "f8f28ecf02103236a2cf33f35f2c5b27404af5212b9c61087817634f44dc330b"
+hash = "83fa590f0891ffd6629dd892028dbb34f0058c7a69558504da8243f74609c075"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/honey/block.json"
-hash = "69b7e06ea772af63e14c84e59ff279ca1dd2fdeedcc1950172296676e7c563ed"
+hash = "f3b0729d53aeaaf49328a0921e511a60f4b84700c465a7d23c12d4602cb058af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/honey/bottle.json"
-hash = "6815ab8a01f9c49a33d788e5b039aa661f8a8068411fac4a1f4db403d6f8f9c4"
+hash = "1a6ed53413b52ae60b72b360c39e2c01aacd9b493f70e4f805176607ad6f88f5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/lavawood.json"
-hash = "74aef072aec1daaffe0a0f26c45c09801086889161c562be82b0f68e00e3d5c3"
+hash = "6cf88321cde3689c953939bff7a68021e6fcd7a0bfa20f35b39a227998c12278"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/block.json"
-hash = "70b157133d086acf3fb2761573f40728c1ccc3d7f699d1640426c99eec68fbbd"
+hash = "5853dc1d8ac2cda1fcf90995efa54b2ee7f62a9228919220df96f1dd0851c93e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/coin_gold_cast.json"
-hash = "84bb44bf9fbabf10241f692be8402da48ae11a2aff9fa0ecc26053fc7b4c24f6"
+hash = "4d2457f4e220f88f7d5b924ab955601de7402cb35c4e6e83fb84a4f7920d2dc2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/coin_sand_cast.json"
-hash = "37619c29affc2cbe3151c959c36f27db38da11c7ed2c8539c8488561f60a837c"
+hash = "22b8d62b0a6aeb668c2f3e79d7de1220d52ac3012215b0b7ef609bb8380f27e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/gear_gold_cast.json"
-hash = "eb906667a2c80b2efb78b2cd74f04f7c435b27111b0fc5a1bd05074df643e5e0"
+hash = "82146d289e6a7d4796e0a1d31e672edc8ba2225fa4f43a5374041755a7f7a206"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/gear_sand_cast.json"
-hash = "910cdde49c39149227fbc46b556e4362406a7117b7ea8a5742e712884f469a56"
+hash = "892fa2f743fb59133086601c44a908f2ea7f5cfc4bfe48f7fe6bcddf540fddd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/ingot_gold_cast.json"
-hash = "90b49bc13dfbbb70219c958fdfcb37a9912d036b26b1737e65142de6571a7d3c"
+hash = "da47ed8b3b9fa1a5c46035cec1dc3bcf45558cf0d712812a17362bd268a04791"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/ingot_sand_cast.json"
-hash = "b132be4052f6b2ed9e3fc978559b1caabf774efd01e2fb04430097b749ae6391"
+hash = "7fa72946f82ec4cd8c28b2671102830de60eafd64ab7ddcba8fd6d863f5e076c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/nugget_gold_cast.json"
-hash = "23ad6fce25fab4183734736af8dc831a57af0c580fdc79a335d5eb26d92661cc"
+hash = "396eb5ee2c5af306d3ddb8de26a024d3fc261e00072a60cb12551746b51ba66f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/nugget_sand_cast.json"
-hash = "91ed7bf616a8e12af9e4c650193a49fc4cbf8988062ad5dd5723c7a16eddd037"
+hash = "9f10977e43a5f94003d62f1a82467f31528dd685cd96f127e9e75d1542bf10f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/plate_gold_cast.json"
-hash = "3c774f315878e8eaa21dfa7cbb618319826d8f346ab6ff74d8322ea543328ae9"
+hash = "c52e55e92de936da044dcb72a9bb2410c9b3070739bd76b48ac8decfc47204c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/plate_sand_cast.json"
-hash = "502ef2b8ee003dc8173028cf27a8ac71dd979b8ff6db52ca2c6854b736bdeb12"
+hash = "f006f89ff8b7dcf3669989be0830865519418fa4dede1887e07527d6b3db4a95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/rod_gold_cast.json"
-hash = "023d84ba494c0530efa099c218a4ec5b2be82c79053382bb0ecc5eb1cce3ea0f"
+hash = "3cccba919f051f1d743e73c000e6ce418af2a9ec7db441a0ca36a63ae3beb183"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/rod_sand_cast.json"
-hash = "cfc7f1ebbb885535d777241ca213624d9bc3d0422ff0dbc882a94a2da1bdd74a"
+hash = "696c385b7014a4fe47306b00a109a08a0a55ac413371b7d0820f6a2a2c2c6b38"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/wire_gold_cast.json"
-hash = "f65d6548bb38bce8464c16c5aec84e54fc67fff45ffc3105b17d24753fdcbf1e"
+hash = "ed40eb9ee2e3762637f0ed9d8ad95537596ecacd97aa3d6637e4426f71b02c43"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/aluminum/wire_sand_cast.json"
-hash = "0dc175b908bb381d278064c0c0e0f82cc0b2ddff215fb70e494b954e626edf28"
+hash = "89f50864360f87e65a2277c5bd331773fc448bd8a4eb5c3f95ceb2757aabb309"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/block.json"
-hash = "f5e6a8ec73c8a66f3729b146cfd1b04ef52f399294a31b38659137797143b26a"
+hash = "2c146bedc8a319c669efdb5c2fe08ab3324d75c29ea54123f36338a9c0f0113f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/coin_gold_cast.json"
-hash = "3cf4bf464ceae71da09305885f8046f26441ff9b596a8870621e5db830ab750a"
+hash = "eb0e9068240f3c54ca5b139274a1b5a1b26e45638a9848f9c684d6905d29b0f2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/coin_sand_cast.json"
-hash = "63e33626e5f4ab9536ffe7a835b4f3dbf92b960acba0516074446553e3087a14"
+hash = "63f322bd0ce65f50a34a811321ad7ca71f6f1c12edc646c3dfd2e82f009ffa45"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/gear_gold_cast.json"
-hash = "fd1ae600047eeb24f1b0f4c9979bc2d84da7365a014de27adcccc973e46f6c9d"
+hash = "c6939456c1b39b4544211d411d426ba67d727819193a97476ce2e32c99c81975"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/gear_sand_cast.json"
-hash = "f00785e78111204cfafd58b02439deab93aa91c61549f34314fc7e4a131af305"
+hash = "af6290c6586f02ee7fb4701cca6ff444d23c17b48c183414d0bea121623f5c21"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/ingot_gold_cast.json"
-hash = "0f74278bbb5b2c6b482985b401796cfb07794e34ea329be107970247f8cadaa4"
+hash = "f790a07fb0979e10dfd618237b6fac9f2e38a57bac2995d1805e0c242996812f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/ingot_sand_cast.json"
-hash = "85f4218b5199db83950d29ae488d460d7d173810d28c158a782f3d1a54502b07"
+hash = "1ee25d692a46df3a077b72a3f35967d3f7390b8d3850466d5dbfe918fbeee768"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/nugget_gold_cast.json"
-hash = "d49e740f71c6f408caea62036ffb95910c06b876a8baa90cfafad9d5eb031360"
+hash = "541e11a967350a8ea0350f4ac44b11c874a3f0909e8d50c6e5f3b606fe5c4528"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/nugget_sand_cast.json"
-hash = "e25f45b0da94faf948aae182d19ad0fa8bbe7a6838ca0ddd85b7db1c1ea6cfa1"
+hash = "c64a7d93ac75738ec354e23c9b9c0df472ae20c745fcea9ef553c23de7fdca47"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/plate_gold_cast.json"
-hash = "ae7c7af41923feb79bbad054c1ff77b53725972b70029e83c2d2c7714490aea7"
+hash = "1611f6dd4d73c36b7eebf92e0ea3a288b13901a10a83570019d5514d75268044"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/plate_sand_cast.json"
-hash = "750eb4ac4f67b80ad927914a53607ef5a7deb5bf0d2486e4e345dcaaddc4cdcd"
+hash = "ec243c262336c85ebff908f8cd6e050a9f2085b90409ad72771f456b68e61df8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/rod_gold_cast.json"
-hash = "bc32fcb28032740d0ff6cd09e6a705cb0c7d813849e66f7b32fe33b208f68c36"
+hash = "1117111e32dced53890a0360f6cb530e82b0f6b5e3fe17ffc93e0090185e2a4d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/rod_sand_cast.json"
-hash = "11b3c865a721ba183f0138c9060b26d09b63553c29c39df66c1b43bb6effed0e"
+hash = "fe7e43ff2468df4ba6b7a71bdd0bd1e49b2179516133d1d65bb7279e1376a348"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/wire_gold_cast.json"
-hash = "536e81f6402bee4d17ff5a307c30b7632c9b141a3edcc337514ae18b2b31e93f"
+hash = "5ece69fa83f6a12753c143263a15cf82855f9d810d1e48fbbb8678782c970394"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/amethyst_bronze/wire_sand_cast.json"
-hash = "0378ad800a7ac52249d75cb27d41e3e802130818509f8d4e6634166b94ca67c3"
+hash = "87d76d825d364cebb10b567c329936b1f2b617d1c90527c0ae1dcab986788ad1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/andesite/ingot_gold_cast.json"
-hash = "71f0864edefbbedade814895e9163afe88d08271094d2d78e2f0d6bcae27f592"
+hash = "703805490175d6c3310f395af2d2556209ea52db7ac255ca88a324c0a8328e1f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/andesite/ingot_sand_cast.json"
-hash = "748c71e32bbcfb9f7da4c82de68179ae72da2ed264f07652d24cae913e0b486d"
+hash = "b1533eb787215d81da7accbb7e533f3b214bd452bf3f7070f5775f10550aad6c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/block.json"
-hash = "f79c6f0612ac935d5b35a80b94a99eb11cbc8196ed682dc50e8346ed0b4b69f4"
+hash = "66c2728a1abea09116d2d6681ed8f02c98c67e744a94b7904c38eaa52a67acd8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/coin_gold_cast.json"
-hash = "ea76056d27fb88780afe70f323b26c32c9b237d14695358822a56694e31250a9"
+hash = "449bdba6f0b151806572a12495188bfa063e5df72d929786cadd4322e3027ca0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/coin_sand_cast.json"
-hash = "814f0ca5903368ce61703e9cbb0564da96a0708dd90586e53d4e69d15f5c504e"
+hash = "5a2317237a748bbc93ebd97b048b02b41c5930bb681b5415b1c861b11abb836e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/gear_gold_cast.json"
-hash = "27aec03b6b4365d0ede0e764b7ad33b6741f18d17c769f31a521c4558399c562"
+hash = "4dec8dc066edec4da54b7e8a487b68ee8addcd09449b9bbc17955fc66944e0a5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/gear_sand_cast.json"
-hash = "27b560d1d901f3e7f40925cab7ca40de35f9bf307c70fe4989c21e30a9517f63"
+hash = "9842f93cffc0e6541a4bec4062c8c77123fc44c658d9567090d4d91bfa23ed98"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/ingot_gold_cast.json"
-hash = "b3867701dc095d12288c983cae7e4e1888bc078965d8ce047b079fe0adb09577"
+hash = "5eb109543c49db5c7eb89099eca9a693c4e432cf0f3cd5baefc2927169657c2c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/ingot_sand_cast.json"
-hash = "f7f2e203197db8600df378fbe9aae3aa28b6434b766db40ae19d8fd233909c64"
+hash = "1676a47cc6f5bac9e59fd42ebc08645333a3cb64590e371715894f33c0551cb3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/nugget_gold_cast.json"
-hash = "1adb244a95ca898565d6677e5752f46793d2f173b0a0be38f74ebc1f6d320453"
+hash = "e645d64672c77c326d9c639410e942d39aa3cbe7778892cff52b9cfe9b249b7b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/nugget_sand_cast.json"
-hash = "07cf9b6c861715c28c591f13adc712cec83f5e42d8593dd6b64e7299138b0438"
+hash = "d93dff291c0f7307092a2f53b7d6d76069d28f325285f319b94b57d233f805bd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/plate_gold_cast.json"
-hash = "e2b2d5a2bf8ae4cf76aec7709f57ef3f765653499f12b64d8c815c9c02c65f36"
+hash = "9ea80b0d49846e3b8bec7c3c712b6c5e4dbc81cc14451316895513a48f4233c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/plate_sand_cast.json"
-hash = "a47a5487d058d66990464e8703960dec3c2ca7cf8ebebdc0da45b02c95f38ad2"
+hash = "e0004ee0afadd6cd2d354b9c3e4487339a06a6b090ce040b88466739514c0a79"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/rod_gold_cast.json"
-hash = "6b957ea2d6267ce67cbfe770bbabf898115b18f538f0475f996ca6be7577a75f"
+hash = "cbc2bd42e50554a52e8ca9ec0404a89f668ac3ab2926bcf4f51baef633aa93f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/rod_sand_cast.json"
-hash = "124a4296a6567cdb4eb197dcb93faee23787aa04bdc8647127ca7a1f38feca3c"
+hash = "429f93754c405690f5f7d29a72dbea6d306ee183c1566b8faad280b26b55c4ae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/wire_gold_cast.json"
-hash = "9da7a75c7d6b8bf31bd6869847ea53d965787fd63781bea664b838ff5cd10dff"
+hash = "183ac8369ffb94872075fc8a7b4529e10b71ba21120b7517b66723564c664135"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/brass/wire_sand_cast.json"
-hash = "6b1de8bdd8c6874c4ab71b66f2a582033dfe63d01b88a42d16baa626159d062d"
+hash = "e3193a8c070399f378db21ae496b86fc8b0525c25576259cbfe0997c20682267"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/block.json"
-hash = "6f11c9f975874022f3880b648caa93d669b2fed4ee873454164ec834abf49769"
+hash = "0cf955ac85e33768f3f8706aaae1d29be45df75beeaf4a21bd0c106fc1df9180"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/coin_gold_cast.json"
-hash = "0eee6d97820b14a313b65778815b7b54e3d1ce794484ddf442da747604a65d6b"
+hash = "28f6db3f4ed3528c0aead0a7b16de80aab1d36be78c5504acbc770f2d5c6b991"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/coin_sand_cast.json"
-hash = "7a1b2f31474c7947b37f51a05bfc2175dd07c74fa220a548d2273134e2da69a6"
+hash = "e32597572e7ed033ede70921ae0cc3e89b8031ede30cb7b0a462de70adddec9a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/gear_gold_cast.json"
-hash = "94083e6d0f6722186b7ef358fb665f06b71ad71bb9eb29fcb8fd0ef02573650d"
+hash = "753a34a1561435f68e5843f2ad7d910a219b3a1297a75c56d6aeaa7afd9fac13"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/gear_sand_cast.json"
-hash = "bbc5352e9b7fd24481447ef33c68ee5d3b723595c75f026fccdcea85cdc8dada"
+hash = "f31502cbfbf8e4b58da1bce2f096ca561885b94da68b7be8dca15bd0efa14832"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/ingot_gold_cast.json"
-hash = "2a641a8ed3c7993fd230b1d859ea69e3ea215d53258cf0d19c3d8ad4f57d019f"
+hash = "c85fef177edc8dcfc0e8ac0d1f6725242b234bf62dc9795cc60fceb611fd34af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/ingot_sand_cast.json"
-hash = "072c7333f2f7126f39a4ccf51785b25cab1e59a8ca427b68d9214e3fb02d448e"
+hash = "d1332245dd524943c3ed696a6e22f73852f304daa89f5840faa2e25de98266d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/nugget_gold_cast.json"
-hash = "6cb1f9fb66de1e4f2ed169221cf6895db75bf4ef2cbba948e62eefb8f5d19e31"
+hash = "eb4fa1382111a38837f4502f77ec062da3aabfa797d27039b8d8f53bad6f99dd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/nugget_sand_cast.json"
-hash = "f2785d242277aadd8e4416728baf36070140a0fe3fb36338061355cac0de5f05"
+hash = "dfac29b5e10988f4e85799a2e21691d69670c4aed47c89f389bad92333d5e4c3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/plate_gold_cast.json"
-hash = "d074f8d566b3dd43ac9ae14bf7e9f232cc58cd488781bb6991f27827fe24c0bd"
+hash = "3346468f8e4bf31e0f9cbd38be29266b0471006c75319dd4296236012eb01bb6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/plate_sand_cast.json"
-hash = "e4ff2c30e2d962b742985f96ca907b695d8eb524fa2683029ff537112798d766"
+hash = "8a927b0896674797bd0c0c5e19d2fb88534c826c51fc21c6b824329a8d6ce448"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/rod_gold_cast.json"
-hash = "68bbd947f07dcad960b2cc8b549d056e4e34fd457f0f97fddc2acb9a79001650"
+hash = "1e6683d01748a432d265e4332d76986dfe9460f2df081481365e8543f2c427a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/rod_sand_cast.json"
-hash = "3bb757ae34eee4d8c4c3f9ffba2558cea67a4a20c1e0a11473d7fdca6fa5f8cb"
+hash = "70a62304c6aa349824ba8d108a00a0455f177c60d80e10d0b2439c7201444ce5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/wire_gold_cast.json"
-hash = "57116b9c1f2a26edbffa40cf85e77a60bf08e861f82f60e44aca314a790c36e5"
+hash = "20e5c804f189057078f8112a30ae9884a8a27e67c4f7cd3a5454f04cd01135d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/bronze/wire_sand_cast.json"
-hash = "c41f5342aef8f61fde409ee09825b76eaa4747f3b70bc539017af1c4da08a5e0"
+hash = "a5bed24de0a1a0381fe4a291b9c50210ddcacf7dff85d255eb00ce26d685fd45"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/block.json"
-hash = "04018b8edf1737e4e165d130aad1bd37c184ac2c446c8b7f11922c2c2b23d20c"
+hash = "8bcd056ca7b633444a1b4c1a8342f3214ad48355d2b4c0c7daa47fe5463f8987"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/ingot_gold_cast.json"
-hash = "ec5f25b890338caf5e583c6c001bdc05effd55ca01403583dc3ea00c8b658e9f"
+hash = "fc2ca93ea7f90dab6ba3cfabfcd9aa13dde3e0e060330ea45f102cbcde22c149"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/ingot_sand_cast.json"
-hash = "0489a823948a37270bbfe53c47fc92948a6b11177175ecf0b3e244153d1097a7"
+hash = "c6f474deb5fa154bb2029b269f913320c2679604914ca150aa1a03b3971ee3d0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/nugget_gold_cast.json"
-hash = "f75c3a23778d9c0004a3e90548b65742f0e83c6397faf89e15d566663ff03cb7"
+hash = "9f16e5a7b684b6d1a28604e8361a1078710216596c704735d6f9ef1804dc02bd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/nugget_sand_cast.json"
-hash = "4978c54f028a07ad6e03cda73b4d8f198cbb9a689b103584096e9813b01c50f8"
+hash = "8ed2b3c70c1be6e8228ca5d52b478b68669ec8adfc2175a00a328bbdf490cfcc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/plate_gold_cast.json"
-hash = "d01ea7b27645fac776cb56d78ad5e02b58b07c5a43871d6778d030bf69334393"
+hash = "beb423c3435bb8279c5d1148bbf67a5467a66c63c26b3cc38261addd6ae20a27"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/calorite/plate_sand_cast.json"
-hash = "b4513174c3e9bcbeae798b89c752b0fae6ec99381e7643f612a78428b8446c9b"
+hash = "d72353cc7aaaca5ec2c4d49af0f58914b04fb39b2a86a26e404037881148522a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/block.json"
-hash = "116dac015a8f1507d901345c2717ae3927dccc91292c33f173d3072d069cc5d0"
+hash = "7fb5fdb076f36ec15e39c8c7523394daec68f454136c0ea244d6e7af07a343ac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/coin_gold_cast.json"
-hash = "96ff754a0225d6077ba9a12ba92c6c5b02c6c7144b5833f5febe70bda2c341d2"
+hash = "5ef9f417eb9ea7733a0a101eeeed08f720d5fea7467cafa4e02ec30752ce4966"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/coin_sand_cast.json"
-hash = "db4d8ea6776590653bc244c7ff81764d4700da0d160d55e7395bd9997b5430bc"
+hash = "01ffea8e4fba3dde32d200190ecd3837452ea361300796c20511815eb4c0c38b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/gear_gold_cast.json"
-hash = "82c3fba6e085c32b6717fb188e2bc2e7e4e1d53220e4510590c1ef8784ffccb2"
+hash = "3827dcbe86263baaf8121af66378f689d2745bcfacfbe915e9b55756e7a01838"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/gear_sand_cast.json"
-hash = "23177447d09f21e6ff8c4e1c4c5b55f238636e89f59687b8ea0a2bc844bd4f56"
+hash = "31867ed679585e0a6f9f3cc8bd30458e5b2a1b5f4ab0e4a211e1ccafea2b7419"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/ingot_gold_cast.json"
-hash = "5ba4615f6a217e742512fb7a34a735b393a3dfe758ed459d4da1bb308b4ae2c9"
+hash = "5a02e460f4162188f804acc1d06f5b5bc9274fd936a8b2ed6548909e112ebb25"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/ingot_sand_cast.json"
-hash = "d6ccdb5904de5ac03b8fc208e0a884b70b2493ba0571abe039ea9b56723fd729"
+hash = "6a537b5d6c2f4429bd5fdb0d6ce72acfef6174710504e1e9697f2ca806add386"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/nugget_gold_cast.json"
-hash = "48a7a00aa24e823a43fd9d3a863d7f9bd92ac05c0a8849eb6b368e9a6e06ddd3"
+hash = "24f32ed0672af4e2ce473456cd8b409ab8b6aa4dce86ccf49ce6ad8e9b880eff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/nugget_sand_cast.json"
-hash = "95cca9f2af9ef3ee7e2f561cf60b2bc6737056ca47d61dd38885f9b27d68ad45"
+hash = "c348631c82c0238c7ff3333ca7500a1b5726e1212871ffdbb81e31cd85310457"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/plate_gold_cast.json"
-hash = "5ea12000a0277122fe41d878308e7762568a2dd20f819eab6f2319a1665d1296"
+hash = "9c33f1d1fc88c4c7014ea082979206e62fed766f687e3beb6723480ba34b3158"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/plate_sand_cast.json"
-hash = "f6fd97fc5663e5d9983bda2b37a92db37182d3dbd50d652b000a80fa7b9adf8f"
+hash = "2441929e2680b8e72b39a8b6a198f9ba30920d2267d5db9a2a8fec89ee89e265"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/rod_gold_cast.json"
-hash = "816ce6e508a5426dfb07b27b6d1ddfa28043b28ef688711102121813ed3ff394"
+hash = "877a6d7605f2c4677d4000c5a1b8541968c8f5203ac45794d853e99d9e5aa70d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/rod_sand_cast.json"
-hash = "de87e61481f07ecbdaa700313346949fe04196989927c6df59344a9fb45f29d9"
+hash = "e49bd043f7e6a7e1a8c3281d1ebd7086b7c87bb4156e6d91e3fedf4cb93303ea"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/wire_gold_cast.json"
-hash = "c9ca76ffcf986e47e3a8859a603a0e66afc2cdc8e897301f467ea86421cf14fc"
+hash = "5b3bad4c12cd0dcf7a60c915b3f041a78a9d743c17dd3ac58f8a9d4ccfc7aedc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/cobalt/wire_sand_cast.json"
-hash = "271393898bc47285cd47a1d8dec60a7c8a19bca7c00269db1379b263dc66b442"
+hash = "4f92de744236d9cd3442d48cc95c5d74184c598e41a418b8e3df706942918dbd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/block.json"
-hash = "4523fc9c719ba538bfe28036c60f6c75eccf6d630026c6c419ec3e4d9f407e6b"
+hash = "672b04ef4198d8b78f2ad6eeab80529b74e245c8a05c7fa5de6b3f411d482714"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/coin_gold_cast.json"
-hash = "15cc0dbdb62b0a1acff2edb038b07ad5183e6f7c9b4408f8b0a19acce13a672b"
+hash = "c40e9be2c852d3351df2da48f67c6f4de791272c3e2d48f3063c4296893b672f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/coin_sand_cast.json"
-hash = "4be8ae065d1dc2cf687b69e45785cdc2b13b44433e2611433070b2412c378541"
+hash = "1aab2cfb4b5aed437c3eec9b77a976ec2483aab2e774cb0e4f9d7c81e26a7645"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/gear_gold_cast.json"
-hash = "70a0b52dada58b06795e3e3e42b15dbe3e72016b4c1c30da0f15467474dd2fed"
+hash = "315d0df48fc9df43f2dfa45b16a4b72580a587306d86f7f9d1ab63af3a7b43de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/gear_sand_cast.json"
-hash = "e948f5935e16b9d78f6a7379de3a26478564a3a13b107feb46eaa0257815954c"
+hash = "c92af530deba282236c90aa72169db0e1e1c12ce427d1b44fef4e183aad6361c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/ingot_gold_cast.json"
-hash = "5349dcbb2614a2a1291a4f7fc116a4ed988173bed36bee8def23aa340bbb3a02"
+hash = "8961ff8d1c779918f2d1e74709ee008db64a42846f5ec4ed25a5144530295ebf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/ingot_sand_cast.json"
-hash = "17b0abf2050f848d31f9d1d13bc7a517df7f51c918af11f29a16211f308d7873"
+hash = "d6cdfa609afe9309aecd7c17c4fb6584fdcca0b76ab2eca32b1e52930a310873"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/nugget_gold_cast.json"
-hash = "1d9570bcf0ceb57a2d26a503201258cf7cd2ac07166177a434bd71a09c07c37d"
+hash = "06a22b4f521e049c3c564989c2b423ee0d71e0b643fdfd078ed2c70b3ea7b44e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/nugget_sand_cast.json"
-hash = "3f0f65872d45b0e6d03ec0e672009c7ecdb25f2df3487a1849b5e5fc4bbe5d55"
+hash = "3aca3be32f2af5b2aade1d9fbdc27ecc19b6a41487ed4a94c35bb72b375ae181"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/plate_gold_cast.json"
-hash = "8b8b1f1ddee9ee9a7478790cbfdccbd09fe897e52904c3e83a932b61b5270e72"
+hash = "012ce0622be0ebaa01ce051ef74d6dc666fab0076bf82190610425a0337c388a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/plate_sand_cast.json"
-hash = "6fa6cc1ec3b95c806337a1ff232ece3e2b8007a12ddfbc3f3860ac9eabd5bf9f"
+hash = "2f8f264b32d675025442a2ab1300745e8e261b0ccc44e82f784309d7a06f90d8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/rod_gold_cast.json"
-hash = "43c80a0ec709a05e97c02f288eb15202d77c0c98155b8e8808e23b6740fcf663"
+hash = "32f190841efc6cd78806c51a50b62db31a6af1377cb008b47632842bcbe30c1f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/rod_sand_cast.json"
-hash = "fdb105ede8dd0bf47b6be52201ac8792417dec82e31de61feb2218b9ccb316ca"
+hash = "e14b2855068d30e2179c70323779087d14c48ea294065af2e3d2d768f9e5aad5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/wire_gold_cast.json"
-hash = "04147829b4ae7c49a9d371f5f8b66447b2913610715f49db7e9e88e39d69cd61"
+hash = "9f4b369a6abf0223e45f2e196c9eeda6f426abe1629d1e0e0f3c1b63c5025de5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/constantan/wire_sand_cast.json"
-hash = "6666c9f319f703668abcc1fe7b3e1b73c5beddb25f8e3893d4c67f1c1d7f8a4c"
+hash = "ca1d74aac6b7fec3b6b3c42851b8edc135e4b0316e84fbb157da7eab0c1e06f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/block.json"
-hash = "7bbfdcf41202c1af2d31e410b0311a76d2167d9cde0b7bbe5706749c160f409b"
+hash = "f5dc01e1ffef5e18618d7df6da1f5540cfd0b89c34961e34ade00fc8de4d5677"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/coin_gold_cast.json"
-hash = "a2fcf6ebc89599cae7d464110e2038556c038d45894e6c7e134608d9b5fc2800"
+hash = "a6f947a61dd61ac508b9d44b2af7555c61becdeec01a02e5f9817bcc4a0c5eaa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/coin_sand_cast.json"
-hash = "31f093d66abe79e505296c8bd3921d3a6ac0b02234fd22f666ac6dba5a8a3109"
+hash = "904559c32f0703e402dea19a3b85648c526cff2eb7e53d30c3c16bdc5463456c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/gear_gold_cast.json"
-hash = "7c74a3667ac7164655112fd6befe6eaaee2e0eb7cbe839b066e14fc0dc356d0e"
+hash = "09271b15ce3fe88e07ddbe664e93e2e2b67ffac5421532dad6b469ff786057be"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/gear_sand_cast.json"
-hash = "99382654e5e71c2b1a9aa53b5600f706476ab3d9296007cfddfba395507d78ba"
+hash = "1eb32e50841d7b1fd737794ee4abc41e873e5de30f35271b85732465d64d776d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/ingot_gold_cast.json"
-hash = "ab11f8e715a9edf0783b5d8f93b591473a1cb962642c7e12d2f40d5524658b70"
+hash = "8cba0e34de27be7a4699e24415ac4b04649bed1e2d6547584eec97884ef367e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/ingot_sand_cast.json"
-hash = "55de20468d1200c48ffdca41927a54c17ef5b96004439c99627f5c533dd8f08f"
+hash = "b12fd114c18478712393eda8764c5af9daa4546ee41c2ed69b8c44d0bccaec77"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/nugget_gold_cast.json"
-hash = "e4a0acafa80a702db10603bbbeac602af2cf3c2bfc1bfaced48b601d6b0c1d1e"
+hash = "b80c74af9f9aa5ab668c9e75c3eb3951ad3c6eabf706a9270ef419cd73202afa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/nugget_sand_cast.json"
-hash = "187808dea3fcc0a2b0dc5dc8d71deabdf9f5eb780b36e05f3f2a810667dc06ba"
+hash = "1996ff10bbe1ec1200c8540f4997b6cf63a4c889814e8a90d9346808e20b9dc5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/plate_gold_cast.json"
-hash = "6a5a879ae932a44846289c5d8a59d9d67b271836e942d815611dfc01bf3d100c"
+hash = "a28b5714902319062c541c3a6fcac62a685faed7978a9f7d7e3b47cd6eef1116"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/plate_sand_cast.json"
-hash = "6cb0cdb7fc0ef80ead8cb2c23af25bf4a2200b5e6c14ebac36c9d6914a4cbb25"
+hash = "ca5ebf73d241284c598a978123196843c2e7b2515b96e51896fac3eacafac205"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/rod_gold_cast.json"
-hash = "8574c904bd3628e5215e3679c7f9db60ef6299c964430483360309e20299b590"
+hash = "908693f840bf8b8b50e785d6db063bce989d54302322acf54128fca8fc0d2852"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/rod_sand_cast.json"
-hash = "41e23f36e1c73f928ed6f82448998897701391e39f2b812d502ad0b3fd6e227b"
+hash = "59a4fd084983c101e50e16891c659e8b2ff982cfe8d41da2cece734ea24ca231"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/wire_gold_cast.json"
-hash = "ebf4d3d3748aad7bb0216bbc86075645fdcdc5283d03e04399c3e98f57b2349d"
+hash = "6cd79fa18e9508f02a6cf239aa1076abcf913728f822f09192cb92fa6c1baf5d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/copper/wire_sand_cast.json"
-hash = "9cc13fb6c8bf4eb6db29a07fb337f0e1af50d82ae3b14250c95f486eb0586d2f"
+hash = "434e75216fa023038c31abb15ac88a6e583b24f373153ce2509ff1a3b01420c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/desh/block.json"
-hash = "5846dd7e544cd539c7982dfddcc906c1f721cb32eae87e152f0cd2730a2ce09a"
+hash = "226f303bee8956176aa7b97d32455c6e25a527892ee8a5b9aae49300aaaf4052"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/desh/ingot_gold_cast.json"
-hash = "236f76e229119099078144cf579eb9026a5246e9cef5d09d3391c2df31285509"
+hash = "73fcdb27a4b2b1ca63d577156329c6f52261d36aee30ccb9928077d3e4a42f9b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/desh/ingot_sand_cast.json"
-hash = "6ed21a485102e7c886f99ce5353b00b213f831d8fbc30a5aa8fbb6dd6e3f9ee0"
+hash = "1a27a38205ab898012ecfd03152d3b37cefabf98a621aa17b989de0e0a8ef9fe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/desh/nugget_gold_cast.json"
-hash = "5c97f14fd04ddbe8d4ae59ad55ee4400f658338957ac57c91f1727ac6cd1e8b7"
+hash = "bd83731cc14776be8d464ed1c747b5bfcec1247a4f0c7c9a7c5e710227ef091b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/desh/nugget_sand_cast.json"
-hash = "d3d6008899c3cc2dda08051cd6e8dee63404423d6a9b5bf196b0e84d6a414fd0"
+hash = "5f2556adcfda651e7e0ab85e0e3e738fe959eb4c2d30365dfabd4b0dcec9c7db"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/block.json"
-hash = "221f2126e1a1d6558725016e58090e874254ef086d819069c5e9687cbe74cdd4"
+hash = "6f251dccc72e205c31a18f6a47de1ac1b82320b75b6c6a50f983d005844ae35f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/coin_gold_cast.json"
-hash = "1abc54e17f70bc46cfa21ab1456f5f66ffcbfc90568b073410a7e19ca2ce9695"
+hash = "c7e77e60c8fff36655e02ce213de2a86b39dd4c8d9579077957e9d6e98e443cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/coin_sand_cast.json"
-hash = "1094bb1bca9dc0bdba9cdb534e693469977caea92dcf2a0213376a5053530ba5"
+hash = "34dc29060d62c817e742ead2d01d21bd6f953df89a8185639791257148225824"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/gear_gold_cast.json"
-hash = "b6a0f30db1384a7b80f128c2c342ae00455a00b7c25ab0580c1505fb674c1153"
+hash = "c2d152aa488cf0a550e4dee178303fa75fd4fa84ace80583889c98fd53ac4f65"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/gear_sand_cast.json"
-hash = "d98f9361b396bd9a742c19b10ea9a8036114ebf1867e6e76deaafaa5b767dbb0"
+hash = "4a6c4a7078beb16ea61f34fba2a17fc14b729ed1e64ff8224488540528fe90b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/ingot_gold_cast.json"
-hash = "297496016a136245c4e8a5c12dd2d872c3ade96fc9cb17836d4df6b6103d9c24"
+hash = "81445cd909b3edddfc4ef3e7492ff4626a9acb635f6f10fc83f3467a0cf14b3b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/ingot_sand_cast.json"
-hash = "cf09273732ce8a9d456c3f72e6b63b81ad685a21badc44d06e176e2dfc4710d7"
+hash = "5a43697074a00b597b5367ff9162c4b5774611947509a366babba292cf8c4e68"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/nugget_gold_cast.json"
-hash = "611257d2f6b492177775a46c0865db29b50c6e0494289a53e51a414ff55ede69"
+hash = "88b23c37a66a754cf4065cb38d43a343ec56423438949628300a8a61b0383e31"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/nugget_sand_cast.json"
-hash = "16e95ae7cc731ec4d6b39f41cc3a42b50384e8f7b1a7edc172c4a316f74c5586"
+hash = "c03d7f83603c3c94315e1e934e82fc26e6bea5d405ad927d4265df564b393a6e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/plate_gold_cast.json"
-hash = "0edc0c30a4cf11e945845c22d190f995b66c7dd0e06dbfe18778265b5488e326"
+hash = "12accbf175f03d6844f03c2cea235aa401eb5aa6bb38d7df61ef409b414d7f23"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/plate_sand_cast.json"
-hash = "0a8cd9c7ee3139dbbfe39519e70c5f5702fe171ac2b9bab5c97d5a529965ba0d"
+hash = "6982fb9d2f7b9d9c2df8457ac04c838d7bcd833cf89ff23b5d22b5fbe5733751"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/rod_gold_cast.json"
-hash = "6ac5b7231941af24bc47168e448ab795ffa38d6cf92880d3225db5d168920bc4"
+hash = "446441e598b7aaf63b7cd0e07c39db5565f6629a4260a874d07918c8ecb9b2fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/rod_sand_cast.json"
-hash = "b1d281d37a55187b0355911bc2b96d1f525c4154915c6884e45743e029d279a1"
+hash = "06f1140a357dc0d50edca434af759c0116193781299d080eb68b485099e6a90b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/wire_gold_cast.json"
-hash = "a4294a4955314dff96bbad4f3afb6a012d96ffdbdbf6b89e6f432fe39bd9f127"
+hash = "9fe7b71dc3f4611ef634417c3cc2155d4bdd2248866fb14a0d2b3100bd6f41a5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/electrum/wire_sand_cast.json"
-hash = "ff9baf4e0b7f1f9d3bc54929359639eca3c85b75ae4446ce3e3459d9a755500a"
+hash = "b872fc401f1953962ba48f4a4c9ef9a51eabfffe54ebc959cb0d26c3db689fc1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/block.json"
-hash = "7e01b46fb7fba2ba161f0bd9170bb8947e4542283dafe6e2d69cd9be8b7db8fe"
+hash = "34fc409eebe1838732fe1a0d989588ff29f8af812a6b8ee6c51a7558d26e1f08"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/coin_gold_cast.json"
-hash = "53f95bd26457140a534966834ab87536ea92c86506472f48c34be4f9a565adab"
+hash = "1213c699236904c2b5395f8273e305c7a7afdb11ce8d21b2bfeb9eb64d2e0b92"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/coin_sand_cast.json"
-hash = "e91972e941890cce73ee2603872b9162f327d0c090c98e765539170fa6cd3e99"
+hash = "045016ddb1540cbe439acd3268c6ca5f31eabab34fed380543af796987dd6d53"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/gear_gold_cast.json"
-hash = "218cadbc24cb2b5dce2ac94580394c35bc49305d24274b4aec7e096847455d73"
+hash = "0d46ad2f38ea190aa074d69a814901e1aa6f7be7a01db46b1bf12c64d29c3608"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/gear_sand_cast.json"
-hash = "f3132327f5e11f8c09f7aedf485a3781705fc166037806916b0d6378aafdfab1"
+hash = "4551a43511411e1e542f40d417825aef2d4c68c0481e19ebce353e4024762fc8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/ingot_gold_cast.json"
-hash = "39fee937c3e9351dfdbc2a470ad901599f1b6ebee9d2736088d1470d6b9cbcac"
+hash = "afc265d52eeed290815f3a23dd5d999072fdf4b16af3c64d20d0bda754f6c1d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/ingot_sand_cast.json"
-hash = "8c04b0583fcf5aef76521984b9d351c575181052fce03449bdc70ea5568189e2"
+hash = "9b8bb49f12a791f3c7d9484d7008aaf33ee402613eefc6b82942be529e5734b8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/nugget_gold_cast.json"
-hash = "f1869a7564ef938099e6b283da96f54fb3356313bc96530598c7a6bcace09033"
+hash = "d06985a501c733da3b4e0cdc172b481e3d832868d6ba5a707dc61a15da917642"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/nugget_sand_cast.json"
-hash = "1d108b91f2fb3639032961dbd86fb100c3425f98364f4d2eb44a43e17f80c7b1"
+hash = "da51cc93065af86aa378ae17e0c21e3136b354221f3adb2dbfad84f8063c28fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/plate_gold_cast.json"
-hash = "c0968e721d725502d833df10d366090c23642d32f0910b3da631621be3c981e6"
+hash = "a25a3fb34cb035d71fd4a2d053ebe4e37282e5ba3522de6b42a4edf654e9b415"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/plate_sand_cast.json"
-hash = "cee60b0d6eccb3ed59faae2c03c996e13490339bfacd658519215bd75876cb3b"
+hash = "72e741d724c2691359ed7de4357f94bc8a6b085d56c484d407e4498ea085ee69"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/rod_gold_cast.json"
-hash = "6d79241b47834c0876dfd07dca700feffbea3d0d92126159a8f7809778fba2a6"
+hash = "ef333f095fe52300d94682d9c1b809c2bcbdbd244d3010302cb2c4b74e11f6cd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/rod_sand_cast.json"
-hash = "100b8dd5c4b2c59fb3bf56641c1ad0988940f0e861165a998fafbee207af95f8"
+hash = "2235c874f9ad9ac26b4af5464f80c9aa55f2981b3103826907d3021e168d95d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/wire_gold_cast.json"
-hash = "bf3988b7a508472829e41e214cde67a7574264feceb56b4f8be3989951d71a6d"
+hash = "9969b260eca41d3bdfc20007da1e113f3b84b4f6390abbb33d4b4f23e72d8224"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/enderium/wire_sand_cast.json"
-hash = "37ea9c74a8d9994f73c9b5a6b6deb63718b51c61289438f46afc0a4e4c6825eb"
+hash = "2ea1e8d63b409ba7d4310e90e1383462b83fe34ff0bbf1696004718af6f44e5e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/apple.json"
-hash = "6b1fc78ef2a1e6d54292b3bc7856912169e5b8192341b66340d60cd9ddd119b3"
+hash = "3a7d60ac3f98188ce8bb71928268187d4827cfc4ae12a51659a8437ccc2c9746"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/bars.json"
-hash = "0687e79fb0bcf4d445a80618dd54ea17434834ce2256c59d8241b165cc0b52f4"
+hash = "39e9d68d57f7a35ff41ee4145a67c8e2c109abcd55a5c58052faaa798e4b81e8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/block.json"
-hash = "1d24bcbea277d46a5066881045a2d400d7a25179df22759b828f7ac798a70624"
+hash = "d63df5fe5edaa138260459b592a498df67baadd43058e8b1a486325433f68368"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/carrot.json"
-hash = "4a6e8bf7cbd9f518784c7ba2ad172eb28f92cd5baf2754d6e160098865764e27"
+hash = "680332e5bfd06dfcfd17b3ed4ab7c7e5620448e6730a1e0addf42bd76bcc1577"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/clock.json"
-hash = "7218a5ea152af322c31c1c850febbc0dd0ffc786878d452d16d036e433c4fa66"
+hash = "e9a2e8a6a9d2f5e26410b1b253244e080086f10b7c60e0b2b5d88b25a295753f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/coin_gold_cast.json"
-hash = "9e03d25e79a07c12c1859d4916091fb4e9ddecfcb7c7b93c52b2047f854b2e5f"
+hash = "150a0a190b48b76144b45271f942d4ae491a857350d5367acbeb16f1a246272b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/coin_sand_cast.json"
-hash = "9ddcf12664a25b6a018fcf0bcca2b1d613a31342312324cc0779d5edefe27c16"
+hash = "5c238fe38bf5602cafe73b7a1c5f621f38c87ea9131d3b781e1ee940f40f2247"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/gear_gold_cast.json"
-hash = "57ab10a54255b55bb520e8b3d88e04d27ac8f9154328ce8b50875f162add73a3"
+hash = "69ab1dd4f6b00f34fbcd719df642c3b9a4a602ba341d9da8d2892358dd9b34c8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/gear_sand_cast.json"
-hash = "82be816d04e4ff83cb399dd5d34381a102a94de493197e47d2ed08962dd970b0"
+hash = "ecd6d24086c583c171f8c807a4723114e97da3707ff618ceb73a703fdbd31217"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/ingot_gold_cast.json"
-hash = "ef1159c2797aaca0f12dff064aca3fdc0727f12b3434dc0d9be16f8d4a6e2c39"
+hash = "8bd924c705b9a169a45b2be56e1c37184a7f1cb0e4cba775968d91967bb10e01"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/ingot_sand_cast.json"
-hash = "6830c6a13e5198f70b6caa2d18566c6c6990144bf550308fdc9e4f788fc42c2e"
+hash = "42b4ff047496c8b79c136b805b64aedd3b019871550c16a495cf5461a09b674e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/melon.json"
-hash = "7b978d270d144ba73c8658a13efe0924226c25c61f628c31300734ad9fb76563"
+hash = "561349e7618f0841dbaae80437f13fc5f9d7396cb576b59a402cdbc6f39c4194"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/nugget_gold_cast.json"
-hash = "2557c879b9427f6d2e92e3fc616f41fe5183d7aef46d83f9abae0e5920661faa"
+hash = "3906c77cea741ed180b14de05741a4b3aa6920bc0eb35bb54f7f293937fe8467"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/nugget_sand_cast.json"
-hash = "758f3f7ac2932f70512a3f889f25ec9e1b7080bcd733649f23772631b6f22709"
+hash = "018edd90f0a454d470c583375b10ebab5edb08dee0537d582b5b3b21cf9a6b4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/plate_gold_cast.json"
-hash = "03f161f374c3a60d0cd7347d5771ec674c5d1b28d812157916b55cdd420f91f2"
+hash = "b39a175d28183cd00659eb24988bdfe116df8fe51d0206a911edaa3a4e7ccff6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/plate_sand_cast.json"
-hash = "03e3e27abb506713912c23cb7a17adbb4ac77b1d60021e4462c59c5eb3fbe2c9"
+hash = "6890e7cf40a7ae51982b1dfeb1b674b690c4a6270bd7c103e90976dec064cd49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/rod_gold_cast.json"
-hash = "e44bfa602694cb59ea2a63b0b92de6eb47cd25309476e5c687bbfa38cb5de4ca"
+hash = "c7658f1eb130d137a2cfad656fa43853513235f0a62fc965f85ce9efee907021"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/rod_sand_cast.json"
-hash = "5464fe724fab22b54a689817dd1ce71704a9317bd6a73c00f27a57ef562ac80d"
+hash = "5df619d1afd29933dc28c46da6e70353b4e235b57a037b3e4ab6a9cffce820fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/wire_gold_cast.json"
-hash = "559367c13997ea07c7ac1f52f494ff7d76d03152cb17c0ab48423d7ed92ea6ac"
+hash = "b73d6ce12bd6a6e8c3c8d28f1c6b2b32079bab33cbaf99abfc14d72165bf1b67"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/gold/wire_sand_cast.json"
-hash = "a101a3eefe722c06a2e0afea27907b98464284e89aea391fe3023822214e251b"
+hash = "4f3a5167e398142c8ff513fd8b1c0ef7ff8fe660a9f2065cfb1420e6d9ca31e8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/block.json"
-hash = "c9880bcfda6a4d887f9821849ea1b44b237245cbac5bc4eb787d8ef6d67cff95"
+hash = "4c49526ae2e1a73b8dac7aa723cec403410c0ded625de0a9172ae5ffcd30e85e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/coin_gold_cast.json"
-hash = "6533853c06c5282e1ec4cdb0836f5a7705aab28338504e4a943878baf47b9710"
+hash = "b79a4f5d14ccfa8cb2d542c9d9cb336e5944cf82b64386a690813ddfbe10d2e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/coin_sand_cast.json"
-hash = "e959b08fe07fa668a8a6731ef921035d7e79225fe2a18434fff3b9536f3ec6bc"
+hash = "1681e78ad3a32943e8f0e6b72a8559847cbebbf54fd592b14c69588adfa02ac4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/gear_gold_cast.json"
-hash = "24f589647647a0666d77255889d56460e02254ab550f1c823ad2c68098154c3a"
+hash = "fd40b2056829deb4c76cc3def0bf5789132739c81e9a6584d0b30653471a6281"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/gear_sand_cast.json"
-hash = "3e658543d68aa13124e618299304c3a663aba03232e9db188ad65f7397460998"
+hash = "8d0c47ddb0940508c86ba390985b7e209cc39714992b406e9bd91edac2632328"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/ingot_gold_cast.json"
-hash = "b451ffa97b63ba72241c28343c87ea1fbe7534dd1a388ad7f7a166613dcca9ad"
+hash = "f1e66e5ce8871c07818d4c1623312448f560baa84169bae9dc41337caf3c34d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/ingot_sand_cast.json"
-hash = "6d2c501565d55d7def6f0843ef989fe7ce03e22aac1913a4b24972b06f85d554"
+hash = "930c3caaf977534f263f67aea6305b5b174c9e64bac8c655ab3fce132d63d873"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/nugget_gold_cast.json"
-hash = "9f9812658d59cc77956086a9b4d8dee2f805e6865bf9c27e126740a3e8c4bcb0"
+hash = "1a0064a2dbe0303d60946db2783525ce55fffa86e7a6e268324b023d08f3d0cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/nugget_sand_cast.json"
-hash = "9390274904f5e13a4fcc459760532ff5e272e7d8b90406102ce674e2443eba4c"
+hash = "651a6686248f99e3578363200e881f601f3a50c1bbdfb1d9fdc7af2d893d0c50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/plate_gold_cast.json"
-hash = "91f51946981cfe5cea6ef473acf142bc7cb2edf1e7eb7d23a9e5cba5c5c4009b"
+hash = "3af6eac2a323a5881334e226a957cb81efd84fd021eb070b99bfd89b423d689c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/plate_sand_cast.json"
-hash = "8972ff29e831c93d1f086571d9787b81884ea41b448ce018982be4b5bfa77f00"
+hash = "e8206058f2c1b5b5d1a151b2c47aa961d7375ff2e05fc9651fa114f56bf02d95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/rod_gold_cast.json"
-hash = "6b088371d6d89628c77851258649f1094732bc02b96f3f0ad85f34ed625d68e1"
+hash = "eab77b9c45957c6a375d63fe2ce630f4d55c3cd62e04fe716005ecaade2ef4ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/rod_sand_cast.json"
-hash = "4566bb29854d67bb2401260bb8e8fa0a704cb49fa0d80adad01907259864e358"
+hash = "8868d4d1f26bca7d7564fa04306e61c343830f4d680f6a664d78422efb93560c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/wire_gold_cast.json"
-hash = "dd9fe67a399f658c4c2d649971283b406e5f14a95c9468456d3c848e9767b241"
+hash = "7ef29f15a23d5d6f91901f11f52869f210a4a206a89a8c04e36e8b5e435c8170"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/hepatizon/wire_sand_cast.json"
-hash = "701c6c3b6c5354217d69249d3699aa2ca194ff8eb9450a937afe0a742eee5166"
+hash = "64fc34044d15e9f11f4647d0c0e9d6fb2657ad57341566920677b003d05eb071"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/block.json"
-hash = "2a1b9ab57f14d7b517c3173efde12286ad0b06ecee66ac28322b9316605b7762"
+hash = "ad5766bf6d0208b5fa39f8217956c7c58526eabcc7b4cc03325ef4dd80a590b1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/coin_gold_cast.json"
-hash = "c950d34f9defb2a8208e0f7c329d1f9f750213d203c1f1d2470454e7c162ea75"
+hash = "da3e1e9b0ebdd06283a41c4f5a0aab4b60313cc8340b6ac25d082d97a204c703"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/coin_sand_cast.json"
-hash = "1e61369028f2d073ddfdfcd1e2f259fb8eec98febc39fd7eda54b90b2d08c48c"
+hash = "8e0e5570db631d09281e1dadc3f396646ae48ecaa6901a70e57222ad0d87e7cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/gear_gold_cast.json"
-hash = "711880b58a96b7a23f8e1b1f53cd1b6f4a903b4614723c4ccf0ab79b8b0d6e8d"
+hash = "a5a83b3c3b106d74f81e958afacbe9a4db60510f147b110e214e12cd9c6484e5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/gear_sand_cast.json"
-hash = "b3c07548d33b643c870e45da972c79e2ba73186ba4f9e98f420546b7aeeb4101"
+hash = "917ae7d9a941c251e4123ea1f8566aec9f63c2f5c963ff450347a11f7c8cef20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/ingot_gold_cast.json"
-hash = "518c47fb3ce3339fa1120c5e122ac3caf2002c0339c78d4b8bfa37d9e7e94a22"
+hash = "23b2c63d6289dd4f101e8766df417a894bfaf699931dcc8d933696ca201932ff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/ingot_sand_cast.json"
-hash = "0ea5a4a355503ac53beaa50c5bab9fa42b6dc072a2c7e9c84e5f86c9e7ac975b"
+hash = "cbc0e108e869a0f3cc3cdf322ef68272ccf1a80aae7e1af4a199d45335766018"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/nugget_gold_cast.json"
-hash = "c3adb43eae84f4f9f8a0733a9cdcdcd79af6f01935c8440467e438880ae2cc8a"
+hash = "33446f99d062f05ddf03894d0e0b24f76aec00226348a6112b415bd099924eb7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/nugget_sand_cast.json"
-hash = "aec3f7cc9e067ed362f6a8a392138d1989ec37ab9c57523d1ea52c885bef7e96"
+hash = "95de4b6552742f4c1884fc53f06588a62e763f2a4b550dbd7b7aabed8c96b543"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/plate_gold_cast.json"
-hash = "0058a3f67ed895d550a4a77d8674b7324bb83570a5f10c8d18734b9aad89ca85"
+hash = "42b98f7a31b5d53565ced4c673730b17fc7d2b618351fd159e9131a94b8c660d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/plate_sand_cast.json"
-hash = "49e3e91220379236429a190e692c3458b55b954bab40c1326a662e1ecd4b2cf0"
+hash = "849e0c3558d239396c67e1d61ac8c7950deb1e24ec6f752d51ff2502554abc12"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/rod_gold_cast.json"
-hash = "a16ce6dc49e7f50f3764cf5cc1fd9743db4dafab69e9ba64292d01aae4dd37fa"
+hash = "ff6a93b76c5726bbd04db9df22f9e4e3fc6b3db258ae201a7c580fc3b4a49273"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/rod_sand_cast.json"
-hash = "b86491ea4f09528fc312432ff6cae29df0a6848bd29fdb89e175edd1be38889a"
+hash = "b09edb049e7a083def6bcbb957ec514d95f2393b0c6a5cdd2e01d395d20c83b6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/wire_gold_cast.json"
-hash = "6715cd87427a41ed99c27c12cca47a534756f58259c79e571990184f58eeea54"
+hash = "ce69b1e098bcbc24cb72328bf8ce414864d8dc80db7af880764834b4f3ee1624"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/invar/wire_sand_cast.json"
-hash = "d6e99ef8a022e0f58836e68acf61fae2517d66cdb5f81ce190bd36c5af97bd69"
+hash = "b9f12ad10b76856dfa06349bc328b6c68035841fd1b844cd1f61f96fae223f45"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/bars.json"
-hash = "4d9430a6f64f2cd42b00af710e1746c0b36133a177a501fd5e2e0c8f8b4005fe"
+hash = "3343d545f5a2bac8c046b54914b431ac5250b3e13070200d42dff519ad83c300"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/block.json"
-hash = "4dad139828be6820f0fc25209f1a5bfff95d3d9c6d81fa45f6b3665fa5ec47b4"
+hash = "d56d6d2be87957b01db1617a38a51b275eeff1cdbdf1e71a2a2fffb589ee1ebf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/coin_gold_cast.json"
-hash = "b3d73083f5f045ff2c1fc72d314e029d2704a9c8dda9d2572477996d5b93a5c8"
+hash = "4ebeb5070e68fb1c1cb75bd3926fffac61343363a452a235aca766fa2944cf20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/coin_sand_cast.json"
-hash = "5fb59232196c773c77f4090cb660e3f24d69d753fcf279bd88c3d7ed38440674"
+hash = "6867fcdd17a9d06a36b641066bd525742fddaf6340337749ec1b12351177f42e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/compass.json"
-hash = "4b14163ef5188ddf37f8e9228670edaad828c06cb367332ad1fd8a87101c6e7c"
+hash = "08eb38c11c5ece23c18c1e64b2b4de69e5f99b9f177c8e6cad317d623f644941"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/gear_gold_cast.json"
-hash = "2624ffa36c6515c1628bc213e06ad9f66ee2f341b9c700245256af2a78b7265f"
+hash = "8d2eb54d0b843b150c7f66cbaffabe97e05cc56da72cd63192f5966579644ee9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/gear_sand_cast.json"
-hash = "313f500769e39c52ac84d2de22eb8867b3b9a46fa9f6c1edeba00238b7c1d111"
+hash = "63cd547a8d190b253367c24d70ee0c651bf6427c4cc863927914e1fffdaa9516"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/ingot_gold_cast.json"
-hash = "3300dbb118aa2bf37e7e034a0178445f338f4237d623999ea18893af190e5fce"
+hash = "359d0d010060fe8fe42c50faaefd937b4d75cd10d3352d91c97376b0195509d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/ingot_sand_cast.json"
-hash = "8fa3efa25ff8f52284f447c7c542b99cdb67c1593d1c7808eba4ae1933666fc9"
+hash = "eb64a27166c8c1a0b0b8f24c9a231489ecff3942ded8dc3e1f3166d23412c2e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/lantern.json"
-hash = "3d216e75edad438eab170f5df350cc18a38b4d1b9370243133168ffcda754cf8"
+hash = "95fc62d501493395752b3ecf89540a641d092e77b1b265543cc3599ba70b03a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/nugget_gold_cast.json"
-hash = "5cef7468cca674d030d56cef0c2f86652b4bfa9e6e5f1f12e996bdfbbb68c71f"
+hash = "86100cc93be9ac983fefcb2f371b9098d8490802ba55b08a232cfa066ac48fbe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/nugget_sand_cast.json"
-hash = "b8943f35ab252773336635b545504d8ab586fa130cabd628b283b1ff54e1b5d9"
+hash = "6d735839e8e75985d25f0354eeaea03622ad7012d7e35969ba3b265ccb3f8c00"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/plate_gold_cast.json"
-hash = "de6a90e8de587924e5531be65b0f73c14eacb381539b8989b5feb1da1707f828"
+hash = "a2db12ff3cbf4969da1b113c5f4958e239fddba96fc0bedbad178827f34a5e9b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/plate_sand_cast.json"
-hash = "34203ffa12040dea79ad02ed5e888a526f4533a699d44089f344ff818f17fe63"
+hash = "9bd24e5bdc810b95855157df40489c83429453a033f89d678967aa9f50da32fa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/rod_gold_cast.json"
-hash = "7bcd7fd8da03ff253f3bfb905e993ea322245600df1159dbf51e90ce351f4ea8"
+hash = "1b1159f8ae201c1f64b25d0164e6d80e6b55642f775bcc30625ff7d8644b6b6a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/rod_sand_cast.json"
-hash = "574b38d64215aab629bd4ecf46cf6e18e9c334ef150b00a9ffaadb89f64dcd4b"
+hash = "8a6b3948a3d96fc0bd19f74ddd5e1cdd28f6fbd31522295b4a7a81d3a5e2202a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/soul_lantern.json"
-hash = "727907a4593a901448562c1e836436cdb2aa04c10b282475711021097d3b5901"
+hash = "813856f6605d7f0c16d084f0766ce18f6b536a05f83de14d818ecc4e5278f1ae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/wire_gold_cast.json"
-hash = "398fc6586c310ac45193f7cf23ab237ecdb29e01f355f5908fa5d99b55fd641c"
+hash = "7bf2493145ae26969977730b92fd2b3085e24c26d230900611fa6d0dde426bda"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/iron/wire_sand_cast.json"
-hash = "7b4fd54a53a713a7f9ff32ac701c884e20da5b8b34637e57baeb455df1c1beff"
+hash = "1a0e95cb0f6f9f100024aeaaa4284931f839b58e1a01a90b5c54c97184dc8a53"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/block.json"
-hash = "06ee4cf690ab351588042391e6425679d77d08fecd6d21c8c2f8901829e5decb"
+hash = "7513dcfc4f50277de3352bcf65c44e96977bfbccc1a107c1716c86027b288585"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/coin_gold_cast.json"
-hash = "199063181fd24ef86b5e5fd63fa2b7f3ce6b887147235325ca42fbac62478185"
+hash = "1ffb4138b9cf990f13e773c183c3eb8c3711446fcc94e21797057d4e3c56d84f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/coin_sand_cast.json"
-hash = "aab1ecc9901fc4f4e8446286b6675455f5cf95938906ebd51967959dcc668bcc"
+hash = "ffe82d2065e617e3e3022ee23e6fead3242276bafdab1c05a8b70de2c4373e7a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/gear_gold_cast.json"
-hash = "bf19d28d599f3c69b93af7faa377d7376dbe914bcdb16d8eeb8b36d2ffa315eb"
+hash = "00a55d91aac83b9bdc50d1f012a89422b31927e76f70d688d3bb3b293496fb7d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/gear_sand_cast.json"
-hash = "5a9881efa877dbca927504c7eb17fd157e13676fb1fd550b11eb9ddadf9c0745"
+hash = "aff281c5f4b2694f6202019fd08d974ecdb5cedfa7166432df1bc36c28ff586b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/ingot_gold_cast.json"
-hash = "2efe744dcb4d52029732724aa500e2b2ea1e6aa953103868227ff2cfb2dc2f14"
+hash = "1cf4e13b5e8e6e8204e6479955bc9a12c94cbe74a1777366affdf6f774d55b72"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/ingot_sand_cast.json"
-hash = "cdc6758df10f2e34441890fca989f7b971b7cac14b84f12cd30f7ef47bd0a2f1"
+hash = "19a8fe04dbfa9653153371c9e60fec6407598073812a93975195e039b6a5b7c8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/nugget_gold_cast.json"
-hash = "1501eead283af9279b3b1fa070714e60b0155a0b3cea56afd42f16152b6c36aa"
+hash = "0794ff48343b5c68d52613c3abb1e69df14ee35c7ee450881ce149e1e7b5ad9c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/nugget_sand_cast.json"
-hash = "991a4be54bda991ec6990e1c1446f94a1954e928917f2278c39406ca18078c09"
+hash = "3e45f89632c5b00a4fd4ae8df8cf8d48e477ec046ef7f4eff7f5368729b104a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/plate_gold_cast.json"
-hash = "67f4ad1eb2f304aa88381b59860f5898dbbde9b66489de6cb5231b10c06dca7a"
+hash = "4dc26c3276d8ff2cc381a04df60a7f7377b0c0d092ca3f5ed08fcec916925908"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/plate_sand_cast.json"
-hash = "e762f05fde5f93033a28ccdec03e8894646a12729c1e7d0bde9e37027f46433e"
+hash = "e581ce56f49109d4ff2bd29d2b58d7f89f5894196d5ea066b9c65098482c7fb1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/rod_gold_cast.json"
-hash = "4672eb902d959e863b3044f2f1e56e853a4712376d94ce82d1c75e43736ae969"
+hash = "52e26129a5843583370e601c6c1bafb663da1abf8ed12307ee4d69ba0b3bcb89"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/rod_sand_cast.json"
-hash = "11d3fc8e54622c51899e55584632f2d9ad4161deeb511e8b7e99186455e15331"
+hash = "2718f3d14d9887a567a008971ee9622dcb2c4fbf84b0a98eca9ba01762eda406"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/wire_gold_cast.json"
-hash = "dd823ddcd752ccdcb11c3ea7fd82f095a2869aefb39890376ae6106c745ce086"
+hash = "3e9a275df6d35c4c00441f2c1820c6c2d0f5bc8f6a56f5a781b9bbca363d57b2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/knightslime/wire_sand_cast.json"
-hash = "3722099c300012edb8cbded08076199ef7a8b2f8c3d0e54c65ab080f76b7c4d2"
+hash = "8a67a30fc287592e27d877bbe824e6bb42955ca6ade4bf813b509ad89d71993a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/block.json"
-hash = "cf7bdefc564927ed42ed184ddee5bffaf569f93b02b9075dab4d0462369f04b8"
+hash = "88bbe91f4f1e22f56935c788e46565e583c45d20fcf38a18311f0ce65014e487"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/coin_gold_cast.json"
-hash = "c996b60ba7a8775d4ababc4d9169deb33874d6a4638aef5a83322a6d6198ad49"
+hash = "6a63daf5922db4f5c95bc94dea559272012ff7b800672fe0765379d1d7da6450"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/coin_sand_cast.json"
-hash = "57424ac40cf04d9f52d452a16a3ccafc95a0e84751d16d145b47a234df764dfe"
+hash = "ad31a991cfb8a8c97c894afa5f3989a23f8c6c136a990d07271638f18503d005"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/gear_gold_cast.json"
-hash = "91bff84e38ed8f04f1c5580a4d89f9b96990d851ffeed3b3d6767c417977c7c6"
+hash = "a1e0c19762e17b5dbea24d5628454d5f71d27ba86e2daa4166ad39e9ec207c17"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/gear_sand_cast.json"
-hash = "7a72fbd06c27f11577c5c7dbc965ab86d8562c382fb0f258b5a67725c27bc05e"
+hash = "f88fe35d266efccfad39ff2fa21992efde428bd8d9d9d7991f6455f73b68e64b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/ingot_gold_cast.json"
-hash = "e8430b70b7749289b862ec6d9a59f6c536ac7c5f86c9d2a3b70f6d171c5a9f45"
+hash = "c70a7ff9baf919cf66d69100597b13b0a6a569087f5583fa67a09ef72729db9c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/ingot_sand_cast.json"
-hash = "a0adea7b5779ba02e0742417ccfc6d02b336d2e26ed8460dcec84d771dbd733a"
+hash = "8b6a8bcd4cc6b3541c434ac0c74bfea232e0b04122becfcbfd1310a50eca6f7a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/nugget_gold_cast.json"
-hash = "b3af9a3f8f61e87f64ef8fabf6ac28b5a0ff4d59bfe1276dad12616117ebb0c2"
+hash = "5caf2946a4a02ef9744bbe6af30e541493aba8ae13522bb0b7eda83ec42764a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/nugget_sand_cast.json"
-hash = "2d22d59c6effe78855acde29400ff94394bf381a35b8c8ced00341c08af6093e"
+hash = "c4ff792f7b082d8b58d0c5aa0f1318a4c65145135bc314d056577958a3a57d68"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/plate_gold_cast.json"
-hash = "59fab51814eeceb505daa3ec71b2241fbb27ca1887894c6579a4cec9fb6d58f7"
+hash = "dd910c88e331ee3e24c9809036444a87f2c78c537c7b5cb8aa5356f43da4b29c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/plate_sand_cast.json"
-hash = "35021100f41c35cf6f57e91b24cf262cee0dae090c445a673fd6af09cfefa588"
+hash = "2596893829ee9b3d57a55c3446c37efa6e30dfc931ba2cebf54666b24e33a863"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/rod_gold_cast.json"
-hash = "8c50096e3b8d26d5d3000a4a271577d74186262fbc37bd2c25202eabe2613953"
+hash = "2a89bfde94fcabaf1a885a447d6e4b4595d64e0ca3892092c28bae779a8aae98"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/rod_sand_cast.json"
-hash = "1f97c3010ab4e6706af82451a7e3fb45e68a61cce9965e0e990606ed9be5c41c"
+hash = "8f3c911de76bc95749d09d8e6c1fba8268850e59a0fa08328dd76ff78ea7e83b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/wire_gold_cast.json"
-hash = "05dec2d7e4c6d120d8c28e573424e3d75880b9d3fd167497e6f3999a59335c81"
+hash = "ee42d310376693be54fd1ae1c0c915c28d2111f0556c5f106b4f7108487918a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lead/wire_sand_cast.json"
-hash = "ea7f3a3bb946173612aace66c3bda054eed5b145e8c41a7386ebf76c6e78accc"
+hash = "b485aa8706c13a64fd808ddd0b8135774e119c176de228296a4f4384eb0270d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/block.json"
-hash = "80eb0f31ab5cc7262507b48dc00c559fe42115f9bdc1e11d952f07c93ef67688"
+hash = "c918662a65971ce667d6220a9079719839494cf97dc1d560fb9ccfbe4b36ddf7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/coin_gold_cast.json"
-hash = "4bc920bf31ecefc8b7f888c989f1b6e79e1f03ab04ba388f93bd4770903afc24"
+hash = "ccaf9a11f152be4000d4a113c3281427accb4271abe174bea7928314db9bb99c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/coin_sand_cast.json"
-hash = "24159d9e98516419c877a2368da53b6ebfec7d9f6f9cd5d7987f7722619a0906"
+hash = "8a0bd7973111a32b8365ad007f4bce607dd66be96014df83b0963b1818adf0e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/gear_gold_cast.json"
-hash = "dc8097121138580ec4f5dafc99c35ae43d4e6371fe951fe92b7cd29124fdae97"
+hash = "30afc88c0033236a77ecb00b54b853217be32650be6ce55bb61ce9347dba4a60"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/gear_sand_cast.json"
-hash = "0fb58b29f437bdad45d074e3802b5fe68543d26fa3491376841e15c47a51b728"
+hash = "e010dbf1dbb390c8100387bfec1ca87e7ffff758e5d6bed39f30d1b589e7621e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/ingot_gold_cast.json"
-hash = "d442fc59674bf213d474c07d66ef3713363658a060c7b75b061279fa74f7aca5"
+hash = "81610b5000a1dc464caa77256718043c9eb1715990b8414b2e192e1bcea09ded"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/ingot_sand_cast.json"
-hash = "fab7ac84f9768a4de4927ee778e71124ebd527fd423e62e3b97c6c4943a7e76c"
+hash = "2030162d606552c45a5ba890ee8a42dc2f5c7886ff810dd5007ea60ebb9c4cc9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/nugget_gold_cast.json"
-hash = "5a54ca3ade177b1954b36b6eb22c636f0afe4170f2922d243f6a923624663590"
+hash = "fedecb4c1fc9bde845bc68d1c77063cc6998b81a30f83f330d91f4600b59228b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/nugget_sand_cast.json"
-hash = "6824d49c9a0b7fc1f54fcdea96e9d8f1af7ac0f199b61807576e63aacd98df91"
+hash = "8707c08cf30aa34af522316f27997e6ae660fdea83585f0db3e0daed3b1eeefb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/plate_gold_cast.json"
-hash = "129f463e3418f443fa5d08bcd74c19c55a06216f53f2ee2582ead55db57896e1"
+hash = "86249c759f2ef065445e53028499df6e9e16fb08ed42a0853c1eace123aaf155"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/plate_sand_cast.json"
-hash = "3b2f63852a431fb252fbbc104d30b82624498e140cc45c9892cb333f0108b710"
+hash = "0329ed5eeb02e7110b1cfec16d60c54fc08e61eddb427b7dab97803470001337"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/rod_gold_cast.json"
-hash = "430523c9b61bbac1011717afc1e29066f3636ed32f9cf673d148ddef61c2bb5c"
+hash = "6ec19de54cbb1561fc7fd0ea79b34656af9ad3ab4f6e811c7a431dd968545d82"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/rod_sand_cast.json"
-hash = "332abe9614e181f85918692b01d8fc06846c96c7fe72d9c6f35aadaaf2d55f1b"
+hash = "e69b3c6f164c0a0c7d137826a87aade0a898efdf8499a2ebdb5ff56e0f8c138d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/wire_gold_cast.json"
-hash = "b37c1ae946419f545ffe709ecfeca192a135cd79ee2f3fe20d21aa67e0a26ac7"
+hash = "450b68b5916eb76a7050eb6d7790e704538f860f99457650dad39f3d779b1e2f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/lumium/wire_sand_cast.json"
-hash = "55905fae80253654a3098743c86a84cc16e73ae27fa03ad5a6bd35b54204fdd5"
+hash = "a01fc4ac9a23c1ee41deabfc4e0946d7d8ee1b53c7e055f71f38e0ef48a81f98"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/block.json"
-hash = "fd7f148e1f26ede293d14ee716e836a499e7bfe4f1dba15dfc611b56dc440d63"
+hash = "1c4df1f6f4d0011031cf70999d469ff3fa93f6cc59624a4a73a73a0b74d3e20a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/coin_gold_cast.json"
-hash = "81d05e5977a8d2cfb85d03598058a28b0273d730df0b0d7cfbd8b5b620d73119"
+hash = "bf6c469641f0393ff80ae8755edb9880ce396db846e2d8142bad07f3c6d8f236"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/coin_sand_cast.json"
-hash = "6d3848c9297d6f5348f3fa642f3583b000a420f4a6a8592adde34211bb4a8737"
+hash = "7520a2125800d8c06ad5a999e0e52b9e474a2fd786e1ebe2699df8ebc484e898"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/gear_gold_cast.json"
-hash = "cc40b2e39af1f07dc22ee2efd06ff64bc9e9f21dd07b36630287830d8252d256"
+hash = "fb6727bc681a6ca3d554d2bbe8a3dae1d59bc34a424c68036a17035a2006ba68"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/gear_sand_cast.json"
-hash = "3ef4513fa1ba169a3b805e3a66e6190092b68451dae3ac70735905ef11f89651"
+hash = "a2b94282a0876935cb49fea27ec259472a96f20ffed68eb6e6c0f37b481ce092"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/ingot_gold_cast.json"
-hash = "c0c329284ac6b3396917cb8c89d77e5701691030d08c44dbb661beee8a86947a"
+hash = "ffaf59532120078a59b412906e69dc1772981bb4c665d49d6aa6b4b05b8f5962"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/ingot_sand_cast.json"
-hash = "fe60914b1b30891b5f9a51829fd45ca7edca0449a3f7e8188b638f6109bc73df"
+hash = "561d20ebf7ce4316d4cfb509ff83d1a9b7f62eb1b05b327f1c549af9dfbc17be"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/nugget_gold_cast.json"
-hash = "797ea95cdc5e44b36c48d8273816218967d640e89a735faf9fa9e0bf2f811a55"
+hash = "d483bcc40841583763297f499a2f77d21ab5878c57372cb11e5c92723741a9cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/nugget_sand_cast.json"
-hash = "9db908569408c7a3ecff0c45c48bcafe012a6417af0bb3481ce019081ed75c77"
+hash = "ed2bdb9b4f18dfd1be6aed8443696be11a539c0cb1f1e1516cb7d95a49f67953"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/plate_gold_cast.json"
-hash = "afc263b802204bccb9d1b30d5db629214d47715cf90dc5dfe98b5fe92be30d28"
+hash = "58c2ae96f2849683c63b7b1e5dfa553d59152a55c2a0747fdf202e6fe5265697"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/plate_sand_cast.json"
-hash = "0a3632412b6bbfd0a0007c68011ec2b5a0385c0e0d8e832454e4d0fda579d1f4"
+hash = "8c3978cfbfeb17f928ce6300c27c23840bb261a296b29798cc3c02eedc8b7a9d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/rod_gold_cast.json"
-hash = "35c9cbc15cad0c6da89894210c1ee05405fd7f7e76ef1206a3d3ea56d49c1df8"
+hash = "0d19ec7a9011b66250e4ae546613266f86a03f62734e8598cc1ed7bc0eb5909f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/rod_sand_cast.json"
-hash = "938400ef0d2ba0b19cce29b04f0e6d4c905edc64c2d07f8da876b533f9402134"
+hash = "6abd7ac3cd5d2777835a4a6b2b1dbd1351ccc568f6cc425daf7f1d5cd45c119d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/wire_gold_cast.json"
-hash = "c564ca8fac6bbacf53dfbd5d54e0c200c8ebe2719dfd25a827fffb0ead4c271a"
+hash = "3ea548165c9df553dbf1f6074e54003c435d0aa57aea9efe81d41bc25dea5469"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/manyullyn/wire_sand_cast.json"
-hash = "1ea2bd8531a7abacb77fc18ec83c75a78be515e4cc3a3a41280b0f4858470034"
+hash = "af42ddcb3b7c9330126c18ffea73b380c86ab91c18b20788acd01939b8ceeb84"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/block.json"
-hash = "97c02aff0efb9a23808ad7db54169d5534eb92d6309748453b396655ba34099e"
+hash = "5031dbabd68d9945bda981b7fd4ee2e03c01fb900b0c7848dca4738ab75e5098"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/coin_gold_cast.json"
-hash = "4e8f691bab2721728ba3b3c8b4843b91fbf4133762bf9ecd73abba0d79e5f286"
+hash = "30759c482e95f04b40eaf4789680ad714d96fc672d688a33c219e06f1c66d82a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/coin_sand_cast.json"
-hash = "4b17aeab0d71967973f15b1fda30b773042fd0bd8d259a807c99a987ba26e114"
+hash = "8ccbb08c09d6950aee59682da0bd7f1ea28eb50061a14c4eabd4a5e6f3474de4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/debris_nugget_gold_cast.json"
-hash = "ed002603d7c9353c25546be51d31362c9a91aca90a183972ef73ea12f7ae5f63"
+hash = "30a2a27adf882434c5bb12bfb310e048c0e35e4b38b876ec526121f50f087359"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/debris_nugget_sand_cast.json"
-hash = "4d71218ff1c230d3b7fff90f1d08651c98ee8b0e8165e4dd6870abf70dc69d96"
+hash = "fbba2f1702e98e821d9fd0abdaeaeeee1715453cbae12fbda5bb1ce2ad999f47"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/gear_gold_cast.json"
-hash = "3c058e79cac96b224f9bc5f77db4bce3c5a63769212664f6afdc7317986624b4"
+hash = "1d05e49a1ca2cdb218f4c5dd7bb44ca796d4e597ac18a3cc668ef8e37353b867"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/gear_sand_cast.json"
-hash = "421070d43d99c7b33a65fdf92f71a005f52b71c8613c1e6abaf03358f1b63b5a"
+hash = "b9f08a207aee358154228f290250ed48fb356bd4551df802fa71e7326ec583b3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/ingot_gold_cast.json"
-hash = "2d6df3054356905a724c3cd21a8a418c36694fbf9e21bfa064c8c548c418f2ab"
+hash = "97b6400e4ff59a672a77957dd8b1095501af7e8794a9b6f7618378f2c8950c23"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/ingot_sand_cast.json"
-hash = "8fd237d4e9ddffa1b8bab9326cecf2eac17f0144d6887a1995007a245c90cee8"
+hash = "df8dd156fe60e26e76a3211189332a9876c44750333600eba2a40f04d3b01fed"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/nugget_gold_cast.json"
-hash = "8c537edc98ba963ee1d187aeace26e5a4c7e5db0907c0a1dd12251e5b5dad33b"
+hash = "78eda729a0f6497170c24f98d695d09c84640d81b0a6ff4cb049fe7c4758d38e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/nugget_sand_cast.json"
-hash = "595e613453f0708b572bda80223851daaa2b7c1a4400d29b1879251111669df8"
+hash = "945c8f3597638a0267d445ca5ecb899442acdae596f94c0224f1e3991b401e3f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/plate_gold_cast.json"
-hash = "5e3c1f8cc09d7e06f175bc141746ac24f81186b86295f050ad8720b240658f73"
+hash = "bb496a7c2d58c71de09b50fbaa8ec79a62bb223fad940e081c8a812068871525"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/plate_sand_cast.json"
-hash = "52208f940e0ba5fd125d920f8656ee0301174cc1d9de46912f3c6253355a1fd3"
+hash = "bbf560435d1fb62ee7e3e4b674298f5954c6b5b9e52165e5d3383d0aea80ec19"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/rod_gold_cast.json"
-hash = "77fcaf2f63a438dacb1597083787821af39a7719194802ee4120e19f10124cff"
+hash = "0bb206d65ae051e06a72def1f97d440720755bff3c0d63593651d11f239ac7a1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/rod_sand_cast.json"
-hash = "ff2bae7874988a37e3cad4c59494ff4f30f35f03090c08061042f054e8c4c81e"
+hash = "616d5228c95f5a78fcd371feae98f3f1c2bb1d145428969a88b1818c532d19b4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/scrap_gold_cast.json"
-hash = "a22d5a940d004cc40c1e2a75e58aa7ce9308a455cf741838c31a223af29e9ac7"
+hash = "3b4bde699a359f86d5485b4529a10180af17dbc19d0129da08d6ac3951605f33"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/scrap_sand_cast.json"
-hash = "8846c1c530792b6a1e2d65e74f85e61692fd4f8ade0c6d83b22491393b547acf"
+hash = "5c7171685ae3c87e95b710a3a2325fe6d2e3ea9d84475e084069871c002601f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/wire_gold_cast.json"
-hash = "77af43d25083d17e2859aeaf747460fd17bf9bc725f78da16359eff96b56dce5"
+hash = "e21e1ad37144f8b6dc5e83a2863ea3068ebc63a083c0ea82270b6ef94bf543fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/netherite/wire_sand_cast.json"
-hash = "a64fb5ee210d230c2889af9aa4f8fada603e805077a5a674dbd7799c4606b223"
+hash = "b0c2a09ec2402df8fe1c86d68ec8ab34dd3c1feb77084a8999b8f242e5633b61"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/block.json"
-hash = "f8bd07d65420d84c4c822a3f33dd12927c4ef35004219c7891424effa0817efb"
+hash = "68db8510870f4c52c8a6d4a5cec6093bfa702cd97b871db7972ddacea46878d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/coin_gold_cast.json"
-hash = "b2e57fdd9a365548cfcfcdc6d17a8d20c43dc5bd9a1e3f179bc84170a9ce6bec"
+hash = "91b4369090712c783a227ef0ec4092c00fb4e9792cdb9166ff31447bfa2f675b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/coin_sand_cast.json"
-hash = "8ac7ec5ec77f9973cc8bb83aaf6a9338523d3bd751b2e7f9a981cf166bf85640"
+hash = "6deae27b43c2f41227769e58e906a19bf7c65b308fc994d29d467cff483f5163"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/gear_gold_cast.json"
-hash = "b25f0df9ddd4f4767dd96df2854268ca17def31cb113cc97f8ee800c7f2110e0"
+hash = "5d2334f7abc23959a589851a85627dde5c4a7ff12a8c75620cb8fd9bcb4355a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/gear_sand_cast.json"
-hash = "303d99d75718a1ee4086155a18c336b06c288a6da1bbe5857d53440b8a139975"
+hash = "7b3d3f77a90fa96a30649deeb7ea958005d89f1b735aa3963937f2e3860852b4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/ingot_gold_cast.json"
-hash = "e72221509f88ec5ceeb5c4807a439572d32a53b315b0edfe50b4f131358c2bf7"
+hash = "53fe50a43e7a5fa8b6335175b3de3d101999aac56ae2bd4e681e0a5996386735"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/ingot_sand_cast.json"
-hash = "c2524c69195964af7ab5ad9528a5ddcb9b64d4c00d512bd1a50d9cb26e217d80"
+hash = "9811a83624e6fc613f95edb2d533f08f6682fc23e5c2e2ddf512b4240fe42505"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/nugget_gold_cast.json"
-hash = "153913d8e0aaf233135b6aec971b4aaf8af17e09d2200e6621a4fae5bee32b0d"
+hash = "9f2c426450772ba600771a2aeb2c07aadc1f4b10963bd6fdb6eff032c6a2d5f4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/nugget_sand_cast.json"
-hash = "c2cc7e6391eca4b68a220a64660a2615792a8fcfa432390edc26266a283b241c"
+hash = "1d41af649e5972dcb0a917c6c8de0ab5e228ee16202ea0a44a95c573ea64bbdb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/plate_gold_cast.json"
-hash = "46c796974ef230e4e2fc5b12f4db4b2733a54f6ac78d3ec4e9b91d09dabea9b4"
+hash = "67692ff93012d5f6d106f40a338afc08a77305a90af65b4716b4c024b5545f76"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/plate_sand_cast.json"
-hash = "2a38a60bd2d2c6ebd05e28a73a04bddf07b954dc7c7d039850f71dd63d8b4ed0"
+hash = "b6df63bf1cf00102a2ff7418c56f84b229018b5cc07f64d534d271c197c59014"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/rod_gold_cast.json"
-hash = "03376234e6f691d21563cba55567f35574bc1193620ddc6b674be544133e989a"
+hash = "bd6f01139b2e94de8562bc46bff000ca7baf24154f54d9e3e70bfb6224dd50d3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/rod_sand_cast.json"
-hash = "3779452793445ee8ef228204d596e6437cb39c659d05aeeed68d80ae7af1baa2"
+hash = "c9857d3b0a943e70e5cd70a2e2e060114dca83df914b15b06ce18793b4d4f9e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/wire_gold_cast.json"
-hash = "86a4f33e65c917fe4c75042ab9e4e43a642d7398c74fa07488867902738f61b8"
+hash = "db73a95940dfe85efe5eb0768d5705f417f5cb2acfea811ea49e9e38ee3e1ed9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/nickel/wire_sand_cast.json"
-hash = "0631a1a844152d4e1fc6899233e7a6658fda550c63086cdee2c8c9fbe17d743a"
+hash = "c2c4e7e73672e5330da88df4a0d7bbd411dac4d68e61ca0f4d362886a2f766c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/block.json"
-hash = "528f00df6b75a5788ecc41cc6c189baaaeca3848f25ffe105a61da321a63a683"
+hash = "f4cd86a9e1826aa6dcf5f4302adbdca9197580b0e3ce4e0d0d32401985e536aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/coin_gold_cast.json"
-hash = "7d11bae2ef615d17b0fdbcf39d4170efa45fa773f9e36af921b8d279081aaada"
+hash = "9c7e936cd66863926ad1a0f4898f6c837e36b4f622c7d79919ec6ed5f538cb89"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/coin_sand_cast.json"
-hash = "31b0704ae232f88e95a0b041565b9804adbbea979dcc0dbed55675352b204d3f"
+hash = "f01135be504cdb107ab2b4b22436fac9049509d177ea2dcbb97303eb8fbf5b08"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/gear_gold_cast.json"
-hash = "43bf71c9194d0bc3c38d77fdb008cda1f6a42f93b0949f0d4e275ee28de6b895"
+hash = "85ef7f5c140d211b69740149373e41e96ebb6a49311b0e7862ec893db86548d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/gear_sand_cast.json"
-hash = "f28faa470571b0a128271804f5266d85f371d7d18e9490823dc8a55a031634c0"
+hash = "cf6241fc3e7918e80e0745f19830f57491326d00adc354a9abdf4601520c0380"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/ingot_gold_cast.json"
-hash = "3767a55b9e30b06a474817934b399c4bc8e8fe57f32285195e26b91d7d8b9369"
+hash = "f4ffb1a5e2782a89edffac9a708c3fb6ae55e8212cf9f63aa07abb265fd00c5e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/ingot_sand_cast.json"
-hash = "fdc8cd05cc3aff65f02f183a827a64abab065224ed2a3124e13bc32d41608876"
+hash = "900a9e1abf38901dc5ace95ae903b87b717443bfc3fe7b3aa79f9618af546c17"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/nugget_gold_cast.json"
-hash = "6ff04b5e0a44329bd04981ea1c5a20a918b3227e4b82b5011f164880421d4b69"
+hash = "30feb36a6e93870df8fcfcb4b93f918b208bad5cce2a27f84a4c4274f71523fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/nugget_sand_cast.json"
-hash = "2baab4f3d07ffab5394a08e77880ee8d92905983f4702577727ef2a17162d758"
+hash = "cc7f7294953f89d08957da9ad8ae882b04120ad2e953b7cc769923d6946a5fb2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/plate_gold_cast.json"
-hash = "d524260e3fecc20416fad03f9a22df8531523249088e781789b36602ee13b3fd"
+hash = "65ab837d40a22349321d0cefa48748cab092352b398bd187c1f8cad17f274bc4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/plate_sand_cast.json"
-hash = "3d255d387b4f59f3de607594e62d0856cb1fe7e1e03590c1e15aedd5add838ec"
+hash = "503ce256c5e0ade09f23841a702683ce9f979548d434434d2b6068b5beabd394"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/rod_gold_cast.json"
-hash = "9881fb138b4525affdc44662126c4e14e13f73be49ef33dcec45c454629b7e79"
+hash = "8e8b8c17d5e700188b51cf77e974b14cac3024f06556fbd0c32b2d1e2d5dba7c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/rod_sand_cast.json"
-hash = "862cd8427fd08e206e1f7ea4173af7011570abccf4ee0360fe8df3b2e4da1d9d"
+hash = "78f88e25a7ee90553a78ec283efd35cbaab3b2d8f718a0a080121d0b480d3018"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/wire_gold_cast.json"
-hash = "33abaa2a245bce700237096f59b3df4388fedeff23c755c5bfb6370d48ef27fb"
+hash = "b005c00e098d486b292f0da7d82a1e73edf39e6b61c5cb378558a10468a5ad4f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/osmium/wire_sand_cast.json"
-hash = "8e64ab7b5812efbe5e132e7fe630aca74f536a20f7974f5c77ab2d8d8457401c"
+hash = "3dc7e70f5ee881dda262d073fc7a2bd2e2fd1af9b3632f2a0437007cf7bfe78f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/block.json"
-hash = "e87de94bdcb8463681e8800f0cfdb9dc9ecc65ff2b3e54a90a0f1d11a97319cd"
+hash = "0f052f437035c165d03e5812725ef8a1d6f00a01af7a8fe2d5b5ecd6a8ff1df0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/ingot_gold_cast.json"
-hash = "fc2400257139aec67c6deb403298cb102d635cbcbc95707d425ca4e03e339715"
+hash = "ec019e1b350b3e56724faf61e3e7f8b57c0a66be6bbfcdb0f006747392d09845"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/ingot_sand_cast.json"
-hash = "8ea1e9fcdcfc322c096b77b445231706fa8ad9052c59428ca365a81393ce490f"
+hash = "52c6f27c8e0da384d33a8fca894dd66e004ccba184837d07bc6804dc321de5c9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/nugget_gold_cast.json"
-hash = "91146b31820b76a22f637a435d2afb7103548491876f7b1d8371a81820d5ff7c"
+hash = "301eb82a3f83228da593a535bd551e90cb4258c5d70035d5aa35e2b9e0de1ec5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/nugget_sand_cast.json"
-hash = "5cf572875eaa60151ebf07fc426b530bcc2849213627b5472ddaf69225743273"
+hash = "b2405378d6d5c2bd613947edbb5acfdec1d73f1094b7da892f35ad807954f1b9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/plate_gold_cast.json"
-hash = "1cbc7d3f0ca94729adc4b06f5771d357fbe13c592d5203bd0d916b57a2421422"
+hash = "7f15d6aa434ce2a1b5d3b969f542dd1bd65d9b425cf69a481df7307041abee39"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/ostrum/plate_sand_cast.json"
-hash = "2b98a5d49a224628d6005088e614cd0c2ce2f7b94aea3def8cb3dcbb32a665aa"
+hash = "63c1fc3897244f213decb6c07fbdebc4ff8349ddb605005408edef5e701af5f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/block.json"
-hash = "82682c2070ac0ac455ad71d651f6eb235696a2db5fbc3e7e230a2b7e8f59e601"
+hash = "63256e9e11a00a3f1cb361e5143d47547dde7b85650971bfb34d10437284051c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/coin_gold_cast.json"
-hash = "dca46760628d9097a729d55b67380cf71219f608aa5c6515880d5b00cf8694dc"
+hash = "36489c6ff71b3ee002bbdb451174a84d423cc903cee19e0b79865b55d960c91b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/coin_sand_cast.json"
-hash = "c60bbb19dc6e71c21d5564a721486da5809d16fb88b11e691e7e947ca5025ab0"
+hash = "45e018fedcc7819e1b6a5f57de44ce8a5594bef4adeb1ede20c246be7540fc25"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/gear_gold_cast.json"
-hash = "0fbd57703c027ee567f51229b262cfb10a9e8ce865cc5fe4bce15ae830cb1a0d"
+hash = "220c0a1426da281dc75c25278ff37764a43f64554611409fb07067b6b88c1af4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/gear_sand_cast.json"
-hash = "26d36aa967fd92a6429e4ffb54a645fcda778aa34de397d7145d45f7b105b22f"
+hash = "01f82d3d550d44f8dbd484e29998888740dae3001b70649d95d60fa0e0ebcb6e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/ingot_gold_cast.json"
-hash = "5feb491d791466c7547918b250e40f7a392b377ed10b8177f44156058afc1931"
+hash = "ae32a5c5081aa4daae7519eff005760a60dcadcbd2febabe09ba7277098ca4fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/ingot_sand_cast.json"
-hash = "0fa5e127733db77ca39589cfe67c80f2358d19f5c3b34ed25e0c62afc9f1f88d"
+hash = "fd2050a631ce6fccbdb524d612b23621d69345bce80e1e559f8015a2957b3c4b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/nugget_gold_cast.json"
-hash = "2e12507fba42bd3438af645fcf7fcca5494b60e83d3c88419ba136e067f9231f"
+hash = "7e7eb5ff8709a7874126a40a837b6e1f0407ed0f629b4a2d6a36760df802e94b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/nugget_sand_cast.json"
-hash = "2ddd2ad746ecf9cdee0117a887f49fd3cdac553b5c7cda43d6a14f077627f39d"
+hash = "b685f1539f62bb01b37fd80498ccd04d9d981584b23f3ea1831d9d8e247b221e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/plate_gold_cast.json"
-hash = "d0ed69bebcd23caa3df854743f446956f9e534887ef2bf8d9e97ee00a2596b9b"
+hash = "8b935fc190105bbcdd8a474b9b0333944d4aae68bb69d5a712d8d0f76834949d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/plate_sand_cast.json"
-hash = "6a0c333d45f7085567937a56cc97d81ed71595115685329ca00b45d1ea449aa7"
+hash = "0be728684eea03bad9994c919e46f42a6eb412086a2ff1e2bd9129b55ec1b1e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/rod_gold_cast.json"
-hash = "2385c998a0107fe5be79ed54d0368f5396ee01814546501ffa34089327862a9e"
+hash = "28baa390beec9277703c896782be968c3bd1daa6ee50a3a727b0ebc9751b012c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/rod_sand_cast.json"
-hash = "65cdf23f055405ac046b82d67758532d8a4956d8ce107919371d893c646154f6"
+hash = "3f24988034e7c291b42b6b5880909f3cc907ef3b99ef941bba20b7af0e95a2d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/wire_gold_cast.json"
-hash = "04eeed061fc6d01e56f79eedecc2016d6935368ae4d6065cf8d5f6398044092d"
+hash = "acd7eab42914ccdb49efcd26e04ed2c5fd365260deedcbfe22b4b472c7b8bd82"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pewter/wire_sand_cast.json"
-hash = "cdca8deab2d8497c3cdcff33133fb9100f6af20c62b0ad976467bf5e546c7011"
+hash = "b5afd9f721a8d6ae692c5587dbde6bb6b29348364c8ee848b523ffd779f41a57"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/block.json"
-hash = "1bdbd13b4a8081fe72104b75ca87765f6e80301174e3d9e463ede2f752458a3b"
+hash = "4d88500c15a9e0f83e1f1ee472790267634c1e04bf6ac573c55a9491dbca837b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/coin_gold_cast.json"
-hash = "e84e18fb4c507016d461e979381dd1033e2ae34755801a02bb23ad8114b3ab81"
+hash = "5a9abae30f85c17108af43439020e0111cf9013a9636456b834b8ff5a9318a8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/coin_sand_cast.json"
-hash = "f393bc09e2bdcc10a4d677ce8291ab525a7e9902d695efaed53c5ce7952567bf"
+hash = "7006acfa5013098a2087b1f717c314e79c08538e2b30596dd0cdbec4b10c3ee0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/gear_gold_cast.json"
-hash = "c6b88caa3576672cdba7c7fc1249b03da5e46efbd5f3ec08920033982e6f1c0f"
+hash = "c013f19afd223de0945fc35c775a82823e6c1debd70d0bf827593a5b84e1b25d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/gear_sand_cast.json"
-hash = "0cc345ff5931d7ad5e48a8bbff5f6f199de4a04e2e415d57908ac4d4e402bc76"
+hash = "2747e8abad204241b94a1ba54ef98fc6e36edafa7ebe87fa0a47e9e547d021d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/ingot_gold_cast.json"
-hash = "330ee5b0caf64176e92d554cc084ec98fc3b57688cadd0b70a564cfdacbb52aa"
+hash = "d1aa0b9157da4a5f40396ebe4c32f3a76522ad190f5619610e4090850c695983"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/ingot_sand_cast.json"
-hash = "0cd6791c1936bd27b122f64535675e3d3169128d5950cece8f89663cc8a4fed5"
+hash = "367cff928adb1193ed6d56a8c9fa63899bb2fc059f57a7564ef36e34cf5a8407"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/nugget_gold_cast.json"
-hash = "bea47c7c2b8cf376f09f2a79ac4b1110341458532ed67338024bcfc5d6793571"
+hash = "36c1725de798772cda1b6bf2c646898ff0a24b8deb618426ec58dc648f9e0ae2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/nugget_sand_cast.json"
-hash = "6b1df957a139be71ca364fbcbcbc81f7f8333f0c7493088beae3f08c3d36ac0c"
+hash = "9e0d73608459789b754aa4a5654d06336b5b9dafc74fd97ff52bd80084db18cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/plate_gold_cast.json"
-hash = "d8314b5570ca5cfa63dcff2450364a15055167f946a7e2734fad63c89abee2ed"
+hash = "bcca07c403ca6325a45ebbb8f3101f8e8c3a4662ccee91de3ba2dade95f79d06"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/plate_sand_cast.json"
-hash = "3d18a4f333d68965682f390573b88df663f2fb4952db174aa2604ab15c7cf516"
+hash = "41521f7e3a0c06b0918b83a4b6d40cefbb54822e0ebb3a68754d34fd0beec607"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/rod_gold_cast.json"
-hash = "8883b74a404a6ae6248de597ec7904f76c6f86ede5d7eddc05fc54effd0ae085"
+hash = "4a3bdec0a7c1abaa984e23e8d94b1c55a92d61f6d48cd50ada64646225c71e57"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/rod_sand_cast.json"
-hash = "a1f293e30fb13dde34e80824ce7e9a1f900f3eeb997bf1a367f7c1c137f76141"
+hash = "e36d190875f2c8ceaaefbb105c134e787557598ca6b2bdab8bcbc25431ab1c71"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/wire_gold_cast.json"
-hash = "246342a214071a9c6c7f6ad0b731bf837ba7ffe1dd8c138d5ce3473329d03659"
+hash = "182a607da2276b252e86e4dc9d5eeaf97e553b4a836a5a861aaabbaf11d0735d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/pig_iron/wire_sand_cast.json"
-hash = "ecc1be6a0c954561d23da6882cab0dfaeb58b1d87f90488ce34f00290e944c7c"
+hash = "6caf401d39821dee559cc002a04722776d91d9e6e1d10d99e3230289bc890a0c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/block.json"
-hash = "92bfdf60637407d347909d94007e83ac1d3fe221f0ce473177804a6a415aec1d"
+hash = "3f9a848d640d2a1d74a3868ceaba4977490a155ed25cb5bd73a7646c0bf99145"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/coin_gold_cast.json"
-hash = "bb7b139ce4a250424f11aab4afef4250812245723d03df58f269baf2997f6819"
+hash = "28c82f8a7dcbd2c183d271f74c77d494a3bcf23db41b1e6a812178443db2ff3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/coin_sand_cast.json"
-hash = "62b1590a6ba027c3f15b77d91f6ae7fde67771eaaf2de8597f6cd7fc399bee40"
+hash = "360672e52f013aa0804cee77845985ac3927a1a6d3a9ebd9be7267258c354cb0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/gear_gold_cast.json"
-hash = "6c992eb123afbd4a65d9dfd18b4b2c797dadeeeef747a33ab83d53648a446ecc"
+hash = "d0961c16e8088f3c7f8d11eea3008c12ee4df7008b037132f93014aa51ab2345"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/gear_sand_cast.json"
-hash = "aacb857f046b2a16508b11c94ebc96bbc26b30b7b6d18c67e5b2b2085ae1370c"
+hash = "bf8273e7e5906564a15f8ee92894c178f2f13bb86abe8c811b9e2f74fbfcb6aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/ingot_gold_cast.json"
-hash = "211dcfc859c89bc28542e2552a777e4f741199c79b3b39e22eb8688217ec9ed7"
+hash = "595749cc5a7979bb898bc30eca1847748c9d8b1de15f98522693adc5e8b0f3a6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/ingot_sand_cast.json"
-hash = "606f0ffd0709e616f7071930d74057eb1967938eb4b0179faee4ded3a83d975e"
+hash = "ddb6f2b0525b89539143067d750bd876cf5a3beac947a8ae91a51899ea84b9cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/nugget_gold_cast.json"
-hash = "a47bcfc8f6a698e582e5677eab6ecbbb4d2e0cdc0c0758bc258a472e1b0a533c"
+hash = "eb87fe6a5ba7be0123811ce4701afcabf9ffc7c554e9cffb124ca2db72a17775"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/nugget_sand_cast.json"
-hash = "8d1454a6757e0da8abd4a1ced5de2049fe8e59c79fcbaf99d3f8a2190945d4a6"
+hash = "267a0ff459c4bfdc7a99211d5eac81a9528f3a4e11f7ab582998b2b8be6ba980"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/plate_gold_cast.json"
-hash = "3f36f7c0df115aabec4be6879427ecc80384b1198839466eb97a58a5397dc98e"
+hash = "881c3ce46d5715e0057ff868b40ba4f4ef6549ab5ffa987765a97ada1820709f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/plate_sand_cast.json"
-hash = "d10dfc0ba08848884d7329943ef2ae0b5b93f80a903528efebfcd88364083178"
+hash = "fbe214bb37013e9f332052448925960390b822e8efe40fd5b9fb9cb04cfe3d5b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/rod_gold_cast.json"
-hash = "98f1d1ec655c439f1a05e7e92c02b01172765a03336bf4f073e93f51c4aa543b"
+hash = "e7eabbc9e488501c255faa0851b6b59ace0ffa08042a7f60b89277294f5807c2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/rod_sand_cast.json"
-hash = "0a68c8530191261158daa82f960650d8cf946169bcbbf9065344eeabb2d6b25a"
+hash = "516bca264b3f9c663f8b2087a03f8407f56ccf5d8b58aaa3eb99d1c4940aa9a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/wire_gold_cast.json"
-hash = "75e493a8e544b317aae03e7ddf41b35e7d6ed0a6bcfa64b7bd9118006223030e"
+hash = "c714b89023ee4a5b74f266d5276138b81c3ea225954a448b3b83a90722771eb0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/platinum/wire_sand_cast.json"
-hash = "91ac1eafb39441838c8134f7f7577a50f95f2d3ca002560974dbb523bcb54e45"
+hash = "1c6889136b445e49691c19e8e381b70af7d9b1c842b3d600782c9f250d8f649d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/block.json"
-hash = "a5ff92a810f989e9dc5b79f5e187384f8622753f84edffbcee9fa638bcf8fe3f"
+hash = "b85a0010746100d2aeb98d3ff2ee86e795c8cf60bc470c2ed5d14454882f75b8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/coin_gold_cast.json"
-hash = "7896a861de11e11817ebe0c9975a22a1e26d5c5e261c91c218a2801e95cff6d8"
+hash = "8caba9571c21140356bbd48c8ff94cfeb5f51b9bcf28a16a427ec201cf1fe000"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/coin_sand_cast.json"
-hash = "7f618e7ea82a8d23e3f64674607e53918520248c1e791f76981d64b6e87170ab"
+hash = "0283e711ca8aaa2da38efbcc0d5fd2aaca2c930c6c4e31d9f78372fbf4fb2e6f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/gear_gold_cast.json"
-hash = "979e0e743631c7dcb032dccd3e615363cfdbffc1c46422586682bc4c0d4c0347"
+hash = "3f733cbbf4d1878024e9f2852127e74b9605b55cb90c6ff215067135384654a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/gear_sand_cast.json"
-hash = "f8a833e39ddb67c926b2fd57817f540f1d96b98587fd7db4c347fbf563c2dc65"
+hash = "0f1a186b3fa335b5de396a7c038ac8c24facf18b4b745730dfdf376cc39c6fd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/ingot_gold_cast.json"
-hash = "c204bbab272cab7e731de4b47dde85f894dec89be774bacd9460daaf10cf9663"
+hash = "aef53878e61985b85e6e18f205ac970700b042a0f04766854fd4a7403250515d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/ingot_sand_cast.json"
-hash = "901771ee57989e744521b4ff682f46c24a0c57f55eb71c919dcf119042e1dd6b"
+hash = "474267ee3a2af7b0646fc4a0b57f735f4c3ad44b00358e0454324f38fb61edbc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/nugget_gold_cast.json"
-hash = "a1358e438cc7a093bd25bb932af1ecaa235124a4d90f952423b9973a8041ea0d"
+hash = "5008067e3f13cfb5fbef0c6f0a91b9aa11d4971747591cd462714011cef0a2b3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/nugget_sand_cast.json"
-hash = "44e861788280e3d168dadf7d693de03f48d8b28c3d5d95e62904976f4f67c745"
+hash = "450c8660c0bb49bbbc54948ef0776f012cfb0ac3372757613f08f119d23fe509"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/plate_gold_cast.json"
-hash = "bfa81843920acbebdee5e8424c13db9cf49a2ae5e37dc1e04b900537e9093e4a"
+hash = "c18316b4303ac3f40854f3d44dd307b8c44d5e5ddf12fa5f6969ccd52b8b2248"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/plate_sand_cast.json"
-hash = "dc5846ae2a1a4b281df0ce65e4cd8777879f9882b06e93088acaa1a751d72714"
+hash = "dae8b4797ad730ca6f8aee3146e0ed72a6db0b6846db54a3ddd4dc0ca33d9021"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/rod_gold_cast.json"
-hash = "586ba2606d972c8afd330c19f757cc62308b7d58dc1d645936725d0f3ee91af6"
+hash = "a6b8ed6374c00d5fef5752282656dbe580195225943e51e9603f498f59523d87"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/rod_sand_cast.json"
-hash = "b5d44aa60c99956b30d733f9407da6b3d67d1b19ee1295701198c12eb6ff47cb"
+hash = "b68ae731706024b63c9aa66cd6837d69ec17994f592b2bb23c66de18d08716f2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/wire_gold_cast.json"
-hash = "b591d06c6486a61d9d76714d705e226be1db23b03bd33784f7af97275fbd798b"
+hash = "b19be12355061baac58bf52e8d1f430a03029f1e71d2742e40dd59b56609ce2f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/queens_slime/wire_sand_cast.json"
-hash = "ca5f24ca97660a24a40b6f8c39a379f2c49cef23bdad0688201609101cabf719"
+hash = "751846dfc2bfa91fe825d3867960dedb4b3046fc3b27929afde8d5d27ff1b635"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/radiant/ingot_gold_cast.json"
@@ -9030,183 +9042,183 @@ hash = "3472d52df4a1f571f44df345143510fed5fd00f3d5c43931020555ab62abf533"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/block.json"
-hash = "b4680f04dc7d990a365dd38442ca14474083b8250ed515d7df8b128d66f272bf"
+hash = "bdd67beb64dfb40e2fc6239c58a19bf523c601b5d1c770a868ef80d60ecee2e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/coin_gold_cast.json"
-hash = "2bd6d1c88dd8d70622678cb0747dcd59ac842c99b4dc63b6fbaff593754fb1c4"
+hash = "5c04ea85fd03097fa6b2a6d11abd5320cf374c02695d9753820d4922c0e3a8e6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/coin_sand_cast.json"
-hash = "f193a0bb16eef07f02deb34d313a5eb27351312cfafbf65038275e625b237e11"
+hash = "d07bbabf6f81d84925fe4d67931014353953abdeceee4427a33ce9dfef2c9a4d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/gear_gold_cast.json"
-hash = "0098a6638e83b18e75794fba067f4afb1eb4fdc30e97f24bae58f24cdaaa484c"
+hash = "c99056222f4166312b52e7178740dd505899e003e5daa1252f13f4291c2c3006"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/gear_sand_cast.json"
-hash = "4ded673dfce5e2e4b91adf445887e442e02113ce6cec6f8150b9ee21c8f8cfa0"
+hash = "2e752d525dcc2d5f6b77b3e40d8d9786c206e69c23ecbdbedbaeaef7924de244"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/ingot_gold_cast.json"
-hash = "ab62d8b9da93b5057b81d638e769fa143e6afa48383db520bbbe4523945d4b1a"
+hash = "1ed496785e913b7ebc969656284bda4792a9521a18c5997c35fdb3e0c29ccefa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/ingot_sand_cast.json"
-hash = "18f522f8512b74ee236451bbe6e55168b283e964fc3bb2e4d0f7c97ecd291381"
+hash = "5f3f57d7ceec8b4137b551c36e7a289bf714760cf860511092716ef9c8f0c534"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/nugget_gold_cast.json"
-hash = "bc966899c170f406586464d8121142cec938f60458397a54dfe1ad4ca1fe042e"
+hash = "98931649d3c47d6c13b9f4ec38ffb5b87d3279808a8ea28277d3d45e1fac2b5b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/nugget_sand_cast.json"
-hash = "18d8fd35dc778e5895fc1ed135429d27feacfea489b9312c1f2a134feca6013b"
+hash = "9c69073cef8d71684fad2dcc995161c4a147714f061b61be7f10c68db7e2fe22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/plate_gold_cast.json"
-hash = "daf75d176a61420fb85109b861d450c929448b1e3b3ab04754d1e7ed9dfb048c"
+hash = "7daf69c5a5e1f354684a3dab88b7cf02efa63d0e47c43a334533df047aec78df"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/plate_sand_cast.json"
-hash = "20100bb4de8779a65fb8b8b3a56ae2c9641b398de0b94568c19b373365c6cc6b"
+hash = "31dc3a487e602e97b306a1f2adb7880cf38e0e839176466e90aa4b2899e34bf2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/rod_gold_cast.json"
-hash = "94ed7df5c4aaf6de9b8aea05ccfcca3eef8c2255dd8805c459af19a0be393b52"
+hash = "f681567f667c9980d773dbcbd25220f5fce1e2de26b13e56084ad10b3bca0714"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/rod_sand_cast.json"
-hash = "295920e0abe6f0636d33f52491d14ece9093c151d6ed2fd827be12d50a14a61b"
+hash = "23e22722c503e2d5b0e14305b9ecc8cc92275040809b0efe954c7b62b7a813b3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/wire_gold_cast.json"
-hash = "a87642dff5246bd6ca1320344ba0f99308e96a7be44361766c1d405264948786"
+hash = "0c406b15f487b2a733dd541219bf6bd98b4ef47f2a189e54b6ba58b6299f9d2a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_glowstone/wire_sand_cast.json"
-hash = "b5b73ece2c4b6412c4d945d457f3cf5fb206d7437db80a09ff55bd6d19f81488"
+hash = "0f81b130f87cff42bf611e7fc9de13800fd422a5a5ce6b21851adb6abf8809fe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/block.json"
-hash = "f73002abaf4dc3468a68ecedd2a241040b68991e1bd37d5b23c756545f64a2a5"
+hash = "44045e1a298ee5a5ff049e1d749bc54c3063a8973d0da8fc4332dc1d9a07324e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/coin_gold_cast.json"
-hash = "d72ab872b9bb77c3c559e19f9402ad2d37cc98e08c3dfe17968b3c6b8186a9f8"
+hash = "7e5ea7b6b08ca07f790bc3aebc8b425b3deb4fe4fbeccd4920074467e925988b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/coin_sand_cast.json"
-hash = "c21c595098101517138ea3daacd0cce48357c8be537624698633b164c6197673"
+hash = "7eb0e0c2d6009abb16e684bcada562280325902a4132ce9fd0e290618a374a40"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/gear_gold_cast.json"
-hash = "a945c7b79424134b51c9d374f9726df95d1c828d7935a43f80d14821678dfe2c"
+hash = "d1bd22f94d9485e346bcb3f0c4c89bf76eebc105819ca877d3fee0f6a52557e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/gear_sand_cast.json"
-hash = "2721296f642ae437effac275293e8557030411d58adb26e3b29ff5f3927ba5a2"
+hash = "61115f208ba339a7709d6fd968ce56923792df5347d0c5a109bf1a0354318303"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/ingot_gold_cast.json"
-hash = "81d6db2190f81f766e9a3344343bcd56510da8c5b9451816dc46302834896817"
+hash = "a89590dcd4e41ae9b72e0168881179fb326b20997b9b4e9d433a2966f8e4f4c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/ingot_sand_cast.json"
-hash = "421b5426d0b761326a296e0ec811a7bfbd01d8d77fc36c6ccb53f107b79efc81"
+hash = "31c18f1b081934fb0eab68bd413a211ea63c3845e88c3742a0fc604ba1ee990e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/nugget_gold_cast.json"
-hash = "2a852593ba05c904b56516d1ab61b1ade5f10ebf88ca4716e0014957c0c559ef"
+hash = "51b31461fba5297fa96ff41b41990573cd641c0471a1e658f403cb6be98b37a1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/nugget_sand_cast.json"
-hash = "7db3e6b3756036ab484c9a44d103db45db16d8e4fd57dc01860bcacf9746516b"
+hash = "a05f5eaf2c78aca81b81558840ca7f741a16e381e64de026839fbd2418f53bbe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/plate_gold_cast.json"
-hash = "a1300f3371ca12e912abb06941821e7910a6b684d122608ba629ee57bcf36a64"
+hash = "2eb5a7693ebe87df208b5864b92ed10cf706a2ac608bede58cfaf4789cd61330"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/plate_sand_cast.json"
-hash = "4093905ccbd02e632044e86f5a9c94dfbad3ba6a39767822fa18c53d25b1b043"
+hash = "b20693aaecfcbb5b1d556187e34ef4ca676ea64956230916237c25c6093e6f86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/rod_gold_cast.json"
-hash = "8c3acb444e1fb15dc035cdd961837a616387e5ea7ab3693906b696165cdfbc78"
+hash = "3e95ef1110d6863fefb56e014282eee3c033e58ab48b07404e16e4e3225eb272"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/rod_sand_cast.json"
-hash = "f6a6e8ae7b0260851e7a7e7e07dd434bc0b62e0be4c96290570e6bdb97522757"
+hash = "3f9ca5f35e86357c24efa158f36b5f5a817d8d99e3aa228221bc534d64208c4f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/wire_gold_cast.json"
-hash = "de15727ab245965b82be8812540553676e7ec15a4cf464a879a042fdd61de11d"
+hash = "68be47ae7e544c776e3b5c196c30e8db932f5dfce8e03768deacb8b398fa1ba2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/refined_obsidian/wire_sand_cast.json"
-hash = "99c30fb9c37e8d1787404c2d382b7a58341cb62345bded68ddeeb7bc9c7dece9"
+hash = "0e8b67682141244aeb43b188e81459911e1bde37cf68b7a7057923e11f6e913c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/block.json"
-hash = "651d5b514bc67db9b876be67ee2eebc542f6844f9faf9392bd9ac73368799599"
+hash = "f4beb087af63858f4bf6ff6f430a0b753165250d0ae64217bdc85161052bdc44"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/coin_gold_cast.json"
-hash = "407c2eeb57c79454df531698090b370e0ff3b6946d73b8da4de9806fd4508088"
+hash = "e2438965c47eb7f1be4d21e5b940cc0d48e7b2a538a526ffb4c7f60140f31499"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/coin_sand_cast.json"
-hash = "6cbee1cedab9fdd5567563a78602847209ccdebd940243cb01739431313db67c"
+hash = "724f805b4c7ebe4a5b531a6d812035763219fe6336c156032bdbc9f4a79ba9f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/gear_gold_cast.json"
-hash = "819d029437d31f4847ae55d5725538683cd589a96c60575329b7abada90a6084"
+hash = "e6974d135f875982c058a4c8404b7bcfd6cbad223b6ddd2e438a8545f63294f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/gear_sand_cast.json"
-hash = "993273bc30ce4ecce40bf9c838e94bbc9d4d108e2cca782a9a2506a16de9b56e"
+hash = "ac496c41db18aa76f9357ee659b68503537f762196b6c0cf8b1c39809fd870a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/ingot_gold_cast.json"
-hash = "25c1dae9d2a3cd3b836eaf7cd1642db2114fe3f754343f7720a6d8e5d3c087e3"
+hash = "b982b463000a28d6a894577c46e15769f7f1906171b548ae3492fb95c05e7fa0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/ingot_sand_cast.json"
-hash = "2d8354a3feee7d0d1acb5e80fe42fee9fd773b3e6a83266b0ec4b6c90b61072b"
+hash = "36bc0824988b91ce32aa81888ac9a696c9fbc4247b83916191b6d8469642455b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/nugget_gold_cast.json"
-hash = "98e74a3b3cc937c62d400ad026db004f6f7a4a14c054f0e7760b9bc004c5c18c"
+hash = "dbaae9389dd1199096f1d59abe5f9d83bd90679b39bad26ee4c49aea7112d901"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/nugget_sand_cast.json"
-hash = "4bfb8807862aee21cfd140ae2382df91a09fabd3aea8d971822fac7b56c2a1df"
+hash = "52ded225ee47ece542d81350d164e662ae4dbf5b1b920b721a583152cfcefa49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/plate_gold_cast.json"
-hash = "0e36c294f12c355f23077f9c9feff27e7f971d8f22648e92e75f187a6e771ee1"
+hash = "1c9be6262041acc853cd72eab38748a12358208fc0f49277bf5364a41def507b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/plate_sand_cast.json"
-hash = "011d4ad59487d9346b0be20c1f351230f10975f9a533a33d229422e47697b1b4"
+hash = "ca9b818f727861d4e2449825a8a94aba939ffbdcd90e9b57030a59a58bbc8bb9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/rod_gold_cast.json"
-hash = "9a99c1d7d2f067de7fbcce88fc4e8c68a02cc69eade67a34fdb9e745a31f0557"
+hash = "8c4943dfe8e6d553b2f0033dcc547d228a49c3fb30edda5d4cce1af39263e0c4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/rod_sand_cast.json"
-hash = "c26fcc2135a01591417d3a7592a849b2c6250b093e12934451b456101decda93"
+hash = "9c296f3f5bb93ac08184b8cad9d5657ab6200881a9fa48dd5a32294a13fc5188"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/wire_gold_cast.json"
-hash = "e885f2729ea738db39ee248a5c79725543097f28e9e06699d6436eca0446e284"
+hash = "8ba53ce2c9b518e4e2dd9902d5e48e32dedcc0c16756fd8c83e2b5b6b6b3b1b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/rose_gold/wire_sand_cast.json"
-hash = "71a448bed4538611ca21f672b465932b206d3d359627526affa94b2f8b3cccdb"
+hash = "1ef90666c2dbac91c246bc8d1f594c6000f415d8d73464f34a3637b2de143716"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/shadow/ingot_sand_cast.json"
@@ -9214,423 +9226,423 @@ hash = "3e62b25bbcf73b7b8cc5a664b058cce6a76032ad347dcf120104a73aaa1e108c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/block.json"
-hash = "6cf96d5e58fd965275e3946b10acbd666178115ad50c749fbff4cdce5ce9f0c0"
+hash = "db632e5ff9e0ebfc8c4e14fdea2d12bc55b5893b7d9ec31a085be5ca35d2045c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/coin_gold_cast.json"
-hash = "892f4ab77fcc19df0ea0cd6cc4991e2e489bc06f5ee9425e796be62477cee348"
+hash = "8da1f01af9bee602bfd61c6a00e6859705221aa43b10e084f20d30d5daa8f644"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/coin_sand_cast.json"
-hash = "4f46663200958a562aff4ea9360fe30f2ee14726e73f69b90361574ccd603574"
+hash = "535c8a4add4184d63ecfef5e0947ef769f5f029d06fdca66f199f1e33bc1871d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/gear_gold_cast.json"
-hash = "77333af06976506ec2d1e853d0a2e880db64880109b192174718b46bcee0d5b4"
+hash = "d3b9e8dfaf7a32655287eda274029035b68eb9da301b26077a50b424e5e2862d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/gear_sand_cast.json"
-hash = "cad318227a923949eba282c6c9305e9be0222bd494ac579151b34467473d0a98"
+hash = "8c3e4bf9bb7c88f2a84afd2da22e30a5ee71a5dbab5237bcc7f5f588ac5b0f5a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/ingot_gold_cast.json"
-hash = "d960a830a56707fa19c66b6c0db34c085b639cfb3a219ffb6c1b5e1203c72d7b"
+hash = "676bac6ca0b2f9bbecd110c7493e972d0dfdd40d6156f113056c01bd6126f36e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/ingot_sand_cast.json"
-hash = "4fec8a9ce14b693d0293ef339e47b3012c787f8e29d101b705032ee0db412ef9"
+hash = "c89082f238ad94611b5bb5d49c89e07046a4d6e658c094048189dfafcbd3d8bc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/nugget_gold_cast.json"
-hash = "8a4ea32cdc40ebc97b9d726c3f68f46f8a1ba187d511c79f670e90ba013bca42"
+hash = "99ed08e186370170bdb64dbe7c983195e202100feec29ca26de611a7cb6b9396"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/nugget_sand_cast.json"
-hash = "cb9f6a73c4bf51f86a6a4876cc57d9afe6580e83a7e2006b8a87cace442e0aa0"
+hash = "d951deab63bafb6d18e0de78a8194db1598e6c9c6d9b2ec8af87914a5a6175cd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/plate_gold_cast.json"
-hash = "672405986d6c6f8663163e7e40f10d547e275da297d9446d1aad0a888b2dd3d4"
+hash = "bb54ca7ff8b8516f01020ebf521089a13a27e01d4d1afa85c3c46cdfe5637ebb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/plate_sand_cast.json"
-hash = "0b702e349faf9ad07f6274b07dd2d740e4eb399d710b25251c2e7964e0085e71"
+hash = "8d647a4dcd4aa1c87e95346649cb50c5802f0049a337f8948a507ec9f960f42e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/rod_gold_cast.json"
-hash = "fa3808f529855c80f833816f4234755fa0954a7eaedf834feab0e8b46a637b8d"
+hash = "5789c01bc020f27e1454c913bac2daba846a41dd7b14f11f3ac0dba4a6d2af54"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/rod_sand_cast.json"
-hash = "10b5bf2b9001fb35daa7efcd19fd11123fc40b0e77bd8ef3d84402334673f068"
+hash = "dcd2b1a0bc2a8066b4b5f3c3210b3c456a96749931256dbb6e3765984322babd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/wire_gold_cast.json"
-hash = "e28ac51691609e0cbd3778f40c0f1eef55cbf2262483a8370efe42ecf972db5f"
+hash = "3f5b28a1c471d060b92244224ecdc69d0774664a8c70515149fb9418f5bbb090"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/signalum/wire_sand_cast.json"
-hash = "3c8414c0d6511a894fbffb2265a1758393d8dc3bf1800ab5449ac4dda8f3abf8"
+hash = "35f25a9d15e5b479988df3b810167f189444fff097ec00f4adc2bb6c3051aa6d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/block.json"
-hash = "3ed71ec5113dcc73f7449c55f09fafce90277e0fd0ce6c89d13d315d8b894766"
+hash = "4d6b3f9c6c51dba28d9eecf49d30e6e140fa4d1a0db4cda69e27b094fc34e521"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/coin_gold_cast.json"
-hash = "f42312461bcbf6826cc7116c8572d2c3fa6fb5db5e3293ee9ac773b0da8fb335"
+hash = "87a12235d3f75e67e5fa4fbb583607474c825b3934fb5b55e62bb4d5c6dde521"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/coin_sand_cast.json"
-hash = "72dee45bb2093399203e446d68b43b764d5a1208ee0355511b667ba221b4f4da"
+hash = "6b977aa6566fc856dcfc43f9e99b98944f80b9ca6c216dbcfbd923bd11873f84"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/gear_gold_cast.json"
-hash = "5268031b42af0e2f39d919aa2e7675825b4a94734eae5b8b60427c8d5f000cd2"
+hash = "5c47f36c926b568d96f4ab463573ef7560b62b7fd6f517347e5600ac112aadbd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/gear_sand_cast.json"
-hash = "90489accbc32e790fa955030835451d20e7270e52b3043f7894f57775725ed7a"
+hash = "34e40a8862d0155ec639b7b665116c649803692615a94c88fbc806dbee18491f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/ingot_gold_cast.json"
-hash = "57379a32dae17e1208116c6abf02f310ce0048fc2970a648aa21bf547c4c96b8"
+hash = "4dce1ef5baab5254c982e13839c74204aabe5698f235c1f6527268b20c5d923b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/ingot_sand_cast.json"
-hash = "242f7a47788175f188214014a525cfe9e18ddd3cf30e86553c49f89f3b344ca0"
+hash = "250a3c0c437e29e5832d0b37b50b90aba95f828a42100ab1bff965e52cea2665"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/nugget_gold_cast.json"
-hash = "7c82b427f40aede172c22062a2030f658550ffbfd05b5a63c965071a6ff30227"
+hash = "3f7260f737a726b418fda3ad4892782d6e6e92fb5614ece15a0d8c5cf283c086"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/nugget_sand_cast.json"
-hash = "60774142e6eaef0f39054b9557a4b43ecfe1560185d619b667f01c0a7bc03477"
+hash = "546d0b24a838949a34db2a77b4ff00f14afb401301d6ddda630202979c79f249"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/plate_gold_cast.json"
-hash = "99b51303d95e2bfc35bd211686063082be44c588c49fa79f4fa8bb7e46a9e251"
+hash = "e80e02c968b6adf563d5f7a409f39c8ba960b56bc0b0d6de5eac69b1c10001c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/plate_sand_cast.json"
-hash = "6c84f0d518c523f447413a8c37574acc181f8b9d847e3a0c25c14f3ea55078e9"
+hash = "3d974b40949bbb2093d16f05a659fad72a2357681be78de07ded972181dfc186"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/rod_gold_cast.json"
-hash = "b5415cc48339eb03d6a94cc1b19ea4d6672414d07367532d87c50aa3ed4b21ca"
+hash = "26252e9438e7866618a6e843ead00f7fbcd1260dc9f86ad4bae2b5125da3f673"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/rod_sand_cast.json"
-hash = "5ec61f907f04497704a10462d2cb06ae6a93279b871ac667401800f49e1fce0c"
+hash = "4c9b79c5019843b10d1914d54832acaedd588123c263f4e8049f43e4ca0dcb95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/wire_gold_cast.json"
-hash = "a7d5130e4545095c4ed165ba8c01d50c8f183e65b544e8ab3f8ea6f88cdc54e7"
+hash = "7f21db2966b2aea9f904dfede5d4da88d200993a5ab1f625c2c69eec27b71ddb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/silver/wire_sand_cast.json"
-hash = "342b9e1847d71bc197548a0f48228792015337de89f181020e0ec810f67d9055"
+hash = "d2f8d3e17a920587b286db40c51ad214abd6b38be3eea2fd737ecd20c281ed44"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/block.json"
-hash = "9b7cc819e1cdf7a9f5bb1631decf4aa3e3a9d954622acc33d60a07f99a923b13"
+hash = "9e369126236fdf5bc455e76047632d9ef4a4ce55720cb7f93ce7eead1921fd9a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/coin_gold_cast.json"
-hash = "eafde653f733a00557c437b0f6eb0784109c911ebcc84e47db084e32cbf8c704"
+hash = "b8ac64fe5235a4b3ffa9ea87b249ec787414a55fb5dcbe7c3ce400e481bcf1a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/coin_sand_cast.json"
-hash = "d24a02e380854b5eeb4a3ccae7c6db376d33eaa3ba9a9a6ddbb861a5150ac11c"
+hash = "92c7370673c7cfb480798f7572df43f5a4b74db71430027625f2d2656a930beb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/gear_gold_cast.json"
-hash = "51759e9c5d17d2c67c3b83c1730a97d750d0f976dc7ea2891faf3c352aeb9140"
+hash = "f3599f5c5ea311de18f3e0250add70f6dd21685873775c2ff29106b7ff57aa99"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/gear_sand_cast.json"
-hash = "8e0c6452f913b55ecdc1852acb10392d53aa1e82a4c78580e28347ac913b23f1"
+hash = "223bb9574153d1b38d4b377e5d868107683b20c16d667f55317a519ba3f3ed41"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/ingot_gold_cast.json"
-hash = "187db371068141e7fa1de567fefcce9db92f342c772dd37356fec119ad07e8df"
+hash = "6ce05f5ec5ddb077fd7fe5b0d8f273c58e3c992eea116478bb98c8fea87b4557"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/ingot_sand_cast.json"
-hash = "66119d76fb498344b89982d0c97330269ced2672d9f1066c15f95b0235659f71"
+hash = "d45b3e18f274078925fb4e8433ee8db110ab884e4349bc547d41b379313e2348"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/nugget_gold_cast.json"
-hash = "6e37ccd44a47302b74e9a3b67ea88548eda9506193e6f5f67201f59220c874fc"
+hash = "3598cdeef595da37d99d4471cc801e1bb225243c7d71c180b0817bcaf805cb20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/nugget_sand_cast.json"
-hash = "979ae1b2da77d161968d05cf618b251f23e5328663d664cab0c1f65979c93113"
+hash = "7050588ae36b30e1fca584a4c2a7b2caa7709671169f9bb4ed6ada5fc804a1dc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/plate_gold_cast.json"
-hash = "6d7b3492cfd020afb98c81ac7ce0a9b98ca5e99faf1ba8da017f058609da9323"
+hash = "b92e4b715aa32451763a1c6f089ab7c47aa415ff88aec959ea2c5fc509280811"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/plate_sand_cast.json"
-hash = "1f7acc0a5eab3fa457c4113573591dc55849ec1d1d48d16ad396a8c18b91cb5f"
+hash = "d04a5a014449b452f036fd3bcde76c538a02845b0dedfb49d8c0ff7d87425160"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/rod_gold_cast.json"
-hash = "dc9cdada0d2f3e2bf9b7243bf26ec2d8eb0a707f0d9d6466f458a2a82b5ac1be"
+hash = "01a629cc4831b5b99fe96bb7adc2d404b0f49411475f97be580b205bc9173955"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/rod_sand_cast.json"
-hash = "414e35532fce452bb5f4ab3bf85ca9469142ed5cd40bff01f0c3cc523b32574b"
+hash = "25482e1fc27ee1798cf63450d2021e4c64a1c5b660611d4a621efc5eef57f2f3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/wire_gold_cast.json"
-hash = "5cdad4e6e37b31d37d9720111685eeca997c4b19048b6dcf7e3ab372a6d62630"
+hash = "8bfcc88a7da1730c5efaad7b13a487c0b6f5fb779bbf62170510516e8ac8f1bc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/slimesteel/wire_sand_cast.json"
-hash = "c6858270617db023ad3a05d33564673efd3a7417ea704f3f41d4317681736573"
+hash = "98600cf246225354e05f48c788c964721424eecc69f3616714b5d2fb23500328"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/block.json"
-hash = "94025cedbe84a6af6a08d4b8e03276851a92acd08f175b7bd203d2dfc485bc17"
+hash = "f8d7b0a7778d61e238683e34fe9795b257937dcfb68a49a0d2d4294d0880488a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/coin_gold_cast.json"
-hash = "a3198731ee5bdf5a3b0f26bb0555a1bee1074e1fbb0dc10f5d12eea474d0da21"
+hash = "d0f60e1d831b57ac20d0b9c5465671187e4d5e8eab77fcaa5bc41a4207ec609f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/coin_sand_cast.json"
-hash = "92f2897f976f36e397cdec8446225d9d8377f18561edf350e9687e567c17d6c9"
+hash = "530358a86fa544d143cc9aa2fbd9ce6109d7dc5c7c9422317780965c98a5f8a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/gear_gold_cast.json"
-hash = "6c7b435f9a68c5c96caf9fa59a58abe9ad9d4027c110c1aaa72cc63a9d6f197b"
+hash = "74187edf0b77536314566ece1596879d374e1804ec6979bd23c3c8bcd858da44"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/gear_sand_cast.json"
-hash = "e1963604fa153d7a53aeecc3d48d12dea16ff809c5865fb8318a6764e247c4a6"
+hash = "17927255a940e60c4d2677d5fdef64b5a1c2eb0b263e349c5454a7a5364c2bfe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/ingot_gold_cast.json"
-hash = "3744062ed17782c77160dc8b77b13584b9f3c2a1e9636c4ead1376b2f0b95453"
+hash = "3f0bb02ee631dd513badfc9c8297d2595ebb2139834830f1671aca4dc02f26a1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/ingot_sand_cast.json"
-hash = "5ff6e3f35024f32fd446a2e1d34899d748cd0282ecae50d84d1badd7aae250c4"
+hash = "c555fcdc8652313a2e0549ecc71d2f2b22e1fbc2eb60d46347e709e07f60da7f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/nugget_gold_cast.json"
-hash = "9afbd3bd7016a3503d4591e876a6b697e4f126d9ad9dd5370eb5cddfc29d73b6"
+hash = "85acf6b4ec437414b4d5da14b35da27c601025b089a6ceebfd88d2211bf1ed5e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/nugget_sand_cast.json"
-hash = "55d7e2d324293f18dc57983fa5fbad38260fb824f57d955493c9ee91ca501be1"
+hash = "38794c9339bcad006e8b32ceca38968424e52a6da29aa073d2f2366dda93692b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/plate_gold_cast.json"
-hash = "943f49a706277d371c03be6ba43d78f36a4fe61587e8be6433252aea16b43ef1"
+hash = "c6fb04e2fae991329a89061a66c24610ce1a4413a8f9eccdfb2c063404363498"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/plate_sand_cast.json"
-hash = "a96f373139810165e6a0fd0866a3b6a98ae4c489e331348030d6f102695d0423"
+hash = "a157bbf8d842b54dc6c1e618890e0f246549688fb8ec916446a16edb1b33a880"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/rod_gold_cast.json"
-hash = "8f6eaefe8d07c3d302e0b5b760e01a71b6e5e896ea4e2ba35bd0d8005f791a6e"
+hash = "9623309e80d6ff051db3c0cc7e99292a93995543d0d01f89b8347aa76a0fc26e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/rod_sand_cast.json"
-hash = "85e71ba7c1f3b48474b5596362171417c2cae4af4c927c8a3299f8ae163cd94c"
+hash = "da18369680e26a02dd6add2ee074b8ee6aacd7cc98e4f281b8bb448ed2d1a0b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/wire_gold_cast.json"
-hash = "76e3735e92211e42eb8ca4648e7c64427f24312b6250992699474e9882aebea1"
+hash = "f0a701e3b09f9730f9d57a8b1cb483b7a77bb843b19ad9f040b2055fb4cc8079"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/soulsteel/wire_sand_cast.json"
-hash = "6f610fbfcc575831176d7aad85adad9690bd774aee87d5fe2266e816e854de1d"
+hash = "27799a6f04cc7bd47d5d5b48d0091fe94c8fb2877e16a742d5493242d39aa2c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/block.json"
-hash = "09eb2aa179d5ca8dcddb6021634834784ef28e0b671fa33f54b3cd8d0eb5e60d"
+hash = "ab7feff5cd0b7438879bfce9769bcc1046ca724177112a41160756f779752b43"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/coin_gold_cast.json"
-hash = "cee883edb8a474fe88f54f59b003c8bc3faaf7db2952bbf40ab81cbc495d3eda"
+hash = "e49c3b182f990c059e65f3fcc3c85f953c83db0c0e6e4409eacc38116ea196c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/coin_sand_cast.json"
-hash = "8b029897362cbf0daf9c9a13e8dae63a3f24fafe162f31f7dcbf59d63a2627f9"
+hash = "eabf6cdcccc30dc3667e081dd9830a9779c228843fbdb27bd629da7fb8c85c0c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/gear_gold_cast.json"
-hash = "2f75b672cd6a633e33ec970e9070b62f381fd20beb280ef555881106df7a5951"
+hash = "7fb6f88c1502386890c9058d1d07d2a8a140ffebae65fe775bdb65e50781faa1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/gear_sand_cast.json"
-hash = "bdb13ac2ce3e7dd9306232e7d91c4dd31ee8e2f58cad19fa7927ce08bf00f5c1"
+hash = "53b4a557c6fdd3b963a279a76d24fff094880a8729a352ad9f18777530a66bf0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/ingot_gold_cast.json"
-hash = "beef590d0f7d6127559f824458b940277c4352b0f4abbd90e1015d54e9f1cadd"
+hash = "518ca3c1729bb7cd897a9ac89396436b77771c6d8e8735a0089130c04dc1f9a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/ingot_sand_cast.json"
-hash = "7aaffa47f20fab4d79b39761dad85bb0bd7a098b9bb33001a6e9454669cea77a"
+hash = "b93b5bf2c19bf143417be5ff3d9b0982f91394a6380789ff7d1c90551b4e32ec"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/nugget_gold_cast.json"
-hash = "24566135990a473d7d7cf2ef34569dfd8f315c1fe083ab0233aec4d2a9aa9e5c"
+hash = "148815c52c64db1c487778ae3ebe32b21b20d1f13e60cc1f0e4935e8d755d932"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/nugget_sand_cast.json"
-hash = "f1676db3361cd30d83d5402af52b93a826ace6a5fc761a6e9856cdea1842832e"
+hash = "734a393453ec3efc408e140dee30e4c3309955194807ae4a1fd3c4852ce7ae72"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/plate_gold_cast.json"
-hash = "355268540e943f92ba81bb744aa6a6c6fb727ad4e333e0c50e00c6e1a713036f"
+hash = "b0929ccc35ad4205167c20241cf9c0e289ce297a2d508c8fd0f09a9be74badb4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/plate_sand_cast.json"
-hash = "5f60aa9e95e4bbf88563f54eb568aa20cabcc0ef610bce79ed6461cbd039ed84"
+hash = "6ef6b87e8e94edcc286d239391d11afa7ebf91653ba5e3b374f37e79ea340c66"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/rod_gold_cast.json"
-hash = "54bf1b638a4ee36607c05309878eb5d7b63b99f5caf8cce3b56c9e5e860ead79"
+hash = "1b5a0f5253f115ab9121ddc5309110c4815b3c2bc057deec80bc9fdb62db2e17"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/rod_sand_cast.json"
-hash = "8d556772e074f19331b3242086e6a5cd2799a78862d731926246298d07955a91"
+hash = "803f0feecefb9c3d99e954291617cd2460ecebd46cb104743fc075ed3f6b230b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/wire_gold_cast.json"
-hash = "42a2fcb42b8b3801dae39a0c7bc068bf85be846003c4c842fcaf7cc5a5b638a2"
+hash = "50b0ce3c117234b6fb061812c3c187be56f129365295b4743639369b7252e765"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/steel/wire_sand_cast.json"
-hash = "9ccc72b7790204d7a8ef2d5a2890d8f99c03a566c8b35063dcdf4c948cfa8355"
+hash = "f6c56f04a12a2e77f46b1e27137df6c68b7c2cb3d7371cdfd16c13d6c64c986c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/block.json"
-hash = "732b4ddcadcceccacf378b7dd8feefd25000690de9995b00ee2d2153b9f83ad5"
+hash = "68bfe81ef2ea0860f8fd67487982beb3c471521546cb7a3bb81af486c278d577"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/coin_gold_cast.json"
-hash = "7e5a85d23dfc2f8c9ca3dc8f9a542726ca1344b80a342595d529ad18aabd4ee4"
+hash = "397d792f5776b388b89c513b1495b97a7c881b0fc2836ae982df7a3f51945e5d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/coin_sand_cast.json"
-hash = "12ea9fa224c0ec51b9dbb80575acfb05953f6cc2af88f154ce64f8e5f27b9b77"
+hash = "e47d490e7fa1debec77f23062fa9b73d8aa87091091bdbdc8db1c9da35e2ce2b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/gear_gold_cast.json"
-hash = "f8fe90ca7dec5ca42abadd0af501b3b29f5974996dce1526f86346c7714b4660"
+hash = "a95c2bc83eccfe3d4cb35c932061ce33ddf2b0afb504b0cef93a1cbdae801fb7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/gear_sand_cast.json"
-hash = "fd922f6c287d7a3d40d1a3796ea4f3a4755e19348fb0a4153b7bbc7ac249378a"
+hash = "637d4f6e3d793b843e54e6b5ac3bc524b9b3590356033d8a66aea19ba6d76156"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/ingot_gold_cast.json"
-hash = "37eb40a7a55cfd50737997a8c34949f68260a55878ab0592a6a48eab67e6d7f2"
+hash = "0a4a2dba64680f8e09e11e60f1a7711738cac7145d0478b1d94692ac10aa3fd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/ingot_sand_cast.json"
-hash = "5d6cb42c821c591c3812d2f86d13a0b6863a7032d48232515fc375d9565a7a63"
+hash = "6f8eecc6bd04a9fddb2bd0efb8c153e9ae305f3494223ed7f4aa71ce3c167c05"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/nugget_gold_cast.json"
-hash = "982e26263490665977e8f9373120a824993cb50dab4f75975ea3a2e7f3f8cd62"
+hash = "aebd1c19d9afd538ad0d8c828f3621fc0bb264f773c96d821b19dd023f3d85c2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/nugget_sand_cast.json"
-hash = "fd651434e36cf8dba59a32999888f92fd220879abd030c874e7798d3619f2a47"
+hash = "480d3f9ba270df2587668bef3d540199545cc12ef55c7c5f823361b63d9ebdc9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/plate_gold_cast.json"
-hash = "3dcd2a4ecbd51532a9d001e99aa2090f760345b7ebd0f2b3510aa6edb66327fe"
+hash = "3e7e395e686c5884b62c199220e4714222868d7ba46ff6a07e3313bbf96b046c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/plate_sand_cast.json"
-hash = "0ba8b5555f7155026029fcfd2a12659e84a668d604bb0100162bd1a9a934be1b"
+hash = "3516d4b1fdbddcf55dc505907a0ffcaf6650a20a228bd66a99cb36531fdd863f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/rod_gold_cast.json"
-hash = "ae61cb8e9b7281c2ed2a7b4980dcd3a455f50e347fc788e37eb68de37e3e9909"
+hash = "a226808113c45194b7dfb1d56b973b1996fb00d05bb7ace1a6074d725271961e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/rod_sand_cast.json"
-hash = "9828acb6618695bdf504c9e6c6de9bef0ad97cecc411711f5e03175dbdcfa4c5"
+hash = "d16c188960e93fbf6646e06f9c1059e975765e6bbda4a2de1e032a3b6b61289b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/wire_gold_cast.json"
-hash = "e5bf86231293258863784b4d2a6e3f8129546922739777cf4691dc2c49905999"
+hash = "b00a295c4e261cfa05efc091f3bc07ba9f1d1a42eaae122909e958021cd3ba33"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tin/wire_sand_cast.json"
-hash = "53c621c5d8316c8bf18c335d2b912d113c085cc0d64a98604b976a152a5ea703"
+hash = "5df2c52717ce194a0a6cc4d02f74b3ef10f732aa2aaf8cecfeabf13cbf4b09dd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/block.json"
-hash = "fb6f24fa22074d16be66df76f0fa7749d903796330f975d589ad80e3e48b08fd"
+hash = "82bf48ddde255bead3c43f7823be3a1dd0ac81e15d4cd18c9c735e72f5fecf3d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/coin_gold_cast.json"
-hash = "7564bb4d92a2408a477a0be6ac551a6c14e3f6ad67c668dd498b206c058ea5c1"
+hash = "852c35131e494495959a71fb4ea713e0b643a05b9b76844032ed83dedae7dd08"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/coin_sand_cast.json"
-hash = "47b9f1c0455e1a60be6b35168f0823b3f8ee99c2cbaeb19b9fb66d95965695a9"
+hash = "d10e2eb665c035ea307b75e5d660b62cbc40d7a4ab592fde784ef69e5548a17c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/gear_gold_cast.json"
-hash = "208f0bef5e21964ed2627a217932d4bc3ec3cceb6e5b7cfdf4ebe2a7844361e0"
+hash = "464316b5043f2be09e90eb1600644e45dcbedb80a052c21b5ac407e451e5ab62"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/gear_sand_cast.json"
-hash = "355208f3f05f180810d66816547df7d41a1f9872f4fb60a26a8e07b9744aa5f0"
+hash = "fc32c6871880ac7c42ce2c5f59945e4b4ebea9c429702c5ed0afc03bac0a7499"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/ingot_gold_cast.json"
-hash = "a92e2c9ae68cfd6dcac61099a2e446fa75c82e3487fe921687b28944807a429a"
+hash = "56d54590733b7b7ca1c6a03b863c2da528d93b9839544fc8e9a194d39eb00f95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/ingot_sand_cast.json"
-hash = "6460da606936263c70eb8dabdbf9db08cdd24bbb8169829392c2d96cbcacc969"
+hash = "80855409ca75a2c51e81148f010d3a659b7d95f082119a70420dab2ae2b25087"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/nugget_gold_cast.json"
-hash = "e3890057c3ceecde427178f7817440ccde1eb68b5fe583adf6e471c8bd93a650"
+hash = "19538cf65c6eab022ec64bca44599434da60e882400bfa01219efb9dc520594d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/nugget_sand_cast.json"
-hash = "bda28f18037a82e21dee82a983c7e0076212a80d0bb0a2a581655fbea979ad4f"
+hash = "717f8774cd5b5b8bbd31487c1321f7a728ccd8df966dfcb389bce5262c5788ab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/plate_gold_cast.json"
-hash = "f9df96616c827ce1b501ef140ca6921a5dae4e405437d69ef796164b23987ccf"
+hash = "8619612382308a82c9077246d1c53014ba4c713a87cb9ede4262b0e1b61c04cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/plate_sand_cast.json"
-hash = "a2575cbe8ac4e9e6ff5529e93ddb48c490bfa2afb577be35503785b255ab775c"
+hash = "2364bb56d505efcb8dfeadafd0099f1cdc243c8e7d5879ac92de919366709447"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/rod_gold_cast.json"
-hash = "60b66c037c94d28bd3f05b2eb3811d60a6fc0019b6c35bbea47172f32c965b2d"
+hash = "b8e2b26576e87a1cb650a863918a42f2da63f5b04d0371c395a9c0bbb0d4e4f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/rod_sand_cast.json"
-hash = "edff89bc6f1b4e98c0142c1e6f5048b441274032d2afce90f1a37cfb36d12114"
+hash = "04e6ce345f86aaec1ee3126f1660f907671eec1b2634c1726d45e219411ce934"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/wire_gold_cast.json"
-hash = "519d416593e155c47904e6fc77578c6b044373f2d5108447f2aaffaa3c5e5af7"
+hash = "af5e5089a335b87002ede25b862ea0f777ce185783608ca3a2911c1553b87768"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/tungsten/wire_sand_cast.json"
-hash = "60ee6c8ab98b701daa94694021dd79a3b43aa4aa7de508560692f86308198eb6"
+hash = "c9ebb11c45ec1b2c24c36ed653c0fae88553a82c1434193c98597a44756e9695"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/block.json"
@@ -9638,139 +9650,139 @@ hash = "9e7fbcf9227e8486e21c832e3cbab77292c9e5c9d48ceda21254a1080ae160b9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/coin_gold_cast.json"
-hash = "33f115b364c8a0462f5ac9edec73a77a80a556e88b024014b5f2cb54e31f8d1b"
+hash = "a41c6c560009f2f2be64b5e35eabe8ee16f08698192cb7a195ba834903002ca2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/coin_sand_cast.json"
-hash = "09785a9495fe298daa4da49fbe050d8802977d2fca641b9d7f8bcefcb0dfa494"
+hash = "41a31e81d2debd7d0625db72321393d33cdbd94f0c34a9e933956321641c62d0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/gear_gold_cast.json"
-hash = "86b913c56d5a596449a7c0e8c6086f5c7381a6c747ca2298676924944d72145c"
+hash = "098fbb94894d4c4339168abb5889fad584ee3d7e32cc181cf4d9c319318ef847"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/gear_sand_cast.json"
-hash = "0314472056c3946437753b62b19eb52c952b3c2620cc8f46e7ad69628b709754"
+hash = "25873d5623e5f595523de493b9cdedd5258aeb81032d57a1bfdb90852b7e9e69"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/ingot_gold_cast.json"
-hash = "1a5214ee5cfcce8faa2afdc3973bbd465c2fb62f6275b3fcb50c3766727657b2"
+hash = "7a8f6b7c654088900a9ffec08b4dcde7115e7de6dc4a16b6682e59bfdc8388b6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/ingot_sand_cast.json"
-hash = "de48227588bc024488c89f21a8f3f1ec7f3248fec0a3aaf1402cb89d32c45fde"
+hash = "d2b64c7c665d4f287aee5163238601ed565f96611a9a96d4bcb63306482ad3a1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/nugget_gold_cast.json"
-hash = "8f7523dce589237a5db21a6a0ea28471c61391ea3873c065d0376e76d9622ff7"
+hash = "130521155d0020de36e2db44a3551339776b19314ea3cad6b4c1b25bd25779c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/nugget_sand_cast.json"
-hash = "7b2277e5e852938c472df32f2adfd173d915fb65e469970cebc5e7462a5a9929"
+hash = "e2fa64d5af61370bcd62c667a72ecffe2c7515f94d8b00da526d82ff1c3b6701"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/plate_gold_cast.json"
-hash = "ac1b7a767fe05a32ac9f31f267c8f503d24547b573652bd2536bb9883ceff027"
+hash = "7948df7c9b1eda4d9cc85e55b61a5df4751569dc795a0c626cd4edd7ba2bbd47"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/plate_sand_cast.json"
-hash = "099c985d5405d7478897f47963b2cc25b257f6bf848ba6e615365a25847995f2"
+hash = "66262f8274fa613ae07d73984adb935dfb8b7ac21f0713048d64176da254b113"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/rod_gold_cast.json"
-hash = "1c681840c077d4a71e2f6a2f5523dda9baa7337ea4a8d4627d6865f2efe9a56d"
+hash = "50a2657804967ef92f6299b9e1f384cf7f431a152eed6754dde1f0b2e07f8df3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/rod_sand_cast.json"
-hash = "fd087c722a877d14acc33fd7983a99b0b8f5fe1391cb70b346ce4e64f39a8f62"
+hash = "9a896f6dab274119cdf12594c9d5d1493653ad2e4f42fce6b650f6ea8efddf55"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/wire_gold_cast.json"
-hash = "13c4da5f100647cfc530f6290107e31c8db8cf55a498e867db3b2fc4f90bcbc7"
+hash = "393ba429f2d23ee9d9888c7d2bf35b3324d4444aba98fb4b8bab182554012628"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/uranium/wire_sand_cast.json"
-hash = "a86ed57d87466113c2228cc6a62511868dcf88a4a0e86bb75d5655ea5bf3069d"
+hash = "9238fc0ecb3e2a9d970fda3907ae28c82fdbf59addacfec9bb96bfc341e18d71"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/block.json"
-hash = "3abf1476a7f55b05e0f09059dd7df642294aa1cac442a4659927d6e88438caa1"
+hash = "8aa37aeaf6be36b780151b1032cbeb6cf63b3cc364e3b4ddf36e09a2a4e52d47"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/coin_gold_cast.json"
-hash = "3983816bb6ed4f8ca433c2956eca0bfddcc0b816cbf25ef28fdf0330930f1af2"
+hash = "f7c524473ed2ecaa1262069733146ff0f7b719601d055f6dfe6720ae98a418d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/coin_sand_cast.json"
-hash = "aff604c29dffe519caca2864cc19fb72e23a44ae7ccf99a9507d6fb1d3c783b3"
+hash = "14ed3ac3ce626934e0d1b5491f395f0db38db794a6cce86e3e644212d8db3b94"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/gear_gold_cast.json"
-hash = "049432702e6bba49717d5784b7c5191874ad779832be05e0f81d21f0f60b90b4"
+hash = "1d058618c47b76e2814a2b8b1e9f515bf72b501cf332b1adb9a6edfa55e8807d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/gear_sand_cast.json"
-hash = "a51c72a04623ea7c937f1753cfcb4f6812c6d1916371a140bfa5c6230266fbc9"
+hash = "4ac17a235aabb5547e65d6e927f9c959560c4ed4cf50c54813795930c68e0975"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/ingot_gold_cast.json"
-hash = "258d84b227c89e174b0c0e802c0603da5f6170545aa68a67a3c956dd8547dd6b"
+hash = "6e942865b8cb1538d13527be5de0eae573c09d0d9c91dcb7c66f5051847aa4c3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/ingot_sand_cast.json"
-hash = "2e53c91a9191e29dfd8041f30637fa6e73922fb40e875082608a0d48539a4de8"
+hash = "7c18621422d0cfeeb2c91d723c4b9d9adfaf36eec0dd01a6935e69c6dfe7f13e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/nugget_gold_cast.json"
-hash = "927110e933440372b63707414b7f6e5e54994fb86ec1f51f6941900269e17ebb"
+hash = "77660cefb4b924cd1d7c5fb36fd6d907c3312d31dd76a32cecc6593995895bc8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/nugget_sand_cast.json"
-hash = "8d196fc12e5b144e453b2be0dad7bcb5715a49d325b2916a9798814f1c48a134"
+hash = "1b280dd6dd803c8e0007f3609f2c88e2b25d2000b050aa605f42f169b83c9387"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/plate_gold_cast.json"
-hash = "0312bf23128deac82c190069d1aef4e893bf128ab02d0124c97b05ca1d79e859"
+hash = "2733263e9ad321bdb02a4f9d9f3109325bf4d5d4a76afc09ed2fc81988b893c9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/plate_sand_cast.json"
-hash = "e4b12ffbf5edf6d39aab3a41ee9b0a58cac08a06651c544773b2c02e1c4d0714"
+hash = "a95c0de0ed41490b77abb5fc3d31bd7a4e3795d1fd7bbb2f2f1e24c718ec66d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/rod_gold_cast.json"
-hash = "79e250e03b61f923a574b17f6b9dc64ebab41ef545050f4810cc5e4c3b5d6932"
+hash = "0c17df4b5497ae596f5b5c8da16153e6086ddfba95457609cb776434e43d0f6c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/rod_sand_cast.json"
-hash = "a1e9fd556b140eb5f3c7d771ce4c213307345931b37fa6cf9bab368354a99001"
+hash = "17142b369c4dd6a4f0498ec8567095fdbed3c3ed508e3afafb64b32a8bf1cf86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/wire_gold_cast.json"
-hash = "94165589fee5d3a87d77efae7e2152018a1688816d98149aa8f5ece0d79248ce"
+hash = "45ca052c7d91ab29295f711678b4e2781d1c4a5dd361a50a7b1a811676572859"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/metal/zinc/wire_sand_cast.json"
-hash = "460dc95dc4147388e0f04b7b43ffd8d6ad082db9abe633c7fad047af7c2c5ff3"
+hash = "df1f07df57b94e8e2fb73788939e4287f3993784bf7558e7dcfc49e35fd2c0b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/mushroomstem.json"
-hash = "74f5285b55472201214974f3f0773ae1fc72d7090d8e2e56e1a9662ca3e4ca40"
+hash = "a609926a2e3520a1d9371f857f60f1335e9e4e0bb2dd2a0c4572fd3fe91e4061"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/obsidian/block.json"
-hash = "0bc807eb2d8c91949cfde11b8e414449452f0ea0c0ae2aad16c221d156f437c6"
+hash = "7548258b93c30d8bed10a15d5a9eec2366be652d33036be87249e5b25f8555c8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/obsidian/chest.json"
-hash = "67a3064cf29cc30658365e16f29d2148f08c462a00a5d85f63f65e628b06562e"
+hash = "2d128c29223ee59df138d608b395234638cf2c73b5c579bc7da31a979e3b517e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/obsidian/nahuatl.json"
-hash = "57d7b4184612329e46cf8bfb76c15a154d657e8daecafaeeddea293b037ef867"
+hash = "1b1b3d2928901cbdefaf6e88a1c2834eab4c2539ec8ba87286c369cfed6fb0eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/obsidian/pane.json"
-hash = "5a573d7f0e2bae580bbd71add85cd62e1348e6f48b334bcec26e16a2a3a25e71"
+hash = "6ae5eb1fb7fa2edac66c5934891f35171eb71dde2045fd79fe7540823c0feb3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/ostrum_gold_cast_ring.json"
@@ -9778,151 +9790,151 @@ hash = "9d34986b26e10099148a8904e09bbe5a70fdbc07a062d0ad324c0f9c31f98545"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/andesite.json"
-hash = "93ab868c263dd9469557adb70cb7ec7627372d4be0190634101fdd96504d6c85"
+hash = "bab54b3dcb2b9e571b0fbe6cd5b2cf09a23d73570ffde36a3c5cedcc88345583"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/block.json"
-hash = "5c9f1c8f97cd8ed92f21224b7158c996e24525af642e88076fc437eb39d4df77"
+hash = "21a49192defe09d0e192947a1a77a4c1cc85bb93c96da9417259623d544b9eb0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/diorite.json"
-hash = "dc6a730c780f3ef9a26e80970858ce868fa31822113b9f3a38e120b2ffee0e43"
+hash = "d9b90aa3c58da94773e2c0bd583c77669e84395de5b62140f6936ea6a62fec06"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/gem_gold_cast.json"
-hash = "38385a5eeb1fa16b151bda3889a8341b5506568dc6f0cf427c6b484b74204553"
+hash = "890b4bce7f028d7f65bb5323dcd06e4c38c8dc5c78abc83275574a51444b5797"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/gem_sand_cast.json"
-hash = "1f8890a46b3db35c2dc8367a10bb0eccd5795f6e6acf17d85e606cbeb42be137"
+hash = "aef7e57deb9a7547ab8f1554b337d36707ba81f6feb8e82ef76af44d9b5da471"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/quartz/granite.json"
-hash = "3ff0dceb5449b1a57e398f75c7538953de9f063769176b9e3f12a328653ff2e6"
+hash = "9ef3045219543097dbebc534249aa9a42f4ea76592755a6f4dd555708c5edfd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/brick_composite.json"
-hash = "5392327a974ce0d6afbec4f02a11fff8a033bb7daa796b8c0f7981c31c6ea0cf"
+hash = "20093c7deb3ede00d7aba7bd462a64a390f67b5265c0c55562107c8278a88e19"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/brick_gold_cast.json"
-hash = "678f138e0f06918f23e67f5cc5debc3b3d590271dd25fcbe5b05865fb84def27"
+hash = "9dc66761cc0786c3d1f9a6ae9b63a06416e137d1f6791b21ab74e80f6d6a7618"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/brick_sand_cast.json"
-hash = "618a5668ea6d70c2f89331b864ec6f6404d3cd2964905b944c15d20ce6272d53"
+hash = "6c8d7992ef075346dcbb0109d8123406931c40eca6f567979a729b7da93b67f3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/foundry_controller.json"
-hash = "9220325b5e26ec6aa98b37b0c33f236b06ad4afc745015dfb87bb06ac9af575d"
+hash = "4ca3093c059d14330670f617fb2300df1db1332a7d7c4129480608cbed4e1668"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/glass.json"
-hash = "fbdd346fcd9a16012fe8ae3d5e7c96106b60a9835bcafc9db84953d4db00b69d"
+hash = "2bc05276b2413eae81ef4bb7dbff823dc5ce0846ad48da796a0cb1f7bf49838d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/glass_pane.json"
-hash = "a0f4203c1c234bbc23742dbcc6588718c5fb9868eeef377da126a56bf5e5bd4b"
+hash = "3c3c3764958127b2eed3754e2a73d524505864c804a649cae068119f0c10b5d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/polished_from_magma.json"
-hash = "19399ff28eb5a090f57c36aa4ef6c8697c66297bed0d07708cbb47a0656070c1"
+hash = "f2359fea6cd99a4c7d0d5ecda0ba9fc51998db2456ac00c9ef6db778f3a8d1ab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/stone_from_magma.json"
-hash = "b1e899ed8dbe1db02d60b175852de34b620b6d48db35ebad16a9d40a7e0aff96"
+hash = "dffacf2b2ac2498e49603dcb36a3f99b593862b0b0f3e6371b7ff0837a5117de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/scorched/stone_from_scorched.json"
-hash = "be411656610efbe35a5c5babace58a6f0ea896a27ded0252a01cd9b96657d275"
+hash = "56ae46f75e3c06f81731c8be0ffad6515c544c0338293029a49654dd80ef4363"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/brick_composite.json"
-hash = "fd3d0d6b4a3d074aca3ca753941a4a11ddea7d273d6f1c4441056f042b703d58"
+hash = "94771861be9dc713628b49441bcc46a2a7a6d9ed978acad3cc97154e5000a7cd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/brick_gold_cast.json"
-hash = "bdcc39817843a67f6d56fe58c093c950485006808e61ec350e05a42c3b8c5cee"
+hash = "4e3980ead17ba62c4c6a6e4fe9e78440357aeea1a961ba2f543ffcab9aa166d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/brick_sand_cast.json"
-hash = "fdcc9d20fe2563260d4c47e4be733e0a17076a7a77c51519d7eca0afd087563c"
+hash = "6aded39651d52ced24d346ecb75dd9522fa5684637b46dabe7c88681e3d5afdd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/bricks/block.json"
-hash = "df669cbfc73b3d13cf2e3575fedefd3599533699105494d263ccc5139a2e1f6d"
+hash = "08421d18477cd90394c2efce0de5a3ae68c2b568366fef2ce6565c39c5a656d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/bricks/slab.json"
-hash = "2a5484c60b9f19bb7a350879cc49ad0e25042c05b67cf60cba8014a104d48f64"
+hash = "c457a9a721154502965ea1cb50dd1c9fd73619d74bace73968be88f3adc8e2e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/bricks/stairs.json"
-hash = "1797775ea8642202f4053e60bed12355f2940ea095a4c6bc902ac513da164843"
+hash = "a714f6dc9eef331e391cc5bd1155355398ef934253c47e5f42d2ed138deb9302"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/bricks/wall.json"
-hash = "870bf88cdbf926706e230afe4fc5ca403755d1f1b2cf6632d166dd54bca0a0fb"
+hash = "3cac0b375bad5b7ea7c6c936addf9ae7a4a0d52f164dd8cf4339f39aeb2b49fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/chiseled.json"
-hash = "30823175db57f3b65a30efec81f2763c6fd605711f533f0e610912cb61911d0b"
+hash = "db38a2d5f4e00536cea4c43d8e5a76702f9076748ea703fa0f46973481c7d9b2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/cobble/block.json"
-hash = "f53dc12796e4e7829a4f2c070b08249451ab531c6206b617f82cfb6ae5ddb9e8"
+hash = "aadcb255c04ccef7cbc0bd1861f89aae2212dfe8e3d8273e79bc08f7cb2aeecd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/cobble/slab.json"
-hash = "2bc62adbf393c5ff7c82767239b5a5d2dd2b2168970f3a4c0a17c9347dde1d3d"
+hash = "7846a6ce13f06f68b0bd9a5d7c34911d12bddd1a0a87782694e87464fd3ba51b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/cobble/stairs.json"
-hash = "33eb3dc7e0db50ae852fa5ff3c5461757753b406e53277c62a68236e5325396b"
+hash = "5f0218b65a7ab9388b69fb8a449f2a10dac6f0d1472805d5efae0aa505ca71a0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/cobble/wall.json"
-hash = "b1660c3fb59d0f9f141d7f9cac5ec1b38cb6fcfd969399cae9c5c7a56595ba61"
+hash = "2bcd696ce7410acf6f3eedf79da7539688df5d10eb685dde357d871d94e840c8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/cracked.json"
-hash = "3d558e70fdf9d97637e3a9be011a742c9a820e6e93a00577b637165d0d7ab3a8"
+hash = "41cea455a5fb81e180af5f5fe8144ec71d8f5c976876ab9af84a6cb7cb801a8b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/glass.json"
-hash = "c36035f84051924830014d7a5d5b432b013da7883e876175ce7d7cf72d728524"
+hash = "feec59dde8e329b3c23b8f210d6c1a712b76157c49f4d9309b4ac2b417a23d00"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/glass_pane.json"
-hash = "bddd33a1e46b96a060505ad020399f7029b4a1cb7d169e5e685b6e7b40e6c886"
+hash = "57db565f08efbdf61becbc082db087b1103a3986469b8bfb7d9bca57961127de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/paver.json"
-hash = "7eb9033302ce9feb354705a44fc05fc2d83efa5c40129aeec02b25cdf0024966"
+hash = "3b94b8147a9c8a5ea484f608ad53b43da19d88591b81f1b079199a30df579ad0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/smeltery_controller.json"
-hash = "a7a388428b842736302662ca37b9c7fe67d2f35904cc8ba6046992f427c0f0bc"
+hash = "dbddf108ac59778b3a1528de372814905ddf84c63cef044cc3e32c5891c12ae5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/stone/block_from_clay.json"
-hash = "9ec1eb0469875e2a106cef526094c72efe6836c85a8b2f1ead26e203afa37bf3"
+hash = "7c2ebd2fc0faf6d59f77b83646c6af8fb734167e2afe54e876ac3f8d526017a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/stone/block_from_seared.json"
-hash = "0816d983d227d6809760dfc829064d9ba5db2577b76e874756ca9129851ffe96"
+hash = "c9b602a08b60850add4a4775983db0f09aed84436eb7e6b004c01c91a1396104"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/stone/slab.json"
-hash = "76b030219eed33f294fc7a5be90c1edc06830f64b602ac3dc9e115d0b9db80ec"
+hash = "6185efc54cf424eafa8bb44ef5f4c310e1b5ee34d76646423bbcb9a1d20160f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/seared/stone/stairs.json"
-hash = "c244573e414fac28eebe5fb72e15c48d6c8cef873edb7a5f28590bbb4b648e09"
+hash = "2c0d3e367d6fbd163e37d11f8831bdb2912b31518883ce242eac92557626356f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/shimmerdust.json"
-hash = "5848f2e5622b000acb70f866b2a1d4fc8288df63ef1e1388541b4d7f8d473027"
+hash = "015f2176b09e4bf1aaf29c7de3676598d3fddf904475b5f8280ef8762922b8ef"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/shimmerstone.json"
@@ -9930,95 +9942,95 @@ hash = "360cdf8d27e0ff0e65c99992f2a384ef2e2ceeaf31bde32ad9e92b3bc6470634"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/shroomlight.json"
-hash = "8ebd9f1d1122ba4aa0ff89e02d39b0fbea9a696224fc5b4d2c5e2ee11ea8033f"
+hash = "cad58b0e33ab1ac8522fdac21ef16ee931d1bb7618fed68bb1f01118ad867485"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/blood/block.json"
-hash = "ec06325cbdcbf61446250d3042209ec1e952feea6c26cef318f46d5a3c16ef9b"
+hash = "243e5d3fc0d4402ab79c82544e11f526f75695961d7aa46873dd07f679a57362"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/blood/bone.json"
-hash = "93106e0a8ba0673bb6eecc566c9003471c4b3933aed83a5856349a381e564323"
+hash = "600e84b55b4ca071afdbffd40233ffe82a8bc465b0bed75f2fa2c12e4b7796fa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/blood/congealed.json"
-hash = "08c6b0fad439356b2bd32288098d7a6cc1f768c8fba62e355bc2ea74616560ab"
+hash = "5661938cf4a4b32903082cbead91a9289842bbd49143a721ffae0a72076c1726"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/blood/slimeball.json"
-hash = "ed2a7d13b28b412993d908392076b071e98cdb8c11f111652835a5394c6f0a43"
+hash = "e2021c356e5f5d93a403d3779a64972a017a883a826610ac8a56b4ef8e57bdab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/earth/block.json"
-hash = "71bc09685aa0d23cfc6fe064beeebd109289e2a0343732033c39a5b2283e273c"
+hash = "7689642273bf42ddf080f4e6a2d82bd82898058cd0ffa0fcfbd86923aa44e6d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/earth/congealed.json"
-hash = "6d2585cc71421dd7ec025f75a3d039f2eec62fea1960d20ba0c3ae983f14eeb2"
+hash = "4c51c442f29a89901e82ee0331797f33f6194f4ac4ef6d6c08dac6b824a6f20c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/earth/slimeball.json"
-hash = "7876e2d7f9e5fbec820fef6c26a4605686d22dc21d38bc86905bb00232c19fa3"
+hash = "dd27de0c9fcc32f3a3b8691602292507854b53635d2b2f46bc454bb92b6851d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ender/block.json"
-hash = "9ee5162986b7b894f3263f5d69f0aea19564bb1dac9d021239e71683087710ff"
+hash = "8ebb9edad8d4a1933859ce0e7f7b8ee5ee570c2a403c9580f0a7e45972d0b268"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ender/congealed.json"
-hash = "adcedd75573189a751f89c9a64ca603228292a18b3d5f427a1671304279065d6"
+hash = "016742145f7e000ae0c67b5d8b7e3c34bbc002862f7b2185b9a06adc52f3f130"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ender/slimeball.json"
-hash = "2a940c1407699fc844dfcfc4db2c8d6ef22051201d138606e9c2f55d1c36fc7a"
+hash = "77ca77dfb820ab17698eb2ce1463934fa70e5fd851961a7b2f2b958ca553f046"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ichor/block.json"
-hash = "3228281ee51428afd85a673bb8a1c564116102163024a4d739a325abf5b7b260"
+hash = "a100394aa0dd8a66873ee629325846fc60426f18b499a11288bca777c3bb35a1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ichor/congealed.json"
-hash = "df894e1f0041cf93aa0e5cbf658f9d4698bd1a5d11e956f42de8d7561c1e37f9"
+hash = "3e4877171e0cb9f42c7dd6dd595019aa58ea78b11cde16301b02c529c086d7e9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/ichor/slimeball.json"
-hash = "c396c9b3febda79a030e68260bb82394ac8315b831299dafbae4c21d21292141"
+hash = "f8403be00d977a74e6631e48693960256ca5f7dad55a597768f69042d2a452e1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/magma_block.json"
-hash = "0978113bdea3c1b8bf6ae831aa7bfb113682f23194efdbedd6f959436a71608a"
+hash = "5e91901a809acffcf9bf0c0f9dc860336c4756f057311d2d6c4cc20df64a4ae5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/sky/block.json"
-hash = "88d3d638ed2506d479fbff2b0e473ad5572809a89cc37229dcb22457354deb33"
+hash = "e46a3e74e4e5b1a2d43736c6fd7b31c2de9e7e5d25e51c7845c1d7a54832cc1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/sky/congealed.json"
-hash = "43f44927ffb7d7803a7fd69f145d0a709e4c6a4543ac0dcc7d804e7ae2c3d3a6"
+hash = "be4ab9ed09025bed3c54bdb31ff37c05caaffb33ca673873a8e7c26e93189e29"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/slime/sky/slimeball.json"
-hash = "988aac485d7e6317745a30cd398a23346aaf55182db156a1ef68ffef6b83e2dc"
+hash = "1c2db08a247068e83b4d7c1941699e00a83153ec9040e01d97c464abf9b015e9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/soul/glass.json"
-hash = "986c4c6e378c49cf025f045f98871a0982ea31ed3e4f202a1df6ced2ee5c6ae3"
+hash = "be0eeaab8c644ab61017a3b849144f476ea056d7d5ab5eb9818d7b4cde64bfc5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/soul/pane.json"
-hash = "1276ceead17fd347307bd37a05a375e29521c306451ea750469c5a9cd2247501"
+hash = "ee7ccca404afdf00a4bdb50c47e8e98ccf5198f00a0d4cad4848fbea64669db6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/soup/beetroot.json"
-hash = "473925097bc61b14f264daafd47b9d918bbe292dba6d1e3409b1785ac8b10d5e"
+hash = "5f60551c28470e990019f961d3d4a751c2a1648d24f4a0877799f783b4a421ab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/soup/mushroom.json"
-hash = "8e946afa344843c37f242cc9aad8d819de6a1bca132ce0c397ccf860014447c1"
+hash = "c892b80cad910032b7c956732f8bd3e596b5a1220ac8916f17fa3149b315883c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/soup/rabbit.json"
-hash = "d45634ef46204fee0a461799698a6e8c9d74e293fd45a8f0325939f49ca75c1e"
+hash = "f20fb4eecdeb37d056e93159f11ee0af8ca940246c258527a55fc9a756d75b1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/steel_gold_cast_ring.json"
@@ -10026,111 +10038,111 @@ hash = "faea1d9e5fee8546097e0abadfda0bc937d21a00ea754e41eb3134e8de4db553"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/black_concrete.json"
-hash = "c631886aa7f5a8b1227eb6c92b644bf1849c00b503ff8e7d5af8946f3d89d0b5"
+hash = "0d705f41e2f9de678ac4f2a2260b186511c334339dc67f6bac25e322610086dd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/blue_concrete.json"
-hash = "44c9723eff1cb1f9e72b77bf6a3fcaf2e3933b4d73dde8d5b25aa0dc2976fc14"
+hash = "9bc716e3ddd685c34722dda27307761e866b249e2736ff130a75cb660d45e404"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/brown_concrete.json"
-hash = "272e70929cafe7b97cb63ea3d085af38391c8aa0158f30ca3150eb0885900e28"
+hash = "74cbd79d62395d854677350f61289127ce797071144746cfcbabd318c3c8cf6c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/cyan_concrete.json"
-hash = "e4c367165c5bbd20443e94f3257e155b92a5f0e3eed3a5234de01c0946949940"
+hash = "b4f70aac3676af4795407a410b2274fe2a20eec8728267ae01f6fc4756f219f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/gray_concrete.json"
-hash = "592f294f315b5181e9052fe1ecd706a76e7e19f94046357887368a568bac4412"
+hash = "acb0e9601714a0fc2d1e104533cb0e92639a6803ab52930a6dd13b6c4be16e52"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/green_concrete.json"
-hash = "c5d88666497001c37bddb3fec7a386d56bbcfa80bbad0f113576a6d85101c4d0"
+hash = "93608e0a31faf057d09a4a385d2e2a9655927538100a12eae1f22c9db5232a9f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/light_blue_concrete.json"
-hash = "bead51c0bfc8e36f55b1b684e63ca1b62e3c29bd1723bfe54fc18d610878f3fa"
+hash = "8fd75b9254c346bf32bd4ecec7190cb338aa26a47372ce672c80e9eae65cd391"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/light_gray_concrete.json"
-hash = "da738948474b895f3239b1fcfc4cddeec986f3c7d0ecbcd24e1a9d1f6e0d7a92"
+hash = "b4e1022d62633f6f5588dfb97b6c6bdb7147f7675b8dfd5ea75aae8533003b20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/lime_concrete.json"
-hash = "9f0269bdf22d80321f1a6ec6045723da60e6fffe8229c31c0878ae9b72c6d77d"
+hash = "558fa040c11ddf1ace08368b764aa6f159a2751b66c61345a7cf3cf0511144c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/magenta_concrete.json"
-hash = "e2d54ef65cae8c21d52e312a41b3ae0970271296bf143f53470f40276ef1254e"
+hash = "a142968f8bf21015c9214e2c963b4b66b8478f043e4be6868304f748ce98cd1a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/mud_bricks.json"
-hash = "456013a0a890aaf22d77fe0f342a1387a3194f7d47d1dd8472f4b837cfb13f47"
+hash = "02947482c4b794b79bf4b13cc46f9372cf1bfd3da9a5b984802e3a42ac772b06"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/orange_concrete.json"
-hash = "216293b4b8358c9ffadddb3b8a162461f493cd00ddcea197f7c7aaf5c314d1e4"
+hash = "22bab5acf0ae9a1efd4055d0924450a8a05996ef9cc299e115c446d387955120"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/pink_concrete.json"
-hash = "2754c150d7323905070e76fc256373886f62ba05cfb05ddfeee0d3b43a0c9549"
+hash = "4c3f3fe5f0f2b2f58b571d375c0686d13d14d17c9ef036f0370f2362b4a7d0db"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/purple_concrete.json"
-hash = "e4ffa8487ec36334c407185d0bf1f6b28909dbb21827ad5d7ce2a584ac949be8"
+hash = "3a8868bff8ed8763f9591b3aeef3f21bf3cefb2b11b1e80efd64a0342b1472fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/red_concrete.json"
-hash = "37957521db2c0214f45e5aaacfd11d5ccda348c3670a62a56dbbda0610067b8c"
+hash = "8101aa878bb7c96c4aae881f33ebf70be73981ae0924300395dabfaf7e157d1c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/white_concrete.json"
-hash = "ae4625f117a1e858b8d1d54426f9e0e280b32b74316892e85bb6d04d414ce5e6"
+hash = "641ce0d7ea8bd105af9fa67a62032b427191915e8f8f17db398d938d9e98d9b8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/casting/water/yellow_concrete.json"
-hash = "af46dd3b5b2a12319586f010de46ebb1bb4bc4fc272b8a5602d888167c0e04b2"
+hash = "a3a7f2168df7504765276822a3be17da7bef25a284d62298c78ba598a23b0881"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/entity_melting/blaze.json"
-hash = "3f8b45efff1d5e9a5b278ea00e98dedf6541a17d9fac19701ae37c7723c2591d"
+hash = "ae57980ff33fe8a7403bc43c88dfb7463495a2597cc30044678d525e74ceba73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/entity_melting/heads/blaze.json"
-hash = "41fe679ac400d23c8b5f3c441ae9cc7b1c3bcfeba1573631eeebe01c34993955"
+hash = "fda2327dc603c14aaa052b6d6354a5775b17593144133f70dfe744d342646b20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/block.json"
-hash = "1ab5f4935d77b12933caec68ae5fc93b05adc75657dd9084a10b65af0102b241"
+hash = "ae03d3068729d14e6fc659454a83de66bad2d3162f68d2c48858fc9e00b43a14"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/bud_large.json"
-hash = "5df6b4c99f3279ff679391373227729c50f08e3e06a14fca249708e4cc88382b"
+hash = "d4f75741e2948e7f429c83baf4c72d1c75f9ebc53edf141cfdfb46b42e51d43a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/bud_medium.json"
-hash = "f5ee78faa340c4f5fb2e0561a7cc56a315ecdd0b46953625886f392782583b2f"
+hash = "a440de3978f043f01c0464cd56e54950776c8116ae830a831781c4d56d8e8ea8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/bud_small.json"
-hash = "d64985b0f244710c5d2943596172bc089273251f958049da25952cc6eddd6546"
+hash = "7cdb8d442b38c7b6a0bde71943558dda9840c8064a989711abb38fb35c03ab4c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/cluster.json"
-hash = "165fbb10e8421ef64e108c523058ba07a415d2a3d88abedff0b02245e0e82a20"
+hash = "16842bb50adc35c73f3b331c5e6b1b0027bcb33f584bd8de4759251521d03333"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/shard.json"
-hash = "0a4db90d89cf21f55de4cbf854e54adcb8bbec473808d38caebda44525d23c26"
+hash = "2d92d20cb1d88b38f4be9d684c0606d0e05e0026759125c1fb09051481fff5d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/spyglass.json"
-hash = "707ac4141ab8ca293f3dc95abe1685c1a68e1146de453778a95233437a63c603"
+hash = "2887b9da11a50e4a0180727302937da73708799f50d1ced91ba496a5e23287bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/amethyst/tinted_glass.json"
-hash = "ea19ce1ed62974354fdde8ff9194feed9bb5682bddb3ef47a8737f7a73eec757"
+hash = "67dc99560e452703487dc43afdc002396641e1f8f6f0f4d0c0f874396589c555"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/blood/cod.json"
@@ -10146,167 +10158,167 @@ hash = "86166423529b377f9ee547b216a2b514018e41bf19f52ff4fe161874cbb905aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/ball.json"
-hash = "e9bd3c34efa7c2de9882d6ca934c62e3e952232b49d3f6bbf0e4a07e66759c42"
+hash = "b8157c21190ad370e4b3333803e5ff9fab61e77d7261cb22ca6f9d8dd60929a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/block.json"
-hash = "769b48841634c09f0beda7088542ae8ffa120f39a6262f91ad2c17f88dd4a3b4"
+hash = "503e290a2078974c57f7aa7123a0482532e1de18b48ecae63c543e102c04ff12"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/brick.json"
-hash = "e36716236a0a9986884789adbc7252264271505d4eef34ab361312eb95f17aaf"
+hash = "88caf56c84ab6fc57deb00979e9a8f011b38a53d310cd2bfb6dd7a4e91da395e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/brick_slab.json"
-hash = "cf2e490aacb3c86899c2897e3374e155533a76db4b81a3a2e94c484709ae6911"
+hash = "ae98e2072958f621d090123083e36f72783099a238498cd5f959629166a3919b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/plate.json"
-hash = "9e8c8d65b5830f60333319b760777835a4a8619afb27ba47eefad326e06c230d"
+hash = "d35fdc16de0b39e98085bb0ccb143e0892a0ef9336b8bff2bc402debc8867e78"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/pot.json"
-hash = "851400b62508a0f4d59fa88af08ef02cc3f9081dac0bd65cff28bc4d1c64702d"
+hash = "e91442a8b9f2d7565f2aeda40d09c1b168c3a1b87ca86775b5f44168ded43bde"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/clay/terracotta.json"
-hash = "de1aca0353c4c94265713a9de6c554005232169d56111a31a31c1bd3404a1519"
+hash = "caa2ac013fa769e5ae118070029bb97d6bbe2dc286d376461f4a1671d0e14da5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/axes.json"
-hash = "3afc811579e15831ebe57a3dbbf0d2b3a27de6d2ddb81ee7ee3071caf1972d45"
+hash = "1158a37f57f315f44fde9e92be3dd73b7382957f15a68d9924eab979c6d243c5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/block.json"
-hash = "968d19dc1f7b25845dd3974d8f2e58c4ca4bee48e47df4f629c4bbe1ad441215"
+hash = "10aa09b981a2777dc3cd132de8274fd54c90971057967a112bc346efd6df7d07"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/boots.json"
-hash = "20351637be2d0e582e200f0b8ae96598433e75163d4e09e83f7f2370775aa054"
+hash = "7e03eff00c39933a21eed474ef358661aac5c328e5c0487501a3d96640de6238"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/chestplate.json"
-hash = "490a13423821b3c6f91830786096ac9fbe0c78404f4ce768f095fa0d3f8869ea"
+hash = "22f66686ce64aec8c244166c1bd7b5967a8b224c61aeb0b01ee7cebabb9ca1ad"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/enchanting_table.json"
-hash = "8a8fdc3dda923a2829f415d6ed39bd4a19b30c9d3748b296ccfcc4b973332170"
+hash = "4b2a740753f8ffc469260efc08193b2fb5226c3c2ade715fe0faf580e423d13a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/gem.json"
-hash = "efeb308debfc58bfae4ef7652aa2e112486916095644c009062a079c85928f20"
+hash = "1154e8a9ed5bc02323c8578c9c08dd83d6a0c74d4466679daa884863c55aa671"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/block.json"
-hash = "8275b4024707d4b086c31113a19d8d525518909da7131440b78aa74b2cb6ec2a"
+hash = "96100de3984cc3ca7036c394cc70a403156beadc7e4d145cf5497cc1ae5c4dee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/bud_large.json"
-hash = "ffdf2bdb1b489f07a93a4ea0c469954495b2335c62b92867a7b79f6d60fd52c2"
+hash = "f7f0e950064e3c612820c550de14a5ccff10d28bd173167d54a240f654995f59"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/bud_medium.json"
-hash = "bb50138447be3d8129d503a6f878f0c48715744ba2ad243cd28a3df1a84770a1"
+hash = "31a60c5f68b9cc1e6f01dec2ae9ac65f0de3053b9bac3bb8a9ca8a58bf6377f5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/bud_small.json"
-hash = "d3e6f67b7866dc9e04024ffdcb173fcef7224b6f9d9d3013c3aceb08288b9e7a"
+hash = "b69bbaf4052fbf9545c457620cacae42579ba530895c019912cd8af92d64e68b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/cluster.json"
-hash = "8bc2ec157bd2152ef1bcaea66b5fc11be01a019f7738ba05d55c0d862fc2ad26"
+hash = "1c987f17989f727aae97275ebc000654369b2adb5eac722ad05d8382f29bce63"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/geore/shard.json"
-hash = "eb24bbac54cee56be9c93af1d54e50c8891478f493fb97bd4d3548cb1030a4da"
+hash = "2ae8edc97ce860e7bea9d210983a362af705b6e980d02c78131f72f9b9b426e7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/helmet.json"
-hash = "b0a05ddc2d80b115b32f06d632a1b2ba837134fc3e3bee790efe13cda8ca4da6"
+hash = "1d76c1e70ecfe0277e15d16ad8d28bfb628113f881c65cc6e0c9f195156df3a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/horse_armor.json"
-hash = "600efd2d43382d21f41ca7bae37bea3b58e502b67da0d5fe1aa7c33ca0770336"
+hash = "fa92007439c55dca78efad7176b0dfcf6ade9a11488edb94b2fd2907474d7a73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/jukebox.json"
-hash = "273ab57e40f1f43eaa1c15406cead81fad49be9198da84c9fe9f1f11cedafe8d"
+hash = "89e002654830c627f35b50e8c9abf5bd6046f2c568ba36602bb0725ad9faaf73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/leggings.json"
-hash = "5c63ae40e3531b5ef6857fe266f1b9fbe335d6a0d00f6208d395ed6cd6f2f8e3"
+hash = "c541a02071a96cb0e2a5d9a2f21335b3b4147aa7dbef357df90b0fa199b28a58"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/ore_dense.json"
-hash = "761f4ca0992296aeb06b1dc5be2b6b7235446a12d1a4bb10e1df6763fd37520e"
+hash = "a144ad28034b22d59b19e33592463308e8ac94591a8ba330b7b25b7551e9897b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/ore_singular.json"
-hash = "53ca5bd8898732795d765671c9ee904e512f1238e2530f4ba4c400a967109b7f"
+hash = "10d9c0e6f74af7bc2c4f69efdfb58e03dfbec5e81ac783dc73bef4847175af8a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/ore_sparse.json"
-hash = "b5cc5bc49fef314a13ade88864609a58306ad2199eb0ce9bd2e30b733298de7a"
+hash = "c1990a63c7fe0104c83312005d7775f94da170507494c08b03d478321d961220"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/shovel.json"
-hash = "c3174688e941ec0b13a26367809446cf5a3e56bad56ae67788874cd81ac4e4e8"
+hash = "1785dabb7a3128587e0953dc37b0602372eb1bee5fdbefa31c1b7e861f2e24ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/diamond/weapon.json"
-hash = "20fd952c17df5c1804356e57f0999a63dc1fac102ffdbd251e5d2e477156d94b"
+hash = "4978348cc60b40c432e090b2a7cd477d2f8ffc43dd4244619ec2ddcf20ec074a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/block.json"
-hash = "753a24712b3339167d43210ec3921c935860b7d5acf1d3228ff59521200f959c"
+hash = "06e64aa41b3d3fe734508318b7b82b66f40fd686e4b46c4f98253418729af0a5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/gem.json"
-hash = "5bb66ecd900c91880af13dc627314e08a0cad8770c4f70ca81a4f1686ea4b583"
+hash = "38652b0ee900356262d6025c2aea05f0bb993806e4e155081b3e89c8d256f0bb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/block.json"
-hash = "68a2355efbec9eb3560cb7a9cc4d4349b0df60f106d152ff3bfcfeb7023c6dd9"
+hash = "481f21daaf78e64c495f7ffb4ba06758be7d4315f95ef6fda38c48fb7fe60ad9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/bud_large.json"
-hash = "b212b2a69d8c08b3e9073ebfb9d16649f1c3ed36c79b031c24e2bc10f17d72d0"
+hash = "cea373b1d476fc2611dccc4021cf2dab1523f94b81f9b350d5fef6a26bf495dc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/bud_medium.json"
-hash = "45e171308819fdd044985db48312e27323cac6b0124ca4ee00177bd68a658ecf"
+hash = "a860c9092b33ea56c2dc3c7c490078e9007d933b228828eec3bba085944627ca"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/bud_small.json"
-hash = "40049568271f6f8d7b7c3f8b908b0e4bdfab5b305555ce42a93b2b44be89f69f"
+hash = "7a2000819a1a46298749cc5fe6c80a309c9bf27403ea7287c3a210b914e64e3e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/cluster.json"
-hash = "043f95943114677b1e06a1bb9807a5490286659210034d198af83a03307c016e"
+hash = "11a2cc0a90e4fe70a6777186433fd00e62a85449df53e477f58a4a6060744c22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/geore/shard.json"
-hash = "5716a409b5a3afa93bc8b0e4d26beb8d1b6c6957ce589bfcd7a057f9e61e39d8"
+hash = "ef8ff80bae65565a3b8d8c6b84796d62fba89a0726f7f5dd16a8a07ffb97daeb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/ore_dense.json"
-hash = "da51ca88fdd607023ceba2a3769dd6c49f1e2448ce90acb788913b13dc57a6c4"
+hash = "aff5bafa28b2972963799e60f6abbe3415d1a920c888cdd9834d1219b1dc5759"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/ore_singular.json"
-hash = "b3ccab7880d3fcc86ed50b49257739e0bce181348aba16a7cb66f83561fc34ea"
+hash = "98665b2a3bf17cb6f3284c37957555f034dd3b9a123ad290825cf3d2a241f607"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/emerald/ore_sparse.json"
-hash = "96e585356d639d7497897a697556e69504a25e0150642f9ab26731e418c14698"
+hash = "7b05e0e37a2cb57339b8d934ae8158755e33b037341183be7a98987a84e4bd8f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/ender/end_crystal.json"
-hash = "e283a662f5f29950564d2d8b272436843436b3616e2bd464d7fc8e71c1757b52"
+hash = "9d018791588d42e604ac53f1d3d1403bf69956eaf404ca5e3e9d57f8eeb0fc8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/ender/pearl.json"
-hash = "2919598bd7d9bd9f70d33b5497ef475d4dfed1fd65e3b77b48433da5ea0b99c6"
+hash = "70c1a4953f92d17f8521fa4bfad2a541c998077b0bc7b53059322eb6f0d93f2a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/fuel/blaze.json"
@@ -10314,7 +10326,7 @@ hash = "548089786834ee4e62e25e206b084eda72437bdc17f9853afd57332903db8b75"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/fuel/lava.json"
-hash = "36c45edb576775eb3288b8fe15afa8218b5986cfedaedf8aa0b55a6e475385f4"
+hash = "a0e82cafe7fdedcd01bf1dc072e9a603e540ff85e60a0eebae830251bf609bbc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/fuel/nitrodiesel.json"
@@ -10322,231 +10334,231 @@ hash = "89859fad0cbe086f86b7658789e57d5b7e37f8c29978508b42ece3f8327ebd7f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/glass/block.json"
-hash = "d93dce17de152a15b4bac84687da63180848c655955487e0525c3cdbb89be09e"
+hash = "72af0e657d34a2d181d732136a594a91d37c0c9a04208b72e403078f6f2b0482"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/glass/bottle.json"
-hash = "dd0ef311f51a076c3a2041b90fe3b1194b665adeee8b00434e9e856c7baba329"
+hash = "701b24116f64946de1e92ee75f2588d13a83f6b88584ca61c5403f3cec6c5554"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/glass/pane.json"
-hash = "714495a65c1387719c050e6cb385d479d7dbdfe5110360caa74c1ab8ab595625"
+hash = "04b9c03d903ceea9721998a8861d9c3cf3dafa5e5d5d11f7da81aa4c2b2958e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/glass/sand.json"
-hash = "25709fe66f59173bec624703ce8f8c5c2a58571b27c3a2c2443c76378df81e6d"
+hash = "51580f5117726c29cbd8e3c6c94f57430d648fe382904720475e5fdcbe6afdd2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/glass/sand_cast.json"
-hash = "94afb5a92965efc1389ce60742a1eec7c97593a6f4849f8bfd38e9001bff216e"
+hash = "4fce7807f4345ce7f328a76b48126f129746e5941177f09731895f9d351b27e9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/block.json"
-hash = "1904bd18d1742a8d93315cd0feba71ddc3e99803436bfaa630ec7b6c4f37cb25"
+hash = "36ce65cbc03333b16481591dd22c065a7e87ff7a732490912dc6f4a7da3e481c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/coin.json"
-hash = "c5bd321cbfd446c2205c432995523e17b6b86f18e8644eef5b5efd73e8bbe4ad"
+hash = "f59f38d9389e8e64614783e72c7743b7de193a9757b4457c90b32a1f3dd3e9db"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/dust.json"
-hash = "8ce2ac6db4b1c5bd1f1c9f2ba7ab6d7b935fec7d28f8b182550d330dd8ffa08d"
+hash = "b5b0cc57f8e644ac50e7d0690547e2892af65ca08cdf83e725cecaa63e74940e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/gear.json"
-hash = "9706267681592977a62341c116baf81ac714dd2741e61be763c7c6eb930553d9"
+hash = "9ac5994763d8d2eddc890315ed335dbb1aaa7827daaca326f826ac77f92c9fb6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/block.json"
-hash = "0ed4d1578da935641b79f705d03bab42a38f84d163300bc811e5a89e460330d3"
+hash = "9902f8df84e2541062d7c3d91f3233ef3a7a52b139f8a94a77ea1d3b5e64a566"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/bud_large.json"
-hash = "9ac392bb2d68c687643589090e4ec1d2f77e29e678f28834a266efd9b49f6756"
+hash = "0e4ca4e27e20c9c24a96ebf5b8a52008404650904f53ef4271f087cfba3a9cf0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/bud_medium.json"
-hash = "3e860970395f0d3d278853c61124e6847ff79bd9a24ce41445cb121f3a8ad016"
+hash = "ee5e5836e8318dec489912b9612d7f659aebec3be518063db00ef5d0c5830d17"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/bud_small.json"
-hash = "f1f98af4f6d8dbec24c8ae9ca5ecc188ed7389b92c0785d0dbcbff1880d0ff78"
+hash = "7d947745c0f34da1743156012d6a62487f8890bde8baa569f53cf63712880e00"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/cluster.json"
-hash = "b8d7582ed8b3f3c552e41156ea4ec257b9f02638850717282e203829e793158e"
+hash = "465c004b02ee55238d6cda38910d0f5969f9d5c628a5137e4ff20000553cf683"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/geore/shard.json"
-hash = "47ebd3039ec46143e0f6a72fb1ea39e43f1b6004d112f62c8ca5564e30e5d101"
+hash = "53c5665757e1e77fbcb3339d2c485d9c7ca8f84e66a631669e4989a51ed9aa51"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/ingot.json"
-hash = "3e7b2d6f2caf169225e013e2814e8d80e1d2c85926c489aef8a315a110fef692"
+hash = "dc7aa3b15b7ea94c2d312ddf8fec283b0a6d4ae8490685ab5f77ce9fbf099d07"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/nugget.json"
-hash = "e0f52b16720af103eda0e6529315751b2cfbb3ba6ef12b427913775bedb74de1"
+hash = "7db9c6c7af0063d5b4c00de74f50c97675b1b40f9f2ceceaf983732eb46e56b1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/ore_dense.json"
-hash = "91023b6ef9ab58e71df2cce2e5b2856a4497f1590a2ad0ea786cd3d3a03c2c34"
+hash = "6a5f0ddb9790183bdaac8765fbfe8539518390f138a56f6857a36d92fde771d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/ore_singular.json"
-hash = "057fe85fb6d7c5440d2218ea96c996ce56ef20d41ddd0dfe89a672438b979c4f"
+hash = "7cd90dba54fedef436752b8ba9d4c5848f2ed1b25a93d38225df281d63fe2c4f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/ore_sparse.json"
-hash = "257abbceb89b84e33ad51a5770d4fba266724d6057da2c4e1400a18d68c37f18"
+hash = "516e992f547544050d86ed7137c10d0b7bbca1211566966c726453246db405d0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/plates.json"
-hash = "fa6123970fad1ddc7764a7c26a21221aa33eec105df0977bd8dd13a32da899e2"
+hash = "61a8f6f14d6d2fa334c33894c33d00dd70639d72fd02983e0bd0242b84dac7ab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/raw.json"
-hash = "c2e1c4777b00da53ccba7a1dbb21e6cc3ae575b783252c02b9e4ff4669700487"
+hash = "7fd6a12bbc0c4c4892323ada3029b68bea9c1f9a896cd339291a134b72accdcb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/raw_block.json"
-hash = "0055ab85eb571547fc3804116824f136ba3ff4e3f350be7550c34ce8a73a0d7e"
+hash = "5ffbec01752ecec49491ff33f8f77700741e8fd77b02279d3d57ce8ee29cf4c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/rod.json"
-hash = "585e4d0863d19a42ba4209f3143eed2c27284724e0c7615e137b67e1e5f52f9b"
+hash = "97b09d41e08edfaa167e48986377ad4b766e69eb8d1a2f4401dae47a39f8a0af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/sheetmetal.json"
-hash = "0f317ad327856ca8e29b1d6883e01b8388023750165b0a1bad64e7c8f44068c3"
+hash = "2b5adcb2988f500fe4cc708a840f52c6561ac9ee1e58aeb8fde0a77608a82be2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/aluminum/wire.json"
-hash = "96422a88afbb60619c202fae04a170fe322f8aa4074eae12a8f1e4e0fcdafac9"
+hash = "7ef119fb99ec434334ea49d51adb201e4622e9a8ec3eb8f98e24f893a8b508e9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/block.json"
-hash = "04aed4167fa5074e7e7d47108143de40f5246e8851235c25adda4e036a440569"
+hash = "a86d1c726421b6d63ee8a68de7214e43bf63e61f54c1d797827987b644322498"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/coin.json"
-hash = "7edb18217753b9f330ccdca58da867d1ed9ed188963f5c5a576e6ca9d3400a9a"
+hash = "673e35183505331e2f5cdd0173df927b28a6ca071623b14656b42df9382d299c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/dust.json"
-hash = "e3284040083d719ca313781c5389f6112a682cabf41c0d49c0c0c8706d0aee04"
+hash = "231dc4d69a3b5557f15510b466756cdaedbded9b7d2c2df6c62daae99deafbc1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/gear.json"
-hash = "f7eeb1cb75d73048548513c95008cd048277731736764bb27f21e09daaf9e29e"
+hash = "ca2b58e814a03b53eff188e9f63c621c3358f402f764fc5c40fcea0e79dd28f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/ingot.json"
-hash = "e1d1724deae5478bf45d2b37747fe4deee42a84eb5660c6a2d6e065ea15b7a52"
+hash = "75f6844e029e377e675defa05a6662eff8226c40bc8d7d70d14a14821f6347fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/nugget.json"
-hash = "b0a1da3e87d956251d49ca10197864e09f136e4cae07532fc1fab1f16b735974"
+hash = "291d4911c920d07d8eedf55210a618e2647bb95d50d045e24e59d93248a1b9ef"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/plates.json"
-hash = "c96f7e9facd997cd6ab996eb5072b5d0576dee0f36b96dac7ab728dbc6dfeb6a"
+hash = "3c1e130b9fdde752542d4d2cc0019dacd761504c9a8c37a47272e4470c74f92b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/reinforcement.json"
-hash = "5e3d5f3afc1eca4015f550f68dabdcb0c95dd1cd522f4c7373d232217e12c154"
+hash = "7a1b9fefd4a85727fa6e9640633440d6f2f174a46896b920e5a4e44083b29fb5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/rod.json"
-hash = "4c820e6b493dba9b39e7edf3c19584808b810c6f3ab90ce7f86cf4387a0605b8"
+hash = "8185a888896bd8a622e20dc09cda2ee29c12efd96bcf8d5f5347b8fe9d2428a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/sheetmetal.json"
-hash = "3e3321f6e7c7b8b0847d5928b0b4fba3c526c55805dca3f95f8025e289041f6f"
+hash = "422b3639e0201979ce24b5c945b357fb78286cfa52f96c95cd0f0913feae9425"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/amethyst_bronze/wire.json"
-hash = "d0106da68f6b1b97e02ddec6bad3ee9bd2323f3f4c5f68551a18e90c85693c5d"
+hash = "cc94c3876d11019e6f4defaae5a9c0b483220c4dbe36afae34420e323ee34fd5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/block.json"
-hash = "f80be928a1df4c4ff695b0b872820996cdcb9d43c8c29b4727e5ae879561d9e8"
+hash = "1d3ab5bf03bdeed7f2ba773da67b292c7cac109f7766e8622072bfd963a65752"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/coin.json"
-hash = "c8467ece575fc7c021dcf32bf31a3c7ef72395b9e9378747b73171641c4cce78"
+hash = "07d7feb16ebe70b31ee1675851fa989fa7528307a1dcb8fc78179884bbd75dd3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/dust.json"
-hash = "73f8f3b2f536943ca0d3548d36bb4bf0e0578857de9f95d5fc06e6ac7f1ad0ff"
+hash = "d9262203bbb0eb4cee870eea350e27f446d493d79dcc86d4ea1d41fb362c310e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/gear.json"
-hash = "7539330e39cdf480dcef47b1162f16d59fd0cea1b7813c681f0df3b17046cd19"
+hash = "d767a07b9f25d57b794d7b91fe627d262fdaf17d1d5bffcc2533264ca1e79db7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/ingot.json"
-hash = "e3f6a1541901652dcbcbb2827a876c714812c83c39095f987f9bd8589dd14c21"
+hash = "052a9151df8527673ac67611694d400e4de36294dc9947a080784c184e85e4c2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/nugget.json"
-hash = "a90a016dedad26c3d7237f3d8e603e871f20dabbb4cc5c80ddbf9c507026b278"
+hash = "f1977915e7b4973c6027df246b274ddfaf9660bcef5b3d9698e0652be2e8ef8a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/plates.json"
-hash = "5b482472960b5b58bf876a376d3f8433fbcb0374e8f9a616a5a4cf362a3428cc"
+hash = "4b274b52984631cda39aba9139dcf5930ec3b3f9259f75a0328bec9687694600"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/rod.json"
-hash = "9a0a259f2db0e87c10401d72d12fb3796864e7e40f3eddbf17976ff2c76c8959"
+hash = "cbd5986e4d9dc97adbf0f03fb9c6d597fcc2c4b29930b7a9cca89878b4cf0d27"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/sheetmetal.json"
-hash = "8f9b924595b3472be7696061f6460d9275276b60142a56f9e80bbca28c8bcad3"
+hash = "6285f0129c7c15a25010b653451f36af1c36b04267a2ca8b04f7631027162455"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/brass/wire.json"
-hash = "5a48a9927736f0b30658475617ae6fd889ae0a2a25e152aea2e33b8dda5926ec"
+hash = "1f9c485c53423e8bd5fc0aac245e4766bcd9b2776182c09b83e3de1926b420ab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/block.json"
-hash = "5f8837850925583a2fba4d2bc898490e2373d43fcfd75b9a5f57c9ba6d16547b"
+hash = "db78e6ea7acd22f6a78c66cd43fb2fdcab881a270fd6a32531da6f945077302a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/coin.json"
-hash = "3d95137dad3a4131373fffab2cabfa08b097ee133476e29575059d2479a425d7"
+hash = "bdc57dbbf36bb09f7f705063c3d4d89e962a724f76cd19f1f0d5b75d443f6e11"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/dust.json"
-hash = "5fc4304d84f05bce160690b8d6b20e026fbca859685df9f1d625ae98aa00089d"
+hash = "7cd31b8c85ded0c090a18fc7dc2e8cfe4c00df0abe7af281064c708003032560"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/gear.json"
-hash = "c4bd95b2607f3399db33533b228407fc48a032f29a505541a6f947520dc340dd"
+hash = "d6751d6c65fd8910ce3bcb49b84161d69754a9fd65dc16b47be0fe9637789a52"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/ingot.json"
-hash = "d51602bffb8d7088ece07553b628683b67a38ccacd0faafdc884625c9fcadb40"
+hash = "5a8b70f09ae6795bfb3755c5754c58a7b79b6b6295f63536ab05bcb218c62055"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/nugget.json"
-hash = "0967cbfb36405b95b4fbf019dd18d9d980b34dead6e6044b74df5495364f4c6e"
+hash = "85cfae0b1d51070e031a964cfde7457cd88a011c139c669dda5f00ac12085dd5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/plates.json"
-hash = "c6055639bbf774f9f2c1bdc53de54a41c7e601d0f71b7d667e68dc65e0282821"
+hash = "8ee69c0293dbe46d0bd5730ec581d79294efe72070c43cdab74d255d121c944c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/rod.json"
-hash = "8c8df6f87e7056f53c3828d019a86ad334b0ef543bebe4ef547d413ee1f205e9"
+hash = "874c3211ea0370dba9989a29c1330c4a1a5f808c0b6481639a07bcf86ff9075b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/sheetmetal.json"
-hash = "272580bb0b24add26ff6569f54bbf40eca6c296cffb2b42bcedead00ae91f42c"
+hash = "1b5184abd1b8b4721e349a4528a1ad3e4638c25f114a1e4b1206f6f5c4979124"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/bronze/wire.json"
-hash = "c186257f210884ff1e1249c63edc3c3325d06b8e8ec82b34147ee13de78e37aa"
+hash = "9a65b754e1a850c23c664a0533752ef5717b653e518a33b30036b26d4c4ea581"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/calorite/block.json"
@@ -10570,231 +10582,231 @@ hash = "662e28f5d5f97ab5ef13548b44663c69c560795533c1f839b449ced38bb9954e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/block.json"
-hash = "838dd88152195b09662826e7e6efc0643d329b2a21e19379a0b332a266900961"
+hash = "71bb97366a48239d50e7b780a2b638de2bbc54a59dd4bac3199386c7804c538f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/coin.json"
-hash = "01e44d47747fdc43488848f5e278e04f87fdb751cca6303ce32ced111ea2c58d"
+hash = "5ec59a4c31801a02d05278b13b7bd3af60a865f930343bc8fd52d5eee74d8f1a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/dust.json"
-hash = "bbddac82120553fe7ead7280372e08723a74da3d2bd9fe59e76be380565c2a38"
+hash = "e9225ac865c811e0106d70d7d7cff58f83374647b647b5d9e4b7d67363aa215b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/gear.json"
-hash = "21f70d2b445cca807db76b5d406939cc155d5a5a27b399c43ee61d946978dc75"
+hash = "32fa4ab2d0c57200b9271180474faee24191cf52f924bcbaeab6c25e4e738e02"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/block.json"
-hash = "75193c2ca9eabc8a87cea9342d96fcbda4f487ba09d4f542c216216dbf32cd56"
+hash = "f0a7d6b45d8b677e41657636c517de6c818767452381c0616595e567b92ecd74"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/bud_large.json"
-hash = "7566a1afffff047696bf241efbc4bf43961218cf5ff0208f1a37fe1ad62d17de"
+hash = "a18a774c39d88540e873ec2b7db10d11bb79e39a8560af2c55dec3905a753a35"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/bud_medium.json"
-hash = "5f20502e9b35a1e82ff71d45bb6cb654e20a7fd5b429b4e898f02248cfd58f07"
+hash = "51b061b893ff74f530bd905beb652938d061942b16b590ce3b69fa3ea6599994"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/bud_small.json"
-hash = "40440d8971fbcb798a1d6cd55fa01d258bce82b16eab51dd075405f2f1c35340"
+hash = "9dd6a2155685c92f8cb208388db3367d7b60402894e97ff9537053579bf94667"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/cluster.json"
-hash = "0e1d192728c610aba58b40248128799085d5b48fae31975bceb5cfa2fc4ec496"
+hash = "8ea5117fe65b106a18b3eba253229e6857dbc138ed9126d267168536dd4f2c49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/geore/shard.json"
-hash = "1364829ca57fc07f752e7f43985fe7391f9dca1254617307d8861f6eaf9c55fe"
+hash = "337d8cfddd2293a6f1ba06ca84dd52cb972dcee33c6a5f22fa0201dd1bb31427"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/ingot.json"
-hash = "fd4d78c589d6acd783f5d66bfbca910b36052b7efd223efa8a65ff6500270bab"
+hash = "102b50e8469b184d7e46f37cf1dc2637156b2222ed967ac84527b12c9b4e58e3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/nugget.json"
-hash = "0698aafeda7cedeec37af826981c8dba0836c49c7e9402a0b7169165164711c5"
+hash = "b9410027f546d5e6b4f508b652dafb06047ce815bdbc08778126b879ed610687"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/ore_dense.json"
-hash = "2547523d40db909e62ec81c3e521d485ac6d51dde489f38d5cd5e92b3653e9bb"
+hash = "bf36e184ebaed3185a1968081f18d269a389afb6f729fd37c9c00aebd9b98d3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/ore_singular.json"
-hash = "5e824055deffabc9b7cdfd1663a49b223b66e06cd55c5382b29b8a005a74f1aa"
+hash = "55057ded2ee5dae488ea7eb8399302cf30673872c61251b218847ea8fbdc7f4f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/ore_sparse.json"
-hash = "b2f0271eaed59b2210353eca160bdfdd311ab9b993add6f9b2218f97fa6f0c5b"
+hash = "d52f86c4eb52cabf0537ba5cffeba29edbedaec555b2c0b9c1eae4830275b836"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/plates.json"
-hash = "d3254fa3d0d3ddbf0438c8d71c290bb44950e8d981f5ecd3c7c75de55d034478"
+hash = "e385368be378701b4e65ee664639f0ed1916549569faba4620c5220a22586cd0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/platform.json"
-hash = "481405f21308dee749c3126fd923e29957a72cc95c66b37d9e0e81a52f1b401b"
+hash = "9fd6a5bfcd38be510522918755a4b35b3507849671031e52dd5304e6aa56db06"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/raw.json"
-hash = "f7d38e202115550d724b5783560ed5820e82166fdae2163c4db59251f1ecb90d"
+hash = "bcd334b3f6de6c45cf49fef701cd229101ceb5e693fc44c436117e3a56f9be84"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/raw_block.json"
-hash = "ea4522bca7ed3206892affca488f527a98c47745f5030672b0434ba8a362507c"
+hash = "1d55400b67ee907d2448bc2e848ce117927def28a1e443d1b258d15a81885a77"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/reinforcement.json"
-hash = "969a59b629c22f6550c1455e0016ea2ac06d49478f6ffcf4b61c441d4d150918"
+hash = "eccc2f9650dccfc8f2aa3b8b2483d86c103f765394bf058b0fdd2a4d83e2dd33"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/rod.json"
-hash = "05d11368f3b8cfbd73c33b049806153a680128420237fa279cc94a8823b578f8"
+hash = "0d878bfa75ea2da7429545188e63a717b3507cdf56ddc570d91e7903957f9561"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/scorched_duct.json"
-hash = "da288d3a88f1d2285b6d95fc1304be0de92da0989884afd5fe15fb8b96400232"
+hash = "11c580c8393aa8dbde6a5e26fe5aeb415d3655db7da0e7daeb8baed6653b0d7f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/seared_duct.json"
-hash = "077434a40997f5385ffa1d246b94d0464b70181e586bfd18b9614d06295df0db"
+hash = "c632025259dcacac964ee085a9b95ec2b3070fe0ccde3c0872d180c3835a2b57"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/sheetmetal.json"
-hash = "2bbbf32cb72ca2bdc9e52810c7b6a3bb22b6641776fae116237902c094dc4b21"
+hash = "af64e6c0ded905df5cc7d9a1c3f8257b9f8c24c50598e8a088f6d1e6eb433d0d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/cobalt/wire.json"
-hash = "fefb3e4dbe9bc6927001f773135af888c160c535832f2146099847da45285b27"
+hash = "8f177481197352c4aa68b115623d07428287e012f76eb876a2c6533d980acdc2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/block.json"
-hash = "7386d0c28b1ec300598b26594c554d68b4258bb911bcd787407d3a0914a16c7b"
+hash = "b3a8b74182f6579383c8c1e6c5519c4b01cf1a32d5775a846cb533e0c9424621"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/coin.json"
-hash = "fd8e7692a3492ae38237f0a12c4007e4b885b476df7b646f5a09d2dd75200376"
+hash = "09461886d741760b7fd40d8c7530dd3b344dc60a208b2179bd5ae762240661d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/dust.json"
-hash = "d8eb2947256b35db7caec63336204ad598edb57bb84a8474c0de63db445e073a"
+hash = "1d42cf38c47bf126c2ac3f0baec306abeb98501115b64e5540ba7fe641267f76"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/gear.json"
-hash = "219a3efd1ec5fad78d1881df07622dca7379fb98323bbd22122d927d75e00890"
+hash = "2dc2c87f2b1a43c41d10a4e2b9c136bac4f62f9e61087458f06ae2f70d93eb80"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/ingot.json"
-hash = "ec5e7c306509f1067458b9044ac28848402ff647b8d4a4e83bbd63b65e5c7ccf"
+hash = "1124d45a4bdd13d1df979b1e3a7a36bc9c8d852a8ac5a62ee0fe8336e4bcf374"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/nugget.json"
-hash = "886fb76d3d7d1f8b9285de53e4d4ea3c82a467035138c04e2e7c6f8dcaccd4aa"
+hash = "c02c1be93fb8f9b199add1ee0071f3822bc5de73b5f0e07f3d075ec3af10ac9c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/plates.json"
-hash = "ae2dbc44660b1c4490dfae0bb0b36d50d3bdb5c20db14df05c729e7ffa907781"
+hash = "ab89891d3d38a6c61d198782a64b930a87a3a647be610cbfa933b787721171bc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/rod.json"
-hash = "b3e23e4aeb1a8f429351d057b3b7dc80e31f97503a26e7d12929614c3bb7b1db"
+hash = "80c26a3868ad58e6ece9bc2a2d5b13efe52f5289de2bb10b199ea9f52f132a04"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/sheetmetal.json"
-hash = "6bbfd20228132a8402208d048b553f45b0df9c646ac8cc495323f83c1c4516b8"
+hash = "aab36e67b7c716b8e6adfebacd88b4ce420c057f070c52656a464e8390b99eb1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/constantan/wire.json"
-hash = "73ba6682acafafbae16e5907b5c5eb020c315b903a5417325ba415e1524799ed"
+hash = "4ae34702a38540e95e99ffa2203fd6c1f435c2d016b9f2c52947f01cdc9cab50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/block.json"
-hash = "e7e15a411e092e93f164527be0c44be6d1d62460a6d6b6ba85a7cb1fc4caae46"
+hash = "5e22c64b6a9d342073831ccca2071f42ed6054785f6e95267f3c4e67365057d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/can.json"
-hash = "b949ae568ae194f752568feee486f13a41137980f0745fb39701ef4c8b94f37b"
+hash = "eec3458f180f64faf4070ac321c823b8b86705fe1a09c9cbc6fd93252b482afa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/coin.json"
-hash = "b5b54ac472c108bdcd2ccc82b1ed0eb6f670b12444dfe4d3eee08731ebdc4b27"
+hash = "1886bb98adab5537eef8679ccdd5ec0b9f940d38da5ee07a3b051c0cf27a4f96"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/cut_block.json"
-hash = "6bf8a1fd08cde258bd28a112c284ab9e7cbdb1ccd3c43967f8a35c5c9cbd23ce"
+hash = "f3b8dd3b320bee655dfefbb29f50706ba17fd39d5313283edc80047551a94dd9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/cut_slab.json"
-hash = "248b8c29261639ec317e1d39da6adee161616aa1358d05f77cae2f53699339dd"
+hash = "a97deaa9f0c0850a49bf5dd9bd1f929d6932cb19956768edd58ab5758399f582"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/decorative_block.json"
-hash = "bc61a504066a539cb9c68a53d418d43fa3bc0b8db228f0ff7055304e1e4d7636"
+hash = "82c4acfd37d060e95c5dca88459b21651ec3debf3a0d461c38c52fd048617cff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/dust.json"
-hash = "44652ac70897ae9db1e86fbbc9b3333efc6ceda65b9e858d6fed4506fcc60e20"
+hash = "27ddaed47e47798bb0ed7b40a464c39ed7b15d1c67734e44a68264ffe2d791ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/gear.json"
-hash = "008bdb283836f67cc17b8bea1e8d5ced8fc30e7a11b8cf5231541c904b5fff53"
+hash = "29cdfadf4deb739bf9cd5c30dca47f1fe3ebbeaa323fc265866c9d8eaae8ebb4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/block.json"
-hash = "ddf82837251989271a62c75c8aa30ffbbb7cf546c1a2fdabdc3782d11b793bee"
+hash = "da705bb6a1406687e58f2d3278413a19e29a799a7459f29ef99f748cc28aad28"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/bud_large.json"
-hash = "a116001d807c428050f8d3b97bc4ac5fab397c2e081ae235a7c277d6fb21b26a"
+hash = "d1b6b7418198c506660cb1ff4d1c19ea2ba0a509d690aaa7b9fee2e9770e69e0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/bud_medium.json"
-hash = "0333abab8f6bc0122822f1e58bb1a7b3f04e6cbb1f9b96177d6a96352dc2914e"
+hash = "6400e054eff906603f6d513cbcbb290bb67b0b8b26f0afcf12987312f628e4f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/bud_small.json"
-hash = "40c290de09e95acb1888f9954a2bd19896d93892053ad6825b91f7aa9ad7e2e8"
+hash = "a1aecdab1f1aab14071ac9216ff212879199b958d6e2d520c75da55183fd509a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/cluster.json"
-hash = "4b5eb4b11959b7deef7480afb7efe0d6293824ce7b947c4112c0576f7bf0f8aa"
+hash = "99bd15d663f4b845dc6f3ac77065c933b9117f81b87f1593b2dbde7d064854cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/geore/shard.json"
-hash = "25bd93daf1e79ff5842ed1ffbbb22e8a573d73677068f25c61832c88f87831ef"
+hash = "8ffd210d477b97b680ff435adeb75052575cd33a52d5f8d80356da11ca41367f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/ingot.json"
-hash = "1df5abc9ef33c379c4e50fafd9f9381701cbeb55517a76cc9dc441845b16aed2"
+hash = "bc545b1d84ed2377c2f3471ee5d5794c17daf7a229b5575811a8f42c47f8b02d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/lightning_rod.json"
-hash = "dd422af42e8a55cb7903f0e8b127067bceb8a6e765cdce8b04df5a65436f54af"
+hash = "6170ea279174bc63586a2ec53840affb9c752f400da1468f2e4d9e4712155b8d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/nugget.json"
-hash = "6a36731073c519f564fbdf1ff79732376d45b66d3d9f5c87ab26ce18637a1724"
+hash = "8d06d110fa1abd588d59527981d9bb285f0b488ddc9abaf618148f79fe09db35"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/ore_dense.json"
-hash = "526033ab1c411b9af5397f9c5d8eb32f52ac62095a85a531f78942be537347d2"
+hash = "8c1fddf034a91566f8772207a69d7757cc2ac29ba291141ff28d1ae5cea02bf8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/ore_singular.json"
-hash = "d693fb8ce94dfce6504ebd6708534932d4874db15c113264b23a281f8e4f26f6"
+hash = "3ae613c104d057c4cd2ec2538512ca99017270947610f00f8564d513b0c491fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/ore_sparse.json"
-hash = "0809ebd88c5d3562c0685fd658d810a9cd7eb2c4c4d9d7a68fd6418dd0a86d2d"
+hash = "02027340cd5ce206bff891d0e832129a3b006cf851cb31b89aafdb5bbc9da84b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/plates.json"
-hash = "e8570fb57debea2a547f85ba90f87f0a1fb983ee856a081357f4cc0a82d4628a"
+hash = "da12fab871dbfe9bba08e906b4b5bc815f2869e28fe74641d6fe63e4297b5d00"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/platform.json"
-hash = "216f04abd18f34aadcf09f5dbff9ccc780e8d376a4f9caeebb46f16a0127b78f"
+hash = "be289dc12d92721d7f5b9dccf5be296d4ce5250c2bb8e4dbdd758d6c3389f807"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/raw.json"
@@ -10802,23 +10814,23 @@ hash = "910aaddaa6bb2c2e6ba1ef17dda8b8142d6d53d4014e1013902cead767824794"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/raw_block.json"
-hash = "c751b5207416c407b27a384604491febd9500047e98bffa3482ab48c58008722"
+hash = "17d7d54b49746aeb241f9665207aaaa0721a459431897deede9c3ee89f5bef22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/rod.json"
-hash = "0d8de4fd2bb68c81a32d5fe8b618ef323b24b0fabcad98f1ac2c72793cac4bb8"
+hash = "f2edcf0632c0f4ceb38b975e3ac2a5112abf0d24b216a60023346271065a0729"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/sheetmetal.json"
-hash = "af64d3394caeda7fe41538f77c00e6391a7a03142abd5c1b10881bc28cad1e60"
+hash = "46ed06f897a7d6ce3374875822063354802ab88baedda1be5775108e70630424"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/smeltery_controller.json"
-hash = "fe0b7b060261fb32d5058c9717dda1799dc76ff9301fe09a756b1fb7af448da6"
+hash = "1e5243ce8372ef7f7908d307543d7834e229778a76f0e4ff216a05db4afb3f82"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/smeltery_io.json"
-hash = "ac72177cdeaf755ab3111269848bcd4faf740e9d074b8e2a01fbad0ced73b187"
+hash = "14b5cb512439df5c10cca1be87a45af9c1eea2a1709a2f871732a6521b30bdad"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/copper/wire.json"
@@ -10826,239 +10838,239 @@ hash = "e26dd4b2858de6e2d597a95e58094f59992c029bd3c308383cedc2f39a995c38"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/desh/block.json"
-hash = "606facad1f27edb94fa3d8b9cce5f38804cbdb0eea48579abcf83af4c722841a"
+hash = "39c3678a3a233f34e01b179b31d3caa8ab0e3a12b2486925ac4f2a36d319bda5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/desh/ingot.json"
-hash = "43e04cef96428ec72393f8cb692cb72116728c7e669bcbb7b5b0561b765eba27"
+hash = "88a2e46c68b10f57b4ed1225634e91ee3f75ece8116698ff2177102e0a05d867"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/desh/nugget.json"
-hash = "9b3702a91f1cbb56653a4fd63c44eb773f39398b6a46564ac5f67f03a1810ce8"
+hash = "d325ba662d1e9bc1028908963d2a9a36161b1294c1b512105ce47c862f90c8cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/desh/raw.json"
-hash = "60cdf31f572190d607dcf4d8b974c2abd52c08c5e945cd4147f9413051aa42a4"
+hash = "ad25dc07bfde65a894c7e1e636fdabe060588fbf05609ad3ee5bf78caf2831ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/desh/raw_block.json"
-hash = "ee905a0daa352d504327c89b7142a2aceb7a8053107ec8cb6d33ddf557b6c052"
+hash = "42500be1f1c99dac50c8684bb1947dd4871fc8d8c0531e7b73d72cbadf966ad9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/block.json"
-hash = "7f223b72a1cf5092ff0bf2fb33d81a9f76be75548be2fab50954a39d290eccf0"
+hash = "45d676744c338970bec6d52a45cf3b412ad41202f3200f977896d605f4d9a13c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/coin.json"
-hash = "624eb7982e3ef97444bb32107277bbb324e9ff41edbf2d19d84727c49f820af4"
+hash = "cf6f85fb2367743fb09529a1a6df0eed8a57afe6c74431427697c4a596419e91"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/dust.json"
-hash = "633eb99842b81058149f5ffeab7c81f9b90a6aa7b79b0e800be21c28b9a11514"
+hash = "7c08ed13724a00d334928442c18d5f3f8ab0d0cb4f487ea71605313cb436833f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/gear.json"
-hash = "3327545f7f8ba82f3296f9b56e656857f1b9db4b20d0e42c612ebc4a020612a9"
+hash = "e40dd07defbef8544c8a110369fdd6c0ad4cb047fcb18c37006e174b820db37c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/ingot.json"
-hash = "6ecc9df13d9e12bad128e3d1106c7486a33c6b0048aca348f384687b08bd70b4"
+hash = "c8be86de10a0491dc10bd48015eaa5a6ccef6e3101153ec756bf6a972372007e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/nugget.json"
-hash = "cf1f6c59169d1700a2f8cd811a772537ecb729b9dd62bbd3231edcdd1d7f833f"
+hash = "31f4b8396d63ab0414576f0f059cdb08df7dcd2cc8985dc14b9603ea120deae7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/plates.json"
-hash = "f583ede01e0f5a0e8bf3d265eda2b2c2062f607dda3526da59014b6d2d251da7"
+hash = "0122150eaa6c6b86e996ea483a4fc0de0f046c85df2319a64d467e3db8ffe56a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/rod.json"
-hash = "9414b04d6502f25d87fc3df58f52ee22d8314dd226dc997e40e74679c3d2d94a"
+hash = "3fbdfc05d6b4a83cfc3785b4eb643e777659eae9edf725bce37c87b7ee73bf09"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/sheetmetal.json"
-hash = "4d0eec3f35f03df59ea94fb3188e08d0303df42e32183e15445e30ef74e80339"
+hash = "8f4763d40770d57e8fb94451eb71b02b437bec88f3246abdf35cd902e4347b22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/electrum/wire.json"
-hash = "4ad29bdb56afa54c36ca60c4141daa3319ddae76ff5bafa779db6dd8d1e70151"
+hash = "a076ee152deae8a6d62af89bbd3b8be501fe40fdc8088be2443dfe33efe83c0e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/emerald/reinforcement.json"
-hash = "d53d6e060250f21356778ff783e04c9a22644e7f024b6209c4fd95be90960483"
+hash = "386679b2b433ad830c41049fdb55a5ab755cb625f3b16f0c3468d3a429a6ba25"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/block.json"
-hash = "adfd6f010c36b00fbad1c73b4eaf32b302cf5f793c79f7b02efa7b4a04375810"
+hash = "629efd078f04e20aa047c771975538243ff3ec38e367ff855a5cc0d1d1d0003e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/coin.json"
-hash = "015f85771a3539a3392c77556da428bce32b970652597d24d4c9bdf784490dcb"
+hash = "232235fa6ed18870f4fc7c0de4c7e692e616c4f7a305097993628b4991396e0d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/dust.json"
-hash = "d075efa1022c54c83049e57d31b97c1990663391d9f99af7640a07071268d629"
+hash = "edb49e44642c99bc0b73b069826e7f10f8b652e32922bccfea50ac294c859595"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/gear.json"
-hash = "33c7edf146e2d0393555f40ad488fb93a1a06eeae8f169c6e2f1c2eb71471934"
+hash = "4f20cdd6e1cc0053147932e31b470a3232f65327fa9c1c5eb90fe5ac7863c447"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/ingot.json"
-hash = "7f6f608425e516bd644255cccdd602b1d352dc151b47ac2b563ea75e31356ade"
+hash = "ac4a9d1681546bfcb4c15ba66d133243769dc7ab5470f594e20c579a0d645b49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/nugget.json"
-hash = "8538bd5f2220031e5373429e4a761f3b9fefccf6dfabb6e1f7ec3c4f54bd8249"
+hash = "d809ae3de6ec67f5635b15458e119a69e0e50091fb18ea2e9a656969979fd933"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/plates.json"
-hash = "1a89eee8748b6948fdbd00c9157d7a4a07b033ec4345eeead38e8a5187c6757d"
+hash = "17bba9f112f3ca8d1c82f210d56c0c34418d86840bec25d6b9375084a7abfdcb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/rod.json"
-hash = "d75536852981ec451c15d2205f0f2089da1b62362a311d05d86cafffa7d85d79"
+hash = "80fe953f81dc4b987b4ed02bf17e0bdec578d593b4150ef3ede313fcc6ea93ff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/sheetmetal.json"
-hash = "bea953e237f1b45d9e4414d1415bfa337ed8a77b21fe9b321813d6bf70dc7245"
+hash = "f6951075c75320be6744d4c960d156b01e1995bf57b2662014fe190aae49a1d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/enderium/wire.json"
-hash = "e5804186918155d8b310653dc98f27e996fe04040d7ed511add454061dbc43e0"
+hash = "8e300e20081003d5afbd1e6f8dfeb0e148f677e72f76a0a1577aea8f0794ae10"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/apple.json"
-hash = "713191d722d414fc2ee1c03ca268bceb596e2078aa12c95e6926290adb2a4823"
+hash = "f003edfe58843ef380ccb9719b561516739da95fc18074b85b85fff951d5397e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/axes.json"
-hash = "335d545f8e848b0c6893926ca4de7870d8b206ead86e77178694823ee171b1f2"
+hash = "c8d3219c4a3e5fd87e30e2086109642ade9062d6aba783a5ca581a5d62acc6cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/bell.json"
-hash = "83a86dd59684bb47e277cdbda8c7d0ed9c370fb724ed871851d13a55fbe3a364"
+hash = "72dada9e0affd9973e3765955fc824a92ad441968d45fad574f897abc970e9ac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/block.json"
-hash = "f89587095ef74a9484ca58fe4ff9d26784f6d895420a7c5532279151161a00ad"
+hash = "3a53525f734eac11c3fa6aa467740ae137ce0f5a35ba352c72f4d14145837ed9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/boots.json"
-hash = "a2374e0a51b51c73510f9f4f179dd77bad88b861fb7f1efb8e16ade3099d6e9b"
+hash = "e803319388f178adb8f773611d6bd1718efe3ad57e9c4f737ad3e5dd08eba547"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/cast.json"
-hash = "cc900bc0a57a0cf62de36cf94cb6aec1dd7a78aa8eeba61ac768b7ab7594be24"
+hash = "9901902bd890e5536ea455ee1415390506fd9aebba79a3492cbaad4264fdac73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/chestplate.json"
-hash = "5156c105b32e89aaa1acf38dca2c4240f55bca00a59de2068d37d65280f42c00"
+hash = "ea41ff30a29cd24722a1aed804683f8fe91cd92bbd98badfb8bd9d1c163c530e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/clock.json"
-hash = "bf5d8922637570fc492483cbe5d01b49ec5de66c612e86587e5614461bf80e20"
+hash = "d3cde9d08041df7e9d1cefc5a955672f30b581e75526d00c60ce10595c2ed390"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/coin.json"
-hash = "e1d8d1ede80023ad8e884b08fd08ad99bbe7cc6d1ce057998fb0547ea5b23803"
+hash = "697f3df24aec234e103cf90530fcb5c709b98bb04602c1770ba84413b612b293"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/dust.json"
-hash = "e9631daada382e9d25724e4b0aa99dbac33589339f36fbbec4ef8e6477b42c83"
+hash = "1bd80b75c69ec13db70d8a2198f61833069751c6b2aa7d66c0781d1cd2b7aa86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/enchanted_apple.json"
-hash = "e7d79ca873104e0be30756d902f42a9914a1764ff98506efa0d9abfdc791e84f"
+hash = "a384d908438a820d628c679a506a514d807daa76b5683849752a08b249daefe5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/gear.json"
-hash = "3156ccc6af8a9992ccb85d5b7a3937e2bf0bf0ba217df80161019bb7a00e0469"
+hash = "e8ba6c9beed6c635e756ad674d8f287011d99b5907cb731ce5b1dd8a1a18d9af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/block.json"
-hash = "dfd311a5f7cb93ba3683faad01bc92069138cab2c6a6bfa2cbc9def8d15af4b2"
+hash = "ba4f57a34715c7be931b5a5e0192db18e15c248df6cd992ebc8f56a781bc9f93"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/bud_large.json"
-hash = "bfa30d5e0d7aadd0bb5e94b8b03424ae23e491f6e1dcd5c30603b25440c842c1"
+hash = "0368c10ad078789b5af3b16fc0fc0af02fdb4191f942de7674df9b1fc4469922"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/bud_medium.json"
-hash = "18ba91cc385ec560aeb5e53ab04fe26c0f48e4fae08b55351d78d2eb35de9fb9"
+hash = "74ef03d78676aca054653aadcd90dbf059530a83f71e7a62f4ca8ffc00e55303"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/bud_small.json"
-hash = "8bfa4bb75d877f4e770b015a5fa394460ab0c323d8cd0e8f21c601d07f0b5b95"
+hash = "465e20f37f6cb83f8e1720cff5513cd96128257580464f19db701c080444954d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/cluster.json"
-hash = "6c5424f3fe51ddd0278bc058b01e0f4979dead737e13f5b9a5fc14de0b42906d"
+hash = "70d724410b14e484bcab9d2b22019826789a56a5306acbbacd509dc932d11eae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/geore/shard.json"
-hash = "dadf62839f61cc84196bef0837210ac42fa61c46566c02842342d55e1ace0a3c"
+hash = "9ecc56b015ced4b10d74b78d2e552a4ac190864fb6fce94ef47d7d05b5701d09"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/gilded_blackstone.json"
-hash = "b8e0ff30d07c6318aab3c5a9373136f5e19066b52613e4484490412378f84152"
+hash = "bf7ee6253f15f65584353177340fe786ee6ef4c6d588fc1a807b3d1ec8dbb207"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/helmet.json"
-hash = "44720fa01cd7216b0d887759e5f1333a41d3000e54c09dad3957ce278401dd1f"
+hash = "01d647cdea50db636acdef039de4da667479d728f710ea4d4de22645f01a660b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/horse_armor.json"
-hash = "02a2f7ec91930782d7bfc88b10c40fa9f612fc4ae6c05bfbd9e85ce81352dae3"
+hash = "07ba7ed1d93e8dcf2ea344103654a2d74975fc82797f6c07480f847ef4ba2c36"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/ingot.json"
-hash = "d310b103b36658199440d447df204c882a44d152edef65432cd2acc4d1855569"
+hash = "cbd0eea851c8b987714bfe7a196e5cb308a813d0b5ea48cc050ec8a66a57cca4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/leggings.json"
-hash = "1da0c3363cc4401067deda65314cfb96ea0a383150bf1470214a8aa00e6d4f0a"
+hash = "6e566522e33ee44461ed46ce7fd7c998a97e11879dd7708fdc79448157b27d73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/nugget.json"
-hash = "8fccc3ee0a41eb2789b3a3bcbb49571d16371a2a2b98dfaa09febe8c97a67d49"
+hash = "baf0ca3ef983c2781551740739c924fcaf7108477959df749aed1e86279f9a22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/nugget_3.json"
-hash = "9e50a704af58237151c1f9e008a5f937dff57a1438a32d47204f88d770d812be"
+hash = "ed746b50379ed734bea2eb07a317818822bd37571e637840bc2661e74ba4c7b1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/ore_dense.json"
-hash = "5cb4a4885a01b961c7a7ccd5f868ea11f7c7ecf82d0e9de01ff5965cfe1165a3"
+hash = "93c1ed7e3efc9b1a93a17c79eb372093e64a084f5759d882fe807acf0c898124"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/ore_singular.json"
-hash = "20b2472461dc18c9161922ce18d7b70b6bdb27e16e6587170d333e92a9efcb6a"
+hash = "00eae7731662c757340435107b428fc1f2fe787ad75280595e070470402d5495"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/ore_sparse.json"
-hash = "1c754cfa1ee4f4d7b769c47a2adc51810549be34df5bf87471be44cdad00c0eb"
+hash = "78a9eaa7bc5ba6eb4d6c32d6b6a547083425fecf3af5ae83a2e56a878f194419"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/plate.json"
-hash = "362881e29f1c4d420e863d9d9d6f4ff8dfb9067596a54323bd62769c3e6f6a56"
+hash = "0aa439482116b1365428f29995771bb94347abc3bf7e85ac1e3665d3e091a87f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/plates.json"
-hash = "3521cf2c4792fc544f57d52ac99f7cb68d11af62f43adc8aabb894df02210524"
+hash = "9778b1c1fe23f0680f4de4c21903802d5bc0666bf35c5404b8770b56b239e035"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/platform.json"
-hash = "3b113491bc56d8c0a41cdfc0b77799ed13ab9606c450ad5c29b058e924f7279b"
+hash = "894d1bbf5d93124e2cc15b06a336944036aa3cc2fb49f102c883f1f0732b266e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/powered_rail.json"
-hash = "c21f282035b9bbc3fe41d95e94f05e3d555508e42d2d43a1be7d3ed457a2d0f3"
+hash = "fc51706d01b7681ed0857eeb7049e257c78395c47f44cbd9ee75d8d4037119b3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/produce.json"
-hash = "533f4b6ffb05a25e89ed506a4842b5ce592157d78e1a281c07e3dbbec4c822ce"
+hash = "9de7b11697de8b75d16954656c6b4d1f9048a9c9a337df605aecf39aea60f16b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/raw.json"
@@ -11066,27 +11078,27 @@ hash = "7a7730fd1736ca8bc7f727156d3fc4ea86b53ba9953a814818808069d1d83916"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/raw_block.json"
-hash = "aa4c411c70543144c39d6b0e6879cef8be3e2b62709ee23fed2351de8c4953c5"
+hash = "7419c52ebbe371960e5e646a021139adb5749a8a4234fbc14ce81f8956519813"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/reinforcement.json"
-hash = "65bb7fe31437348eef39da8ff5792e88a850a4e097f9749cb444a2949c71af59"
+hash = "3278c01fd11f9b54b20c1ca143a119abdc225d0d9108d56417c34f89e7038d1b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/rod.json"
-hash = "f5911b1303cc72042f15db9daf365df69a014bc9fa2ac752bd64c8e4d710efc6"
+hash = "79f08eb1d847f5ba8b0687e9d413b26ae335dbe51559897cf58ac59328447cce"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/sheetmetal.json"
-hash = "504386319f693c2415070ab5371b0a945575789f70967a4f1afa5a2a758c33bd"
+hash = "217539442fe5580131ae640cffc9b3d30eec5471f91ed568458a28c691581c7f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/shovel.json"
-hash = "eaf320c2346d839b4ae9396681ccfc62fcbfbfb42a166f4c78987139259d375d"
+hash = "4cc8508f425f8314447fb8cdca44e2174cf84b611bd42d7bd1bae64a8716e067"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/weapon.json"
-hash = "bd082f083c1881e33e9428d2257c4637db63df6b3befb75e699c7f0b6176cf3d"
+hash = "4cdf911559b221e5dab6bc73faa57b7acbddccb8b5864b6eb51c1d3780553c8b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/gold/wire.json"
@@ -11094,219 +11106,219 @@ hash = "29c0a30b472d00a25d67ac80a4dc98789af70ceac24fa43ac01cd133bc011508"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/block.json"
-hash = "9fc898c84424c8485e51477cb07674fd9d439b6538de785f46d321d337c52f76"
+hash = "1a4c0166f20a9ddc8a1b3951a8a9acd08367849aeb9842f8bd5344a55bbedac3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/coin.json"
-hash = "ba5b11cb8921a74ab82488a45afdfa8d826d6a7947a33ce6ebd411ea6e464cfe"
+hash = "5024bcb17eb685fe7a3f020f8ad426ccca2f8864b842f4b6511ba30789b5a62a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/dust.json"
-hash = "143b5eaa47f840d9a49d4deec1bca7393ffc9a4264265f776cd14a9256eaf85f"
+hash = "7899bc7b285df984aa208b7c8182db514e74bedc125fe41c08a131bf93cff404"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/gear.json"
-hash = "eca7f426fbbdbe337df132622f50aa14f983a14a66e1fccc4501aed02cbeb341"
+hash = "9ecc22223581bb4083102f838e187debef8c372218a5216d9dcdcaa416b082e1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/ingot.json"
-hash = "f635ee4c2515429210b8bb843f9affc30a017a36a271a8eb99391f272e7627a9"
+hash = "e8de7e5e0e45ec3fcacb7a29c682caf46dbb8e59c7fbc25598d117d72840697d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/nugget.json"
-hash = "9f6d7408eae977f4194acc8b1438b14bb877f415a8154a9b71d20645a9cbc108"
+hash = "02f45a1a5c4e574eb92c878fe7cb71a2ec33a40e8acbbc26d6977ab83d984379"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/plates.json"
-hash = "6b75a34ab1299bf74f6769b285a38ca880558ad5536ac585249d5589fe16f7b4"
+hash = "e7672cd517ee01fc9ebf9ff133e64148b45f931b4df4333c4cbff6d727e0de78"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/rod.json"
-hash = "170cdd27e8b8e97c21fa770ee08d131944d6f377c1b47008a283980121b1a36b"
+hash = "b2e58762049c892a8893aa7a4babcc153394627c146057c3f8fc87f9423e02a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/sheetmetal.json"
-hash = "cbf10a535508852820c26e1879c6937184f338bdbed7f6e9a6848814a040076d"
+hash = "4431ea57ad09a563c335d9d5e2d00bfb68be2a0fea549562a7fc2c53bdbb9a30"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/hepatizon/wire.json"
-hash = "fae6677aba057e41e617122f7047a62208b7c9bbddfafb8c25b10785c5571202"
+hash = "1840809313edb154df975394920c5b2472b4ade6f5b5668f729f546742c2cec0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/block.json"
-hash = "935c8c0ca6aa96da2c0413181649add41cff910e4d45dcdef9dd657fd3ba9399"
+hash = "bafc8aa77b5ebeede561c74b2d9720badd27253a88743c50f40e47c4ee45caa4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/coin.json"
-hash = "781a680ebbbee36c794338fafdbedbca60251c3e09881a5a31c62445bc0410ee"
+hash = "e90799d0930cd2d508621b51f706e9b3114fc9ccff8c85a44164adeaf7aefefe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/dust.json"
-hash = "71350a999e2f09a41b209368728bfab0dd57d75b115f4be88801ac85448b4ffc"
+hash = "80aeeecb21b94c356170c1368ff15ccc17ae1dcc87ed25db596e2d8afc1edce5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/gear.json"
-hash = "2be8a6d610fa22f057678e2676fa3ff6e1ca9cf8ea5387ae89197b1d4e6d28d5"
+hash = "f146916343327a235cdd8ee1b58333b4bdb4440318c0a78403ffab6dddfd8deb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/ingot.json"
-hash = "4800adf83aff85a578889fae24ab7ad5b681b9778d6d444eba2d2bd1c652308b"
+hash = "c1c4b03b562d49c021b95f065b6ff41e8673b86a6eac6812aada8b71c396258a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/nugget.json"
-hash = "b6056d548abe6b75af084a45d39c5cbed85cb8353054eb2f22b021cfdfac7fd9"
+hash = "8f44c272f7dd19096b8ac00939812f5f510ce840f0c9a6d33b2fb98d73898f09"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/plates.json"
-hash = "c2c2a4d4b9c84a575b9660bc64aa5fe322dbd12b82d1a375ca5c39ec0b7d47a7"
+hash = "c03a326b4bcb2053efb6ad73084240296cd17f4947f83bf25a5142ac9da8a3bb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/rod.json"
-hash = "8d5894a6ab1bbb85d239d761492a14ca7599aa4ed1b238aa91a1e61238f3f054"
+hash = "d8c13f9effc60f5f8cdeb48083f3ed11d32269194cb6e753d84a145d1b3daaa4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/sheetmetal.json"
-hash = "32673932af93042c8ecab1e60f1175a963461b15657f18fda5bdbfd2a4cfefce"
+hash = "7b44686d6af44b38753368cf7de4c0f103145a3a9dfbe4cf0c467391792c5af7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/invar/wire.json"
-hash = "524aa77e92a0ab665081a7bb009a3d92d1020ece0269c20f364f6da95814cda4"
+hash = "864038f8fb81628e0e81acbec8d4286dc3e21325328dd2ff89786eb5af564b51"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/anvil.json"
-hash = "a9ad759409f1d0b32f8286a9b8027d4c733f9065b20cceb6f9b5299f0b6ca578"
+hash = "11fc24d86e6e519798a585bb8095591e52bac3146f50a7f3d296b54798bd1e8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/axes.json"
-hash = "15a64f5ea9fdc161e6e87f30dbf8e97a061136fac7daabe690fcd5d5c0bebc82"
+hash = "0dcda176e712d3de2fa12be7057483462f47c28d74a3487529086209a8690698"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/block.json"
-hash = "d204b25f59ba539fe98b9612cbd7e3db7cbdfaa21e0f6f7990469fb426143bfd"
+hash = "96ef8ebd392b1356b510b99ac93d799342f3499eabbde2a11926764bd0f2f7e0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/boots.json"
-hash = "2d065004fc2b919dcd99397f115a2e67d5ad3312ad908a36aa9c8d67c4c1b79a"
+hash = "044342563b19250e7cea07e0c04be8cae9d37ed8921c70ee0acc3dd3adb01ba6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/bucket.json"
-hash = "647d037bb48b9c326ca04554b7b2211cc0f23f8ab7d068e11130abd808db190f"
+hash = "6bf1d6a05f47e70054ac368a36e1908c159ce139e341f59ac90809a65129e226"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/cauldron.json"
-hash = "85a6ee0a15e3c039cfae529b60b4038bf4d59c9c1d9bda1ba936214e39fd68da"
+hash = "2bef528eb3d78eaa446b7fee13666ea34de28ffe775678ec1d3669c841a3bd1b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/chain.json"
-hash = "e4d6e57671adf0a0ce71c545b31a3778e6c026beb1162c38699b30c97e2b345f"
+hash = "4a76dff3cb9cbfef46daa89161cd8719e2e66c459a154c79ac201bb10c47221f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/chestplate.json"
-hash = "0d2ae526db92c9c49d3f846f4e0fa5b5b7be41c838932605ae85578cc83251c4"
+hash = "5dc9d81db8c64c32198c2c1a107686b039c64b2fff32ba7248fbc6e2bfd41493"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/coin.json"
-hash = "94d34adf8cc0bbe8127881b170c12444ed3d491753a4a0300336e06692c49e02"
+hash = "211e97ac9e61f3019867de07b597929889b810fc6f60ea2068f6553a3b96dc9c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/crossbow.json"
-hash = "ee2c55e1b88818d64be56a7c1f3b39af5be5b0f334989459d6ce0beeba4b0b88"
+hash = "cad43fd6af28aa9897261a4768cafc2c294214f99a82357cc98d7569ce52e592"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/dust.json"
-hash = "64bc938a28dfce43e61273100a948e1bd059dfd4bd6cc3559930f4ace0ecd1c1"
+hash = "d3671637ec61e33135fdbe848a32c341aa4c56bf88a08449f2d3686f4790db50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/gear.json"
-hash = "b962e2730311dc9ee0a09728bb5279a530d9c858d39316517c5ed367f8eaae1a"
+hash = "fb80787b5440cc0fcf5c868971e448af689b18596bfbe2f2a634b94a8c4a4344"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/block.json"
-hash = "ec216e378d2a8ecf040c82c46fa645ced10cf8d91ec224a65e49fb47bf9af669"
+hash = "ef524d12871ea31295f2cfb5dc1b34f1c08831ff90bb43264be76b5723bf11fe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/bud_large.json"
-hash = "31c0dfa5af41ce90cac9faa37e7beb79fcb689c2a973105637c4f28998e4b787"
+hash = "554c50f180477200981369f314347d6b2377d4639641e1e56170dbedfa452b2c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/bud_medium.json"
-hash = "a2c63df33077f0d7ee710916dcb43c02bc43fdbce3acc4cdb758785d1d54104c"
+hash = "d61b2d0ec3d1155e8d62d85bac7648a9d9d5d274127b76ee3753345c510dcede"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/bud_small.json"
-hash = "ae67f167ac94e359767a6c1708f6b34e5270757c3edd60e57a3526c4f2bfec26"
+hash = "bcc1d238d5bc488afa2a6299290d1eee62c1a0d0af0cc7b746a4870ea641630e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/cluster.json"
-hash = "07a9194ec9f87e378b4dca8d085ccbc747457cfd1c77f86fdf5421c9fb94c2e4"
+hash = "49c10e7dd4eab1ca64450d08c53c38a8efd5b2854912fc8f629826fcff93987b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/geore/shard.json"
-hash = "d52882bbe4f3d89d3727782f820f31e73a72c094913c8c1db9582b4afd25a113"
+hash = "0d4f869111e547576b670f0a4f9c667eea93930e7e731e46245443247b2f9e73"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/helmet.json"
-hash = "db61950171c34982826e52fa99b661af782990e65a4d576296fb0aeb4e030b90"
+hash = "bd73c01ad11d3a76b65cb8e9ce4d2567d23d5256372877d21d4f01d85369a741"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/horse_armor.json"
-hash = "79e70375614a8e37837d5482503f5aace4010984e008d15e011560afc9efcadc"
+hash = "0331507d1676084073c6780a60a9f0d7c340a73ff0bd2d6a4aa6018c78ae30ea"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ingot.json"
-hash = "8b8dea71e3e19f7e3481737e46c1abf4c001a909a9f12e63e841acf8a5c83c03"
+hash = "c6735f0b2388cbf34d01c82b0ffcc5b9829e5b878c6f42c25b84441202a0c566"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ingot_1.json"
-hash = "e4bc9a1f0d3e94ed70639296bd73c4261eda76f8002299676bbd28b1064e9448"
+hash = "86b74cba980b9b1b61629b430d530997c3bc760f5a338fad5ff2a0be132000ea"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ingot_2.json"
-hash = "228f20914d63ef21067890ff055830ced468000f9be45254d96d6c68b951831f"
+hash = "7425617eb946bdb5873d3b4666ff3b1b6eb94c96a23551bdbde3ba0f1e4a5d61"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ingot_4.json"
-hash = "96f67e6cac02f192c8d3456c51feb784011d58909989ddb0c7016b114db808f0"
+hash = "478df162057eeb4a3580c420abc89321fc1fe1c24c7d91539e47870b087b16df"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ingot_5.json"
-hash = "94c1f98e2879e17d5ec65ee4e7eb954783012167824eca24b8dfd8d3736faa43"
+hash = "06962347b4c54f91fa10cb82e70d7f7342708c9ae658095080b6fc0392c549c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/lantern.json"
-hash = "0ed3922509d15454adf0f4d71abe16dd18fc98b64f06c758156e6fe6a4f6af75"
+hash = "b7e6bac15d3655054c4da8e499349f9f3873ff5da194bea91fb306ae6f31fd1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/leggings.json"
-hash = "117388150f0267e5dbd66f4e4b19cd3e4dcda9fe0b6837f4dfb7424818f75649"
+hash = "3b24e1370466b0e51ed957e98f5861b960430ed70765fe5c17b50b3d29a86bd0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget.json"
-hash = "5f1da916eade91d67d0b04c0988df5bf6c1e7b47ed2e8676bae00045e4a9b0b9"
+hash = "553271d829acbf7508b777d148e1d678f57d90caa83db92e3ecad65c9f5667ae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/nugget_3.json"
-hash = "e9be865d0c84b86d43e4d0e580a3eeb70d498c2116b6ef22214e91f8ebffa089"
+hash = "d8e551fc310024b2031e99a4e22f5586eae441064c34e3ee6baa203990b94949"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ore_dense.json"
-hash = "e9835f281b38da77afc1a753b77905897e8a32c1aa8d07a5011b4357e5d14e3c"
+hash = "c0efb8846bfa9acd7509a7dc5bb27c6d1991fec5fc01bbee5e529c771d996ce1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ore_singular.json"
-hash = "d993d6b99b351aaa5467dd427a65ca1adaf769368f4a6c7e92e97ebee0d2d967"
+hash = "d756fe4956d5aead9e9a095d59347c6c97d139d23b6454f76f2803c216112e7d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/ore_sparse.json"
-hash = "afd9312fffdbde7eab086cab9f466c99a944b006e53cefe700f21cc83e4c1248"
+hash = "7ff2c2b91650a48f09668860f290865ff453b8b45525ffb18ac13f201bd6c26f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/plates.json"
-hash = "43ed848f4a2637d5df700edba37e2f1ed3f35202d51aa779c4bd4cf007ac3882"
+hash = "b82445051e1dd78799489ed0a5734dd8c9d325d1b63c17a3d619c458af37cb1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/platform.json"
-hash = "2432321cdb65788cd479aa59eec2f496ec90751a56e6d3f2a57a0aaeb39cd893"
+hash = "e5bed5616b5a2227f1858c1f6479759f5a8dfddf2e560ff30e764a56af7ae9d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/raw.json"
@@ -11314,491 +11326,491 @@ hash = "931e332423df3e92d8b658f3c70ecbebbc7802ec9354b39a3b090d2664635ed7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/raw_block.json"
-hash = "e52beb7c8fdd298c67d963a40bbe83ce589466c1a1a3ad724c8a5950ec1f74b6"
+hash = "ba80ceb78249d7c262be7688bbff15590f66f0d23966457f093afbbcf7ef6a18"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/reinforcement.json"
-hash = "d484c0a136d1eed70e492169cf81c51815f9623ce3043f376a210b2708c1670f"
+hash = "0441a439bc66614f5289b999dd41708f2794d761f8c72b11f65ba137d7368899"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/rod.json"
-hash = "d502217f7e3971eb05df55acca4c3be3ea04c45c4013ff0e1c29c2249144618b"
+hash = "20a47b6c7c9e55779c7bf3553ea9e6eb56a45037a774f4284630f4786feb5227"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/sheetmetal.json"
-hash = "477c83f928da6e370c3a19d8eec25d9b2f59eb1eaa58bf4bb8823dd3d451841d"
+hash = "ae8a9b607de1bed3800ee2f159ae2a1febe43576a6c2ccfc105c92fef3207575"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/small.json"
-hash = "7910d0d01b7322b80ba2f1cf12cbd57c636f0ad3d06e9b8283fcd2295e6992e1"
+hash = "f3c63274d6366e59cee3973168f46ad7749d5bc49fcf19f525e9a05c4d184d1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/tripwire.json"
-hash = "9dc7aede27b9168c84c624786caa948779694eca43b1403cec12c4b06b115394"
+hash = "f6a3b30a2b72b1fa0411c6d2504404c19a3e90e2e95b3581688e2e5f626bd321"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/weapon.json"
-hash = "758414cc3f8bbfc849ea5558d35d605586c9c7648046cc60e70f55f35698fc37"
+hash = "4deed4fe678dab6d3ec0f1e2f45e40c9b60d7314fcc68bb1d8b24d46b2f4b775"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/iron/wire.json"
-hash = "0a6329fac67f8dccc499dc021060fe9337bedbed311e5e5cd719d6b7f0bc65f5"
+hash = "b0853494d033b033655fd120a6b95cfb639e0083fb01f7c409871ea0eef86aac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/block.json"
-hash = "c6d334a04c61a1b9280678642dd36c6efe209d4da577455b8147c8de0e4d2193"
+hash = "2bb21b73b46f702bdf12849217df2df1d23d60ce612ef0dbd1875d6a731b9eff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/coin.json"
-hash = "1f1b490b8da5532bcbf8f8dfa5ad8f9a50a762840fcdcd0776852a5a9aab142f"
+hash = "f5865e27487182e3c5bfcb2b6afb62be4fa0a9a3e69c3ceb33b24700cda3eee8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/dust.json"
-hash = "83dbf2d26177ec42b3aa3bf5afaa3f27ee89364ac8be1e3841c47ed9533f092a"
+hash = "2884c967364a6a2b9d5b679b8980649e95e5a1926a6edfbaae52c783da035a1b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/gear.json"
-hash = "2d52bad0bacf51087a5379238d0460381ec11916dd5d84f1ee128b5d9ffcd25b"
+hash = "3925a663aefc568b9e0d9053fb12735a78b79b98701a8027129049f90ed4e781"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/ingot.json"
-hash = "62914f5830d315a8050f5d7023d5a1f729d76c757d759d0d2f45930b2bb4224a"
+hash = "43a7a0960888b4d19bb190b1acf33c324731d19d2f3ec3d6cde051b9365e7695"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/nugget.json"
-hash = "dfe43d3bff8639770ccd738a0b9f9bf8da966369c91966aeffc7b287c0fe65c3"
+hash = "59b1ac26a9b64cae80e04a3a669859d377bce6b1ec1eb52c16195ddd036f6231"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/plates.json"
-hash = "3c4ff06658f04cef42aa4387a3519a890e5cf024acb757fd358a1bc4d11f9291"
+hash = "f652e5639c22bf8af23229c2068f7f8d875dd59275233259978443254987925e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/rod.json"
-hash = "ecb54bad0f7ad2116df93b8daa949fe70dcf2dc65bcacae544bc8bfe56ae8b5d"
+hash = "d9a25749ad197d7c0428e7ff0e91b6339dd1db00f28974b57ea55ba068fa4063"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/sheetmetal.json"
-hash = "eb3e12f3369c58623bfb909f6ab67f2e9065c656844be96807df05360a946ca6"
+hash = "5a4b28b561d738ab59d98220dbbaf4395c3f8135479e825b9214d0658a96c27a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/knightslime/wire.json"
-hash = "0216bbf9b001126103ad18d9fae4839a78c0e5df0c9e25a3202ea8efecc3a71d"
+hash = "7df5055061dba61372189804b9e380689bd6972a4120e94e459780d962f1cc8d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/block.json"
-hash = "3092fc79ca18632957bdf995151a83c8e54e3d39ac4fda10d10e23857e4ec6f7"
+hash = "298e49a178747c0f9e56971039d35269eadfa50a4a9ed04535241d5e652bf7ff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/coin.json"
-hash = "e411812d626b7376cb8fdfaeb1723fdd59547e14da318d703a302de759c279d5"
+hash = "7cd91b0b9a1e250ddb5b301bdaa404c97cbfa9315002822484f0975d0931d57c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/dust.json"
-hash = "b290050a88565bf60b90bd5e125db78a939dba97a7027c575f8a2d8e4d48f6d8"
+hash = "67c1ea423bcd26399ca932232f44aeba306774bcbc67c61c9831043d623516de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/gear.json"
-hash = "32f216683c410dadf4fad81b6b0e0441af82f189cfaac42aac7b97b7b813fcc8"
+hash = "feacdb2753bc932b74c849f4d0de453dac59deebb2f5c8308202a2e5594fc934"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/block.json"
-hash = "f024b76feabf034a6473923bbffd8c8fab41a4f03b8fb223ecf6a12401a77952"
+hash = "8c9186e81fb134708d1c67d5f20fd6f5b4e273211ff6b8f976756e68e553e131"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/bud_large.json"
-hash = "d6a946ab82021393761b009ad7307311af27a7ddd547677edcaea24f460fa574"
+hash = "5e09b36fb0b048dfe051584beee9de4d58147cbe7d948d87f8b6efe7e1898e86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/bud_medium.json"
-hash = "01c4776ce5565a6d14072d84e89537245f0746b8b40af5a0b25e5e6548a6915b"
+hash = "6031253256481da2b48c6dcef3d76d8f88e90009be42a587fa68f3155bf73272"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/bud_small.json"
-hash = "841498100573485df7390c1131dfc164f90cf9a748dcad5cf472e7009cd83990"
+hash = "d4b15ed3bd42867497acadfe8738ebe118912c67dee7ec5b7f05da90dfd13e2f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/cluster.json"
-hash = "9fa086008f1aca13b3144dcf73a2023aedaf0a5cd1fb27f9e5fced711de4e7d4"
+hash = "b2fcd79255159994905fe8f9b08255f95902132fe46d6b6fc5b1d20dbfd756de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/geore/shard.json"
-hash = "fc149bc9c6a7d5f62752dc336f6a09e3e69792af0eec6ce34f16f31670e54a83"
+hash = "0abf2c2647c6575f30d56942224c184ac34fba79a80319ac3743fbd983a9ab3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/ingot.json"
-hash = "3290588cb200e0a8bbc527e76a0e7a09fb8114c0ac03dcef3348ebb5a46e2ff0"
+hash = "127a0a3fdcb48d59c838ca48cfe97e8308e729df98f3831fa02a0bad749cbc7a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/nugget.json"
-hash = "caab60ffa3d82fdc1a58603b82d151449dc1d091480369380a5679e3b3ecb525"
+hash = "ed1a8a4f3d2dde5eace4dd4f7c718b10069427bc9eb48e4a6c69010ac098cdfc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/ore_dense.json"
-hash = "075f283cbb6cfb6698bc1d69f17fbb4e252aa01d9a63f1c7c97203d3395522c5"
+hash = "1ba4f96f10a9abae560f0a7d58c335c158a36e8b7407ed9fb9dd26893ee66f61"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/ore_singular.json"
-hash = "15c6f3597a94751bf4e716ac0dda377b909aadd4ccf083e646bd717fed673e92"
+hash = "2e9675dd88a928e44feba9be288141a0b030cb243be2e34b92ade0b9da8d9764"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/ore_sparse.json"
-hash = "b7d2188e56a4ca942f2ba79e54565336ad2202c03e90e507ea35b5e5f8e787d2"
+hash = "6fe6882ed65bb52bcd506138b37742a3cb5160651c871874674aad059b08a2f3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/plates.json"
-hash = "65c3efd2d7bc510f6bf2b6f7b0733ac4f1639701f6af614fb502edbec75cf381"
+hash = "e2d568dbed517519715dd959a3ff99e433bf0161448a63fc30b0c6fe9825cc13"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/raw.json"
-hash = "abd5641eba95a031153acdc6fb715faed346f0bba3e6dcc13c0b64e9afa0b195"
+hash = "f22dfc69f86b21e4a38c6fd5c4e45b9b31fa7bc8fa708cfd24ed8ee22e40d09f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/raw_block.json"
-hash = "9a1dccd1804d06caf8c05b15f58d00a8db7143f2a1a4c17646d13ac82122b3ec"
+hash = "80e50051450b7c1ac10f726f61a3dea97bca1e5144bef453c8daa51155224277"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/rod.json"
-hash = "7a94e91d5403fd1d54c7e3169a22fc0f4b4da98a7bbac4edfe99cbb797a7c88c"
+hash = "8eed3dc12bfc6e4fddb8b891f5064340aca17c87f71031703375cee6d7db56bb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/sheetmetal.json"
-hash = "b98c6e4ed71f4a7008b3fadc2a97938a565b56d4c0a4896ad642d7a6593fd179"
+hash = "c5466f991cf1c1dcb3ea4c1de4031791ae7788001d821a9f7f29d594fc6c608b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lead/wire.json"
-hash = "79ff538f70686ea91441b6e1af72e1e65084783963dd2e78570f13366df09e5d"
+hash = "ea0b758cd411e86f79e5d956168b0ff9258ec3b2e179bb47d62ef68272d5419f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/block.json"
-hash = "0e4f111915a4968bac2c72d7e9417d75612a688f2ff434e36546df7d6319b798"
+hash = "ca0d58a2a3d451515d5316f4cf339a7ac766c033f68a342d9d66c3a796d27dde"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/coin.json"
-hash = "c131d3e27774b384e5f49644b16cdde186dc043bd5ef96577b2f75418129e350"
+hash = "8873c5ebb5e0feef656f3dd86f399166bafeec6e2f73ce3073ab7b6c6b09b024"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/dust.json"
-hash = "b24499daf7c1991ff81b7eab9112bf16b7959f2a81cece43a373ea3987af1ee3"
+hash = "7844fa033f9179f182722c94dc55acd7ecb4f5e875d712aec08fc795f07fd708"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/gear.json"
-hash = "f4a08d94f9762bf925bb2fb3a9c1d1e3c89446cfc8a6f796dd28b57dc3f40d8e"
+hash = "b1d5883824cfd9821d7f18ad0853f4a541c3bed3c9cc0c2f328a1a5a15db5954"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/ingot.json"
-hash = "f32902949d12cd6933bfe6be5f2a045abd6a9adfe0b4085950471f383746d41c"
+hash = "590e86e25853eda1f6d07d8ac7209a364a043e7d7a465b53119fe508c192e5af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/nugget.json"
-hash = "ac0fbfadd697bcd40842df11c22b50176ad24787996c143f6cb2023dc3204fe5"
+hash = "6d3d7ce33aecf14be84d978fd07fd55cefeddc2ad1a9cf3f8fdc0b11d36f07f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/plates.json"
-hash = "0368a926159825d92f5cfa1ca3a16ef5f05a64bd5366a38241849f84e630e0b2"
+hash = "7cbfc82dc25db1c329fad804dc9480b3f873cbcde2f0056de9b7ddb6ef66543d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/rod.json"
-hash = "40bde353f099832a36c83de10bb0de5b8e59b8a0f702745f41262396135966bb"
+hash = "436e85a2733cd1cfb117861a5005df5f2f1fd6fa370cf2f0a5f9c16daa3c2b92"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/sheetmetal.json"
-hash = "c9dbb9c49bcf37cdfa1cddd58476f06069f85456b614332ceaddd66339263a2f"
+hash = "98ca5cbaf51fb2d06987058e892732febb5296f27a99d4dcc3166283e0d984bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/lumium/wire.json"
-hash = "c32fcd34800e558537be009f8ec9961dc494219089a3c6f8f92afdc0b75413ab"
+hash = "86619e3ecaa9003c2f5f5c15c46ea55014a967c5f9f2890084ca6cedb8340a30"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/block.json"
-hash = "8b1ddc35255eb8617b9d2be24c8ced792acd8020df45e9cbb3f0d59df5dc5295"
+hash = "a35f6007981afa310bc26615c2d719a99235e419511c4f6ab1a17828290d157e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/coin.json"
-hash = "e7567d302cea6c6b2f3ef965ac255d5386988199f0170ca533e9e570758be868"
+hash = "0c8bf39e8db2c791b578ce3337671c054c2b9f975ee2feefeeb9be7ae238f0ed"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/dust.json"
-hash = "1814abf5cca40a571df63b2d9cdadb7f7563eb41f5eebbf2a955c1050025c2ab"
+hash = "01f6e0074629e83f3c723376deded44200b4412b0b62a3f3046192cb63618395"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/gear.json"
-hash = "824335e7a15cfd9fcf414db8d6e014de4ed82100580f0ca5465cd48bb7b58f1a"
+hash = "ed59c1b6383cc1695caaa048ed5e5fa6c214bb33f3fd2cd49120b11e808da7a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/ingot.json"
-hash = "edb7a1686efed74efc20629182d5fe6a7b9bdd165c55a2cee3bfb21b1bc3f7f7"
+hash = "e25b8cd5aea9c76857ab870b1cd29370540b7215ab3bb2cf092dfe1e73a803ca"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/nugget.json"
-hash = "af8c07cead0128b03d0522f7c23340f4df38ff06ce284a045633f6b6726a6b2b"
+hash = "3fe18de521a5483a6aa6a48474d5d290db8f67886fbea66233b9161f56ce3d1a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/plates.json"
-hash = "4bafa272455acb4e7765bbc46f594debe385785cb1e1d99b6eda772c25d76078"
+hash = "dae5dabfac854577fcf5773a439ea85e638653d268f7bc05a4363d38ee0ae8c6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/rod.json"
-hash = "9f08e151beee582322cfec903ffe28aa5258da194d1ec8c6fded762bca44e1c9"
+hash = "4bce9d47939972bddb33d45b3881b5d6bbfb374e51c6d65c62191a328c506b6f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/sheetmetal.json"
-hash = "ccf702e56123973d85b2bd335d8e64be18c14fdb9716b9e6ec8e3497dba5cbd4"
+hash = "bd8210c55d98a02510a036cf997e9e8fdfb2eebfb532271e1acab8b84a97da57"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/manyullyn/wire.json"
-hash = "7019d9211ad12d813f6a78149f4e2ee3c2168fba846e7906fb9e83f5432246fe"
+hash = "70bad33c123862418ed771b491bd0c23cd4ef775cbe1c8e7f57e25b5506b02e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/molten_debris/debris_nugget.json"
-hash = "793184f4e319b3a229b4841a0c768b05c3c2d06a5ef7e5285e461b087c40701b"
+hash = "c63de6664868fbaa78e724523d5ed9f372ada769178c2aa869c82a7230b341b6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/molten_debris/ore.json"
-hash = "b2e0301fdff42eafdf45b8ef815552bb23416e6f1eb627add313c0f0a14808f9"
+hash = "a5952f3cdf77322a08e8811fd077204cdc687f297d8acab8b394085ee3e3b301"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/molten_debris/scrap.json"
-hash = "6f67d5df42d80b6cca6ea80a76337997c0674c311d94853eec7d6425332c50bf"
+hash = "b93d3a51be81ec3e14e2f3a088559c948716ae138fc202f47035a3f2cb78c424"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/axes.json"
-hash = "77774f425a808d5bb9e160188c9a183e293c78b424b5ce8f832610a124204f9e"
+hash = "1b8a80733727f77b999a3798a3f843cf5afe6a35a728474e408b565f91743e33"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/block.json"
-hash = "ac64e64a3201a7eba140987facf05362ca62da9b50bf78edd61e4b87038b14a1"
+hash = "cfb51dc7f78d0fe621b551c953efa83612fcf44fa0d2f5f3689e8c9f080b96df"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/boots.json"
-hash = "0fdc61be11650554ad882f54fa5f53fd6aacb91dbc16b3c7643ee8a6971a5c94"
+hash = "be0ad20909a230da9b8ecd198b72e50d41ccda505e4da494b3817ffe71965f58"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/chestplate.json"
-hash = "07b41384ea575d4a63f90087f5232de29a72308858a09e10aef278a970d206d1"
+hash = "bd938599ee22c806a7dad55d5b1a4668929d63094281252d5be6b61627796e19"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/coin.json"
-hash = "bac4abe301cb7e67220e5e5f4564c79bea87f592e778e6595a503258ccb53c04"
+hash = "3f1df9bf71764098f726105b413ed79781e6edd8306bc72abff4f44cd754294e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/dust.json"
-hash = "bd7085d1dee0cbc45479f32d6b90e3a4fe09f44956a017ce1ef650ed3d2e8349"
+hash = "013ba20eb483fe8b1e6832e30e56d81a7b3586b3da9fd29916d998b94e8e3683"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/gear.json"
-hash = "95e7ea691dde573eac9531fbb61f9b287d30e669f2a1ac09c8c57002edabf276"
+hash = "4f56bd2e7085b0175e0cf0e281313acd30dc85a58d6b3c53ebaabe59cdc6598b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/helmet.json"
-hash = "e08650d74efbdcc3a1181d475e7ca22572a2b3eb0bd8b3f0c0e5bb22ca29e54e"
+hash = "144e6ffeaffdd6c1a23b624d4612fa35173c3a8011a4ec8a904bfde8561c1eb9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/ingot.json"
-hash = "2715b308828c0301d10649c75a8a356fcf4fc434266580d5d57f32fa6c373213"
+hash = "46634d6fc032aadd037a79e77fda8f477149212f0ab2a0e866861875a6723041"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/leggings.json"
-hash = "302ae8387f59678ab45bc73ceaf7a7998a1aba4b5f646cc1ac98a5d93645beb1"
+hash = "6bb16e1817f6556758dc2bd16e39a76b773cbcbbca274a052d2176c245aa374d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/lodestone.json"
-hash = "02839d82d4b0b05f956783aec1218702e6d76065652ba50b567d293642383121"
+hash = "5bd1007814a0474afe37ac22199bb28c1fee8e68fdea083274e11edea5b65bbe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/nugget.json"
-hash = "d3a1dbd5562a71d189ec454f862c93d1217d7ab5969f280ebaa09962c9501a78"
+hash = "2350b837646dc503fd5763b15b4b752663ccdd6fdb8f20db3304e40354eee430"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/plates.json"
-hash = "db546a8257aac39d11fe33ae0574e44bb799ba2678cc33114b70c90348dbc3ea"
+hash = "1068850b7b80047ae2b3a0f1e3dea0ff82a3bdbbc6c87b3dc8563b3be0d98db4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/rod.json"
-hash = "e1b7bbdeb17e1d658aeb975c6c551d5c84e11b954713ba1657f04ab6f9261393"
+hash = "dfa506c783ad100cdabd53b833d251ad23039b1c3b5b68414e7d601eef48c09d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/sheetmetal.json"
-hash = "172c81636968aae3a88647b42f400cf75a3170e36e3349d5e400ff2890fdf69c"
+hash = "37b3bba175778c4450c1cfbf580864633ca84633907c50654487b3eb8d636b99"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/shovel.json"
-hash = "382f84ab2fb61e0ab22b4c3ef78a22aed937d3fa6fbab0e9a1e98d079c59619f"
+hash = "8ec68d5862439900b989e6ccfed4b213fd3d9dc21f91333ac71ecdcd5d32389f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/weapon.json"
-hash = "84c8f0ee39a26a7796497c745121c001e5d3b610c66084251aba60c0a24d3946"
+hash = "a6a64d7b06c84e2f59196bddad930591901b0ff9c4725c4ad8756cdd00af7dc7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/netherite/wire.json"
-hash = "a17f23fd83c9f2c9ae3b944bdda72ce7625c12f6c7dcc777ea1e797755c514c5"
+hash = "ed73c05e0cc6af2c6ca94c333d01fa6ee6fa684e0c9913692432922fcb49aa07"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/block.json"
-hash = "bddb9d62e552a19c56d8df8363a7272e197fb4c65533ad5f29e912083b73f192"
+hash = "5f25a9e18d64d165de0a088dcb153dcfb20373c6e67d07744660a38e2757efe6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/coin.json"
-hash = "b5e9a9081f179d58ee97c56acda1aa213defb01cc232d957d0f3d120cfedef2a"
+hash = "14e29a9600c904da347e6d64f6c9b9a7f68784755b12d7fbe62211e14a177868"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/dust.json"
-hash = "fd46fe628cc2cb8f1faf143a6d7606c01a087a2cdda37fbf450c5b80493ad5ac"
+hash = "2c064ef88e3a33c6a09484b86b0cac57323b822e7088f6aaee216b8ebe1520b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/gear.json"
-hash = "bd589a28ae8e498df854f6c75e2af00a7c50f76a1ca076c74ad67cb93ac8f2b5"
+hash = "709362c3afe240edc2562a8666c6012af7be26b8ae3a0baa9711ef223f9753ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/block.json"
-hash = "8742c3f8b419c1cef047fb1eec961a6a3355f16839de02a54ce6f546a41597b4"
+hash = "30ffb1a43e5285eb4c2e0f4e4a653e6643632b54e2473523a88466e4f1a6ce85"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/bud_large.json"
-hash = "da5626d87bb553fe71b91371d730b0857e432f28837e952acb75db288342614a"
+hash = "bbe9eb62f5eebc90ad8104349c0fdc646fa70bda9a57b431314a03e7cb7a335a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/bud_medium.json"
-hash = "c907e9d93d131aea8a4496d0e32ea8dc9b1f1a0ca94376b468577fff97980aef"
+hash = "5baf7e1e445eb381235137f86dd9f593cc6990d560b5168b82637b96a45de30b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/bud_small.json"
-hash = "6d770adc7e5aaf02c05c095d36045a82da8e31bb52e7813f66c982853c865811"
+hash = "8fd46e07be9c4a2c049c5bdbfe65aee7021ad2b23b4bbb23d86799c0c5f49a74"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/cluster.json"
-hash = "c9dbff1d506f40062b045c6cf02d0d79c6be8dd12f4d7bc04a39d0403ceaa122"
+hash = "55c32da1303d7a898680801b3463598ec6329a10da786d7791eff6a28ad46b87"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/geore/shard.json"
-hash = "14c2572ad465be768d9e52d0fff547a7cd187c6d1a6d6b45a183f7dd141308b4"
+hash = "e0e28946a776a0b3f63ff6c80267bb59001c0ad0c8336186d2c3023a5b5af655"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/ingot.json"
-hash = "509f86ed07e6adb14a939deaecb8310fc7086c2a09a2f086790c35ce14cbd8aa"
+hash = "7a5b0e2e4a229324d8cffd440ef8792f530cd3aa099e1df37b645801968a7a20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/nugget.json"
-hash = "ddd6d7b7ada78320caab86e8c9176f8bf3fd30a8bd216381c8ef5b64c24b9e4e"
+hash = "76e5dc61669a5f64143b2545f9c1aeaec2f52d99de84505e5edaf20d84ae75b3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/ore_dense.json"
-hash = "a5d72975981dc95fa31c894d8954f1460a6f6268ddc125a2f78c1674e9ee6e33"
+hash = "20ebdbaaeebd23436eba7779488565195e6ddbf2b0e38e512adf12c48ab2a1ba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/ore_singular.json"
-hash = "9c28d419c84f8b8358044db1560137fb7fcc9889b737b871cb732a7b07b4a77e"
+hash = "df196f5159785852a99d4571f4e8a63668e15319767691f7285fc41db1c82c5a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/ore_sparse.json"
-hash = "dc46bd9c565161975fa70f35ce0ebc8ecc5dbe0ab77ceea266d26439c2cc55ad"
+hash = "7b18566ce368ad8da405ce6161cf1c8d0ef329feff6cf0011f7eec60f3b8ba91"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/plates.json"
-hash = "a4122d0964e3cc2e39476a4e1e2c6ab3a4ccd08265d79f96d7e656bfe5ab3fd3"
+hash = "373af2418e1751e685a1cd2e27a8216f8528ba2a93c11fe0256ada00c28cf1b8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/raw.json"
-hash = "aee31bed0b9007f5e3c40598b9e9468fcf4527abb9a71a6d3fd28273c46f9c70"
+hash = "3622995ac6083924e1094aaec7f41781f37f64aac70c117b468eabe1bbc30d53"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/raw_block.json"
-hash = "2c87140011d8ae7314bbea57bb60464571e6302d29da6374f64ae306833c1c09"
+hash = "5a0df24bdd38b936b5f7aef50ddedde0c52edeb50f36fb64b0fe3a4cadedeeba"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/rod.json"
-hash = "3bcbd113a2ce21f9cd09f59f9b28ff33cc97e69c3742dd8aac68d28d9443ab4c"
+hash = "d282243eaed1c20f9ab75b2740a999d9cd5e86f202ea5b86ff86f86aec401c35"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/sheetmetal.json"
-hash = "c61dc950962b93b91a28ad95678622981a12ed9155260607364d45347c5286c0"
+hash = "ddb6a26a39c42b5c4d51057e23b62a1e213be09144d346110edf5352e9453abf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/nickel/wire.json"
-hash = "306e70eb6cf2a1877f1996b529c48b1790c50f721c3f6b2d25ad30352c198847"
+hash = "dce38f4efa4d12cf4de6e4a6149e24c5b419dfda51021acbd14f5c6c55630fe2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/block.json"
-hash = "b75b278eeba163758948a918602adde0c7b54c717e88906f1f04d5a906dd22f2"
+hash = "21d166f9db391afd9893e36aaef8f17fd09d2bbb2fef51f70e4125f916a4f715"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/coin.json"
-hash = "761c289868992e0824b3f62f3bc9d08270591536104a4a1ac5ef82c347f0acb7"
+hash = "91296f8fc26893b0bc14512094b434713e02044cfd463ea3e22d20cd58583c1d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/dust.json"
-hash = "8718b61b23a115b11d247d06cb234fb2a19501870e77c6e12a0759af447824df"
+hash = "cdc31caafd7aa68fd334a5398279365ed1caf58cad77b505af79d3630b9ff247"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/gear.json"
-hash = "078099dd4179410aab517a248ebdb7b19983a0c5417cd54add63364a95bc40db"
+hash = "90b3249e2062495f485c7b813a64636aa4aa39277a84f3c74230f24b9e6a4760"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/block.json"
-hash = "62a8391f1c598814b41ad1eba8ee302105e991fbaa25985bc6b4e684a9709eed"
+hash = "32ca176b6fa0d6a430c5f12c58b0097d265d4dfda32b75d5264798888d2ae8e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/bud_large.json"
-hash = "494ad0206cb9ecd9748b252239a2766945a01b1bae476ae1753133df4e7ebb26"
+hash = "d6488a4bbd9a66eab3274b557d7b39e0521fe892936a359d713fd2f640aae9e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/bud_medium.json"
-hash = "8532f44c759402c737ed79403927e5858c5c8ae93e50dbe7ddf974b3aee38f52"
+hash = "a131af38286f16dc1f2ab3f9ca00366d5203fddd4fff0feea22c71d2215d7b4d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/bud_small.json"
-hash = "3f143ab47a63a70fde395440dfb513b58842e77f6099b39b995fc261b971dd20"
+hash = "6ef692b7e744f4cd2b484789d7f20e0b111101d274a6e8d2f6fc74a06f44c886"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/cluster.json"
-hash = "9d8c9946a0d708814a7e7a3aa62e2071199ecb469aeb2619ed57c3050b9a474d"
+hash = "27c609e4004a868c7b5a3f14a61c490b9530be05760288c26534ab0469ecf815"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/geore/shard.json"
-hash = "3a3a7b731f5403fc74a5eb183541dca2c36c983ab64a58de7be1a4559260eaa9"
+hash = "8da24cba43c40bf9a2e352aa20d785298d2cee3f0facefa284a0f5875af52a8a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/ingot.json"
-hash = "e8eab01f48a01904e362dc16b7d4ba96bf4cf20202b6ef16896e3baf4252cbe1"
+hash = "fe1b42ed576e2cffdfa27bd0a68a3c480f8eba2190ab4645d0457fa81bdf9430"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/nugget.json"
-hash = "e4a908107ed9716a84b798b18ddc41576e2c3791bead8efeb663c39dc90df51e"
+hash = "44dae9c2038f35d6888f3eb6bd91e72dce15f8f37d5ad27dfd35ff96cfec148a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/ore_dense.json"
-hash = "f576497b967fc0c5be80900b517f97f265a2413aa07cc8e6fceefae7586716ad"
+hash = "1eea8338cf58402f1aae03ffe9fee9eb0a5491ffe2ccc9711cf7a77805e0727a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/ore_singular.json"
-hash = "b21d2e9c1d2d08cad1bfb85f695de06435297c9fa6933ad0912f45567e48edde"
+hash = "0b4077430733a27cb821bcaa210f2f26dea43f14bdb2566c39512662f13ff80a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/ore_sparse.json"
-hash = "72d8eb84e28b6cd70ebf1b69f5378cac201684ff3ca6fcd3b05e00d7230bb138"
+hash = "d8bc81ea68840f705f834afdb7225d049a22fc181254ebddf5b5186b54e41df4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/plates.json"
-hash = "0ddf106bbee31cfca1512ca724bb1d7076f56a49ec8bd1439404c727a54c969d"
+hash = "f619bf2dc5f835ac8ec2dd349fb0a2297189f06c5cda07fb62936174c9d183e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/raw.json"
-hash = "d254ecc366eed40851c6180b3ab762c58a35bd61f10b38b6a1e4d3f090693707"
+hash = "1c0d3e7f464a6721d7082fcfc97db5e3a1a801614562966b902d68df7d349728"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/raw_block.json"
-hash = "a2c0157298e130fcddba89ab99d1f73e806cd988bbc9b2515c2a1af1e608872e"
+hash = "909123191264a048b3d6b0ad5e83fc92688d52027746c163d9e3fb284739a00f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/rod.json"
-hash = "527ad905bee7182765a3cb97b32686fe4bfeed8210fdb7a71ce3a462f62df9df"
+hash = "4d59b25e2f1306af33eb77a0d291c25f9511433988397e0d841a6417533fe705"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/sheetmetal.json"
-hash = "108d0e91b9566e053b80c71d9c1779b199dd0d324f4887dcf59c7dfc2ff0ca29"
+hash = "d51db2974393be64920c2c0e5a5f228bfdac9614786a13932764eca8f6d5437d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/osmium/wire.json"
-hash = "5d53216bc04b96864f78140628618bec5b461ee0558ee52cf8b05ea2e145b4a8"
+hash = "0c31b4e4b4860e504d58e2094090f1ee78c9966a2ac8ad7616b0481207d6fc4f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/ostrum/block.json"
@@ -11822,207 +11834,207 @@ hash = "7b5648759c1e2f979e4dc213eaf163620bd21c29819b208271448097872aa4f6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/block.json"
-hash = "430b9fcc974e27b9b29cd077e59cda87047de30dae5e91d21f92a16711045a5c"
+hash = "7faf884f5e8349c4daead2a1fce9727808149575bc514970ce17cbb87df1c3cc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/coin.json"
-hash = "e0db7d3b4a5bf308ee99631a76de2a08f0ed6595cfa3e180560104fd5c851c14"
+hash = "146b5713bd609083a5a564d2713c4d16613eae6da262b8ef3b09405ed2cbd1e6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/dust.json"
-hash = "dcdec6ae97ea72f88227bc05b4edf741e4bc92466cec292bdd9e3204f1dc5e4d"
+hash = "1ba27d16823b238bc04f443409ecb96c1455aa17ae94e13d9bc08f618c5e72eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/gear.json"
-hash = "98224ffdad481fe9468f100187f91f42dcc357ee4b0553aa1cbad57b85ada007"
+hash = "c2472cf6466792107100e68ca4f5993116e72c66e5967d2d205f50f27a7e520c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/ingot.json"
-hash = "9ceeb08316aafc156a429b88165ebb5dd60c421834674d08b0f204ea2f1fa90f"
+hash = "8610dd9e1a0ed978757ee94292e84297480347a61767d7bcb7dafd8d343bb76e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/nugget.json"
-hash = "536b51a40e39d39c68f5da0aefad3027568e2f371811b98115884b7ec9d87a80"
+hash = "5f025763003c4ca4163bff85a95efe917eb0365e4f440853080ea89872f2b1f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/plates.json"
-hash = "620a678de1d2ba32509a88a567e5c7639e281139ad67524a1c9efede024d6cef"
+hash = "1bf457c59e9a60012c2d2e669f1fbdfbbe8a477b29a569b19baf6d7dd59eac20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/rod.json"
-hash = "5f6752298c3f738da87c14e2e1a82c3f63cddb43a2dd0a3a54016fc39b1b2fef"
+hash = "ff78da66989894d4d19a0ea66401a7a8f60788dd2e35c679d2cf01c8212c7367"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/sheetmetal.json"
-hash = "786a2fb2c8210d813a7f80efce6b21bf9bf11712b62fed8b59b0c1a6572aa93a"
+hash = "8a175d7d34ff620c2309352c1641bc4e0926d36bb9aff25be834d41ab9ec4d29"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pewter/wire.json"
-hash = "58db39483ddfe64a48f6a5974ecb31ed74c5659ede87c24a3eccfac4d6f07d0f"
+hash = "e315c63e94a598e2e878d4cd746a078089a210b732fe1de7df894dec5891f48a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/block.json"
-hash = "144de1e96be2735db9107350735d91c8bdb09c2c11dfc06273ebd9d38860e4a0"
+hash = "bb3149c27cbc80b08ee0c3894228606bf88587ea9abe85e2a759332e8bcfebf4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/coin.json"
-hash = "5134489fcf786b03bc7a48de9d84b32ca37083be1b7aa2dc9b6e612de9d568d3"
+hash = "8b7c8fe26795da09fe22c8bcfdd8995fd5f6f54746a456a59ce2ffbcd2a973ff"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/dust.json"
-hash = "cdbef9ba6ba1ee89f96cdd381c9b1cdcf6a7520c0187d503b5603bfc56f80779"
+hash = "06688b8c257813d4833f78eaff5007fee82eb491a463cf40031ae575dc64ba7d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/gear.json"
-hash = "660fb0cbf20247b714a909612e7139cef7b1be1d3515ee455151cf9f83eae0ab"
+hash = "354c9dbf9035a79d971297e2f6a7499af10be34c0abaacaf51b161ea9e5f6996"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/ingot.json"
-hash = "f21de02b576602996aa71efdf361a9213fe5ba0341759f2c91203d708b86b2a4"
+hash = "bf6fae4a68a6aa821327bb5ebbe938061e6e0419fad29dcc3ee047df297821cf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/nugget.json"
-hash = "b0b2212005534872a4e76e714294c8b4233fedbd3b8fa3c6d3db4ea9a506e47a"
+hash = "36df39a9c9aca0d151ec382caeb21d268fbdef7cb0a9a7009ea4d40670fe5ba8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/plates.json"
-hash = "c14e05e708f7670c6f5c50b638faea935a4b89bb3aa8dc6fd4185956640275d6"
+hash = "0578347e62dd40577902e3b0d59c3e1613bb4717753e74f3dba3c2ef97609040"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/rod.json"
-hash = "3d850920a72ee546f348d3b14e00648b9ffb6e9317fd89441d31a45a79c73d4c"
+hash = "dbcce67f6cb1b4dfac2bb8de68cbea0cf863fe6537db6494e2207ca718d74fa7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/sheetmetal.json"
-hash = "6591a4b86d3787385aa147bcdb720941a0961975708f10c30a7932d993c53afe"
+hash = "6c060c4a0b96fdc3aa5ab8280c6ca9b76d6ecd420ce09820982d9f8a3616a831"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/pig_iron/wire.json"
-hash = "4111eaef8d8bf158e575262a5ce5d60effe1cfe735919df9e22cdbbf2853a847"
+hash = "f1ea4b465d3f9c2e3d9bfe8c04ef8cd888bac8c8b5b1a216e4ca7ee1655f5d14"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/block.json"
-hash = "04f0cb26d54400bf9e95a3a547cffce36bf6b593f4ecb5b90c339cd4de46baea"
+hash = "835967ee62b95336ba3115d9339a58b547585ae67e3bbfb615e93323ff5f0c63"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/coin.json"
-hash = "11b37425582aef0290e2caf78f4ea97a50a704d16e6cd33799144aa28f6cd675"
+hash = "a4667cd799b611429dd6bc468e553b5febe4a9e917aa1a90cf3cd652b4eb95b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/dust.json"
-hash = "3dfb5be6ec058dfa217e596de4fedf0185c0def6e0c53982c941c2b37bbcc524"
+hash = "89328b746697624afe7ddb7695d7f5bd5402244951ac4f61de1673d7bb5e9ab7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/gear.json"
-hash = "3aff236ef3a56790076ba640fe9ead8cd9516b801a6247f485247c49db5dd853"
+hash = "42af7fc6510fb41ca3a3283a2d14e15c7506debcfba3dd49c4e43bca9baed5e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/block.json"
-hash = "1291563829c7d124aa1a60e7b1461701c4b893f4d58a9bf92ce358fb7dca2831"
+hash = "f40f4e9d5fd87e80a0e631b8d4fcf6d0a1bef21ff2f551661a241ce3fab12309"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/bud_large.json"
-hash = "6849dfaa90725eedb0c41d912765a73794d713a7b04ac240681adc69998ae451"
+hash = "1f3f63bdbfcfcf9c11d4f7ad35c94d1319f6bce0cb56115056d6fb21293b16da"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/bud_medium.json"
-hash = "b6d302f8a83ec0e8045609c13b465d525df4a585b2dd866492c83daf59597cbf"
+hash = "13188b9a2b99ade946a34eb3fb2b621ae43234197056adbc7ad8681b2b46699f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/bud_small.json"
-hash = "df38016c29daad8d13f524d60b720a851f94bd33f1d0937af50a530bb71f11e8"
+hash = "34e4ba9b9cfe82220339f8dc78b2b8d0dae47dcece12e41e298a38ab46d22970"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/cluster.json"
-hash = "f220e9804a59c759f5711fd4c4ed7ef9569e28da7a8e757845cd7a4a6bbf9239"
+hash = "98c2e720bbc2d893aa04f329a5a14c38a242e879038de6ed89f739dfbaf8e524"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/geore/shard.json"
-hash = "81f0dd8a5f9ea42c8b3ee13b1d6ccd89c3bad29c5aa146cf13653f0d091480eb"
+hash = "4077d983c2f1d79575f95144cff8d3a7ff0728403a3171f9337bbf796d4898b1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/ingot.json"
-hash = "d10f55ee671bebff7fdfe76be0954e66c5931dcc0549ebea93e82eb099802d1b"
+hash = "11367b2644562ad57bbb66e124483c52491934c6385d7b4ccb92f72111412248"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/nugget.json"
-hash = "232613cebaad381c789db61265a77669e9af9647b8644ad1883712b275a17079"
+hash = "59737e1a5480e9badca3719579973363412189bdb8c05ced9d6e08f7afdf3722"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/ore_dense.json"
-hash = "59d357604cbbc8e5f200e64b42c82ccd686c7b0121b995d309e0a0216e9ca246"
+hash = "d9ab225cd787d7324191d75f08536bd3ad23598efc490c582f5e89cd5cf50da8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/ore_singular.json"
-hash = "2934f2da32852cd8bcc3acbc4b2434885ab8fdc265ec957dc331eae6371c7bc1"
+hash = "646fdf1d7a9aa123e051352e893bbb2d347429bac577f2ec3cff845ad8bce4ef"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/ore_sparse.json"
-hash = "cfb96fcedef48ce1c74aa40309b10d919da33f8a314b1bd611d3dcc670299ce8"
+hash = "7fcf92318f96ef1310dbf7fb93016301bd7d96932960e673f2b83b5ca757ff82"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/plates.json"
-hash = "c29e843c281f78c8f4affe7f94651d9f4fc232c09c0d02eaec09e012b044f190"
+hash = "e5642a8a524af20d2b815598ef6809c38b6c1f3df29595f75b7f32f923252aab"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/raw.json"
-hash = "8408d61561fd5c44472104facc89793d39fa2027fee6afb38ef04661af0c5b89"
+hash = "a625e69a470dfdcc53089ff2679f634174dfa9ae302c609213b0cd91c4797ff8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/raw_block.json"
-hash = "da093e7bd32c2aac8134742361b295275c20ac99428d89ec17a036c0f5188d6d"
+hash = "9a435425492526b16155b8b44044d2afab69acd102118acbc2211dc715ede596"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/rod.json"
-hash = "9e6136390a9da8b5b24bf089ba8e43d2b7b2fa79c180e9736827af37748802f9"
+hash = "0be0120f5b1eda0facba8639fb2ba00c7663e90d02d2103eb1d78cda496a7437"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/sheetmetal.json"
-hash = "9bf3877025058060aedb220ef247127b6152a107e633c7159685b9b6f55ec76a"
+hash = "9d2330df769b61840711983adc034fb68cf8c20ca71a8510fefbf97836954cbc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/platinum/wire.json"
-hash = "806d83daf8dd8cf8d043f11073816b83037a21e9f71bdf87de08b390be0330c8"
+hash = "50ba53a9efaca5afa46491a62e907350f2234e0a518a107f2c7e2987b4578af5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/block.json"
-hash = "c9a7af3a98e18944ed5894a1118a2212ae53935795bf69f681cca65bc735ef2b"
+hash = "dba6c0dd4bf519ebd6d0c812a3ca1709e40f3e39791eaac3004c67b53816b643"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/coin.json"
-hash = "4b64f6f6ccbfa42da4bb402e6331daef740b0fe19c63761aef38b76273146798"
+hash = "d8a289184ea279e414a3bc151c2ef2f8daf573af6b1383d12baf85cf9de9b24f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/dust.json"
-hash = "5d0c433c25df7fc5992f416d8ab1457ae51837d2be8e9507fa2f483f1bca44f7"
+hash = "9db4f3b19fb9d20d2f373c876e54380b07af4f22091994906b8d6f2b48486f15"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/gear.json"
-hash = "eb8ce87988bf9927cf1d4290571e0320c079429b31d4909d4f6bab4e92798427"
+hash = "b8937fa4678c673c58b0fb45a8452d78933faf7e16ff6ba427eaf1594c97ecdd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/ingot.json"
-hash = "32270300b530870475bf7f133398bd7439045baad0e9bbaf94c5d3c14ee63f0c"
+hash = "e309f3dbfbfd29195cf684cae8e18cbbd92ae3e722db0096fc66f3887ed48e91"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/nugget.json"
-hash = "4cb818d1d53b4c5d868616a9e05e9e2d7bbd5ad0ff4cdd021c7b35c429d470bf"
+hash = "a0e274752dfb2106c4b6f36eeedf940a441c66b66e544a4e1fe3f8d503ad0e38"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/plates.json"
-hash = "bda8b49a919a0e85ae659f8f7888343505935ea20e7bb1e2d3d9287131dbf36f"
+hash = "9653afc3c7aad4519ae61b0d8aa0da72bcda21e111fac2ad8918c3c7bd1bbc76"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/rod.json"
-hash = "1bf69e567d3c4f4bb354b5992ff665267a7b5db4c906062945b501f0eb427091"
+hash = "1295d7e153cc4745a7c4241ff2e15369453be426c950d0fa66e7721364c20ce3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/sheetmetal.json"
-hash = "827f77c720a5ba8d610bbd97447f4adf17a0b84d038e07d0d4a28d9347e922d3"
+hash = "1f76c4c732f72ce184a1933b5b09b5b349ad866f08c0fa8f8d69967a031e950a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/queens_slime/wire.json"
-hash = "117bcc2111c07c02fca2d6d28cc3705c14fdb891606adbf02bf7387db77d3fc1"
+hash = "4fa50db94231bf2f44b526d106d0d75110ec5e8aebe3c851eb03f8a8a65b3f5a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/radiant/ingot.json"
@@ -12030,119 +12042,119 @@ hash = "6a9d936237976bb11be6d02611efb76ecf3469941aaa870316555bf806f1d393"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/block.json"
-hash = "f3733f7dc86aaeba9a65b0505f1d775a3ee397cf8ec4ce507dc697c8f22e3130"
+hash = "4f5c4cd7cb32e412089032d1358430f53c0fcf11287ebb0d2c0aec627229930f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/coin.json"
-hash = "fc9739e8e7b0217c86304dce296dcf4e1c5d732439419b682aed393247a8bfd7"
+hash = "a56b6e3b5ae36294f1f6d2e5b9a19dbb84ed55bc04f1ba659af5f4b6335fa7a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/gear.json"
-hash = "76803ed26139432f70a4a5109de927c944a89e029125e4352e17d74badcb8a8d"
+hash = "d70ffda0a49be6cc08ce29cfcdd06310911a19349b250c46fe9194819ad67399"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/ingot.json"
-hash = "7bd93d9752a0aa28a734ebe19b7e2a346ed7c0706f21d577f52a475a6bab4ff5"
+hash = "39010487c7b45edd7e34b36f9c5bc5118a6f6ec89f18beb5117e8144e6520a8d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/nugget.json"
-hash = "f14b286c56066a99764bf816b38659dab504062cf6afbe7a02fe19b1d478d82d"
+hash = "77ac8f2047c7588fe6862fbcc652f86fce042e3197a6a7cf79cadfb1a932bf95"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/plates.json"
-hash = "3030aa05fd09744467bdcea6a768b9757095a327e4dcf47cecdf276a9ec793a4"
+hash = "c43d43b9745b9734168a0df641f50caaf4523d3ebbf99279ed3231f1674aeb57"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/rod.json"
-hash = "a41d60494674eb339c8f1bf4ff4a4933c105e44c84b1c588629481b0d4a8b26a"
+hash = "02d69e28fb2045ca4bc0ab45784287273717bcc28903d573cdaac9fc5b59c2c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/sheetmetal.json"
-hash = "c1fa4b69438a07b4d51737d27aa7bbb8c60a72a8a6c153feb78f5dd52d47c5ec"
+hash = "6f7ad524b91f2eb3e626947ed9e3d5d25620a18fa8d7b8e0a10d04afef570375"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_glowstone/wire.json"
-hash = "b378c4098d18ccce1b34548baa58659649d54d237f886137fcf6257a29d2dba5"
+hash = "8e281bd2046df688cdd40f45fb522a3e4e570a4233b02884cb10f79ad37fcc56"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/block.json"
-hash = "0b73d74a1c9610950d7e810e9545d2da356bcd712f483648c81458ffbf742eaa"
+hash = "844beb1d8d913f9020f4e8e5ba85cbc256db2addb5e562e089428b84dd2d9e3e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/coin.json"
-hash = "0595a1a7ce2e479dd7f873b3ff912e032b69afad0d84a49e372a9febecd33003"
+hash = "d7643e71406bd654d03e0079aa17bd167a306a0861396cf5dbef72bc022275d5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/gear.json"
-hash = "efb6f697b7bc11453d54c5101ddc60360ee71e156b19c423531241e7d127eb1f"
+hash = "e54ca4142f426301df2bec7a0af1c8b5f846bcc7dc5ed1dc3046d82bc841618d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/ingot.json"
-hash = "7bba34334ba4a558a7aca6415ab0879e686474db5e3e82195cff129097d51250"
+hash = "c926f063dbb58b42f6e20a9c1f7bb3d4599b7238a7b36c1b3db3d264eb586036"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/nugget.json"
-hash = "9480c3f4e5d14bd12683f2b2253d4a339463a07ea6095ca29b90ad4856741ce0"
+hash = "0b16c7f285f79b452dc9fa62c13122605150c7343a60760488e1918346ea65ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/plates.json"
-hash = "497dd9ba6ad64268141699e92b2ab1be604c290717af27911fb24535024f08db"
+hash = "070a0377faecaf541f08f4b22301f71e85fb8185505861ba76ff1c28c1ed8b14"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/rod.json"
-hash = "8d2830cfe8a11b1665e809e3fbe3e69c45f1750f1e291f8ef1b343d777e3e28a"
+hash = "338f98ff89c886168ca5be516436c067244e12532e01a15c3293aa7835223bd0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/sheetmetal.json"
-hash = "0d4df0443d83c3a8b046ad227ec1f4b81b8f45a81cc33f869d366ab34741a37c"
+hash = "1af7589035b15a08d9052e5c0e24fceb9388c6b6cfc2bd6469c129d611a71d94"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/refined_obsidian/wire.json"
-hash = "66ae745f108aa74f7ea8475610583ca5b565f1b2eec01b293d66b8c467e3cbad"
+hash = "91601a54171601163a69463c2883748d2408d77005d6f7c1f5d8afb383e9950d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/block.json"
-hash = "1d40e57268db295b01658cd48265a5a0be535a249c5afe542f91f3e097e1ff58"
+hash = "869511a3d87d3f27accba5212de34ef078b1e0d4c632d8da7f3dda16cc7774fe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/coin.json"
-hash = "83cc23cde56673cfa10232db3606b949fd459c32708113dcc140572c8906db7e"
+hash = "3bc49d09a16c3ab7ee3b7be84bbfa15c28801f371aaa6bf5aa2242cb4d577ec8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/dust.json"
-hash = "94c3d2b2c005eed67c9f9f31f4d08a4ec1858e6276eb41fe7e5d5c3604eae0d9"
+hash = "5fd63255e0f10496761eb578e8c12e77d3774fd37ba5b2d90d9b7b6c925c1a98"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/gear.json"
-hash = "6e006800b8bb1e85a125a17319a448b08717a8f268a6699e7314bd45c0d26888"
+hash = "c125da4d00cbafc0f16634f541b28bcf1abe7f8c9aaecfb5617fb19ee5088cae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/ingot.json"
-hash = "5cedf545ab64b3938fe1f4db1fd4b7e6b02b72f1e17d707d889f29a566022dad"
+hash = "7ca8b34fb9cd5e6146bf5ae8e1990edc496c70e1b4409e793806d7ebcf93d697"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/nugget.json"
-hash = "5d8dd7e265d714a069c28a659764229d5e35fdb3f0a8bb70e36d3ff3dd5c09ed"
+hash = "2c9c7b547b2e064da90515d8138afc5fcbbfa45ad987a4540ec12617e9c3911d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/plates.json"
-hash = "5daef6384907bb865e6c834df1d808b47c256911738bfecb0dd58f53afc3cca0"
+hash = "dd50f58eed0941702c2a9bb50fc2d5c48af85e1f1b3f79d627267c9904530448"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/rod.json"
-hash = "c0daba22a5c50d38c17e8b1b1b607c28e1f1e1eb5687ed4a18149fe97d1396c5"
+hash = "6be1757cc0c9281ef589d528122ddafd77d93167094a97ea59387d448102b906"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/sheetmetal.json"
-hash = "599114dfc87125d6da621ae9ad34b7752cf06450ad1a8e0c6b7f58a5997c41a5"
+hash = "007c8c007d8394205f07da2bee90cca71eb000df1edff17169eb8ccaa3149d36"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/silky_cloth.json"
-hash = "5a27f710230355bc3d712b6491c3c78420eac8818bf120c1a1ad35d53b1f272e"
+hash = "4c024a927fcbf21a40612746ed69f9ddc69cc039da0221384b7db8bbd8e987eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/rose_gold/wire.json"
-hash = "4c2bc60fb84de8cd6a543eab46774e4aec42b5f69a28b60badcf7f8939ca1963"
+hash = "b8c7e0b5cceedd87b3a47190ba1973bfb1ce93b2f9beaecbc320e15ec665a502"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/shadow/ingot.json"
@@ -12150,107 +12162,107 @@ hash = "e1eaf24eb2820d5a88bcbcd42de72578e8081e10dd9daf378b425c478f502f1c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/block.json"
-hash = "ea30157dcca1776d1bc7e67048658390a08a5da4f4c7811fa0c6969747ac79fe"
+hash = "a84e2aca1ecc2441292465693282954084ecdd36421bc5d876216b27d8e2bf3e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/coin.json"
-hash = "a374a70ae7585da2ce08776e2efaa47728e02723c189bebf90ec7b44f4c2d47a"
+hash = "69ac42c5144e03002f0f114a4920d225dfb2b479ad6a9a35e5e538b509b2355b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/dust.json"
-hash = "cb39d19abb323bd056503df55454af570fe41086f366d7a1a5e9b6ae40551c29"
+hash = "9af298ac59d723eb5581b289f43574fbf8348cd0d59e02c30e05a63a635ae6c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/gear.json"
-hash = "5de6e0d62455d97e95b8311a8500c91b09cd27d500dd44fb2192c5af80faef9d"
+hash = "632fb845841dd5f3898381545d947afc656c9851486a70775a516093fb4dea47"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/ingot.json"
-hash = "15b924305ab7169ac2aa3a6b096ab2682feea397c9484c82403159cebeaf14e7"
+hash = "62569842a85ccfb31c8859e31817da661670b695f4970025d60f89e4637055c5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/nugget.json"
-hash = "89a3db70ad4fb9d35e9c29fa16227892716957b6178f454609232dbda9bac145"
+hash = "b94c72748664b5ecf622dd91114cf21bf27eb1ef306f5871d7a8b1fe98271f00"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/plates.json"
-hash = "8276cb8a552c73ca49623ede762d4077d8d4ea8d45face7cf2691fdb1c817e68"
+hash = "4c853eef8d90a474205d23eb4b06400d36faadaa29df29deb9a6e5b3d3c800a6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/rod.json"
-hash = "691c0409469599757b72c1ceaf3d9cbc9775cd4bbf29d79fe31fa41c78f05b82"
+hash = "21c9603f6b60a70488cc0af60b51f3ce8fd57f765604bc69cdbf9f1457983a92"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/sheetmetal.json"
-hash = "7262fdb14451d474e4d91a62fc3d329cb12850d6e5303cbcec3afff73de11815"
+hash = "20ac2b9c1899eb6676ab2aa2307f4d76729dbaa35459c5244ebb119651ab90d3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/signalum/wire.json"
-hash = "df54ab6e92865c7016e391b38f57de81e8f3375aec3c3ad8a2363fd343365d55"
+hash = "ba29b6b3950157ee7250fcee8e3bae25721c9d0b3b94c2733b055400b8220551"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/block.json"
-hash = "133766bc9487ed6ca3cf985343c3301b085c9f0ab9efa6d09dca7f4d464eaee2"
+hash = "193694ecc29a13f7489970db934c144372c3101df7dbaaeee12108dfdc400f5b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/coin.json"
-hash = "681cfecd0e703fe5e9865df7248e6dc9a68583911c4aa63cca5c0ceeba1845cd"
+hash = "454beb50419e8534c5c31725f891098b661c2813518850430021416a09062a6b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/dust.json"
-hash = "8e348e72f99c02c389562afdd853509160cf8bec584b114dc5ff5a7320ffdcd4"
+hash = "f29ddd28b781acfed41a71c10f3eeaef92a176aa69416fd93cd07bf01f3f4ea4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/gear.json"
-hash = "732288ff12e2dcd4a3958119dc34613d92539da61f86fe0f444761ae038905cf"
+hash = "87ae6cb5f9c6289f2addec284098a653e688b8e1c08f6286b53c2fc3e2b331ec"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/block.json"
-hash = "1cef30bc9a94323c583bac8d5fc46de1a39d0de8cea514510bea7f4b8a791e46"
+hash = "0bf044d52e0728e2aa007dc28e8d1ed33167533a2f13ce56b70f694d7fea0ee1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/bud_large.json"
-hash = "b95543faced22e88d32aeb967a26eaa09a89e5d6f2b6b74c64faab4088cece23"
+hash = "061ab963c7ae5963d2be0f26260f85f76df2fa4a4b9eb3baafb247ced02cd599"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/bud_medium.json"
-hash = "e3ef681bad3cee1371edafb80e6b86820cbd3ca016f866c96f4b8780add25616"
+hash = "d54b02f5c60f7893a4c5ead36379ca9323d893ac6e81af232faabdfbf841a2e6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/bud_small.json"
-hash = "95352fa54e46f8b73aa54f0471145287c39662a5fac7d1026230253b79c447ca"
+hash = "5c8069331f57da18230c19e91d75b973b582687421d1cdf93b1c263cbaf4945a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/cluster.json"
-hash = "0ac02b4f8bb58c9314174224a01089c1e68e19491c7956f6436ae097d27f872d"
+hash = "1023c8c566981c436641d4fbe391a1113fb876c154b52f7ee6716e542fe5cc6b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/geore/shard.json"
-hash = "8965eae78e6f1b40919ddc372ff9dba0b4d705476393633e0a0a07eeae4f28c0"
+hash = "81a2861377ec807306d3b3c2f781596ccc3c1cb27011fe15d62c523f9d23a973"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/ingot.json"
-hash = "9b9cc2beae3524808af071a8aceb8e837ac7a73ba8435788721871df4134b36e"
+hash = "b8d4a37d33e56f851897e94c3262ab22c3374501414c3b899e3b1463debf4bbe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/nugget.json"
-hash = "168e0a609539663f34243508de90e422f8eb4b6203bad9445bf814125aed3650"
+hash = "8018febf68e58f5371e60d4a4039c4809e397c36e6137f0f7e2c290fb12fcf91"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/ore_dense.json"
-hash = "16dcfabd2b1a1535128de83fc8f87344a208d3267795452aa59e7c46bb7b1f0c"
+hash = "7c44c78e4b131ea049bfbd69532190c6ef255f91422c92d97da3f6602806d203"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/ore_singular.json"
-hash = "09c730bdd9e9eb3a14d265c6f0dacac9ea3c07f3b21da9401c14dd479b7f6ae5"
+hash = "784ab829be6967b2f00a58b6523f903409644daa9dda1a2fcec6ff0673afdaf7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/ore_sparse.json"
-hash = "5100c455e6c7e1be5ea37fb18d0e56152b083987ade46d9141c0791a4b0b5ea8"
+hash = "a90a78feccdcc2f6ed09d4911e2473681bef211dcf7369492f500ae4244d36eb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/plates.json"
-hash = "aaa36120c760621445e73d649476c481aa022226939a099eed42da833dd89e58"
+hash = "5770df41d47f350d104e07006d99b68e5f6a0b6383608668e9019887efc50a0b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/raw.json"
@@ -12258,131 +12270,131 @@ hash = "e63832efb5a729f6b2af643084cc4674342e9b353f84347ef4d62d02c89a11d0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/raw_block.json"
-hash = "725c66771784884a6ec6d0be2f4b14996ec133df49a54388e7cb1f9dc7654a21"
+hash = "178d31377b3bd973cf452d892038c04b2cbb78201e60cf412cde68f8dbc0c54a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/rod.json"
-hash = "71915b35a9d93120589cee34d1b0bb6f85652e827a05809f21ab42a991cdeb2d"
+hash = "eeb4b3d747471503ca16028fe069c24f99d80c928f23e05646057c33a8be5ed0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/sheetmetal.json"
-hash = "97c8c13e62ff319aab78c33084bff70b88e60e86d0a995dc242284a3464cb645"
+hash = "163bca0dc4d74eb0c15e0da96145794d451209f5bb346374436aabfd802b70cd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/silver/wire.json"
-hash = "82e71afa0d902d49a3ff905501cdca4985358a45b55659d494a0d89d63d1ef0e"
+hash = "93f2ac2adba76b370697fa6923a06069df224eef32c3308aba22bfed421482d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/block.json"
-hash = "0e4261d01b7f75c2ed9226ec8cc1c65eeb65f8c63989248919403a829a6f480e"
+hash = "f6e7b369382f6c131350400005f06ca9214a62f89937821d0198a1917beb2951"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/coin.json"
-hash = "ee4d5e97a8ba2b1751fdd0316ab66c15e35ea1d1a3f1dfaa8da0f6fd4ed96fd1"
+hash = "ccc2fc1be98f576b4d233f43ea55e04436a3e7868d9856c325a6d5db6aa5cd58"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/dust.json"
-hash = "460c69efee26450c6a7a7b603594eacd47f4091f61275b546c300229d6a926a8"
+hash = "7014a527900d710ca4dba2c19dbb143a67922a8385328f6124dcd09e6a4bbbd5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/gear.json"
-hash = "c250498f517e4261d3d1964c5904cd17d36c9fb9f1e493126d3fdb466da03998"
+hash = "2748a8b310ed8950e2fcd0d4694cda6e2e85a367061ace5e6a17a5787868019a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/ingot.json"
-hash = "2642fb944d8431a0bd906822d48d73d528e6dc337751ba8075d7006d09e8cb3c"
+hash = "63db167a3e9585df15efa28d99650f417e53767723e1d5bea1de63e767c3fadc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/nugget.json"
-hash = "492b41c48003bfc688c7401917ea38f0f69b0c662f30141d17133fa495a9fc4f"
+hash = "907e216e83f27d89e3f94a90cd8dfd237a8988f456c28c8d2a826f88d58822f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/plates.json"
-hash = "e49c2a70f5adaaaa7a7e4d93778b9ddd96a9e246f31b91a9a3e66d5302c7bc79"
+hash = "a483ba969d41632ad1afb4a168d27fa5492e1ec196f66d9b92c4a6c922c4d719"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/reinforcement.json"
-hash = "76b6e81e662ddf97baa29060832b77ee5c77ad9e5ff17150376f514d48dc4db8"
+hash = "446420fb45536f357b720801a47d8ec6407c7be0e9f06186d6e4d6d72f4a54ad"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/rod.json"
-hash = "eab67809112b8c53ccce50d39fcd69c41491c40ff324d9f1ff8fa57e54286bcd"
+hash = "cb6d41f28c9c82491329b7aaaa957f57f3cf9485f765e2352880d64af984fd71"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/sheetmetal.json"
-hash = "cd8bfac7d3ff0b10d35070d5744ddec1e48f781f09bd2e7f1e40833863b6038d"
+hash = "d54ccdd8dc5c3031fc50a5198293d387850f7b84b0ac289063511f831e14676b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/slimesteel/wire.json"
-hash = "9b007e18a70fa33c4c78ae5cb76d9c15727908b32a357995178d3c0cdc23e75d"
+hash = "fe6ee127325bb67a67696736571771d203d05e271827d91c3e4bb85f592b3c97"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/block.json"
-hash = "54ad9f6c51aeaa790b2f1df781be15268e4e9b683361b672a483856facd24b19"
+hash = "1be4c6618bb93338228800e7df46d6509d8a38d5cc64bf6146d3ff8b9bb92550"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/coin.json"
-hash = "867fc1d7a173abd195b5474fc10a00d0dd3316ad7bfca7f01fa7559b98c78224"
+hash = "1415a62bdaddb37e4baa365f34100154239a4c35c9bd3964b1b2d5ef2f2aedea"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/dust.json"
-hash = "8ab8f2b2be58ef685e8b3f84aafc356f74b0eaf0f3f392f9ae40b4a97189c217"
+hash = "0e59366df352e3752e95405e60b4f45c42a74ce81209f795881687e22258843a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/gear.json"
-hash = "49b24caad1a397736a1558688483f8d33ad5a7dd9bc7813b50626c0a720d9f6b"
+hash = "67533db224f9a8ca183792cb42366a73abfb30488d7a773a2eff42aa221058cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/ingot.json"
-hash = "51e945074d399df3723f0cce82aa487af9d66f9e217b6c0cff0727483ba0feb9"
+hash = "5f659b29aff334d9240593616a0b0f59d335583ce010179b60e33027af588092"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/nugget.json"
-hash = "b8e42567249defda6af7600367f3e3a0ec233e9d8b11b17aa46703e9ce0d03cb"
+hash = "5a63da2ec9987516eb600e24f179b25d374f4cca116f6c252637c39cbaa91f35"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/plates.json"
-hash = "14844375e448534d571bd8e8c4d8ab652882330b17795083e9d8dc196bff8e50"
+hash = "3f09f8418d8444cb6e870167b4dd202e3031ba7eff71c1ead3be79ec1965cd8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/rod.json"
-hash = "7ac1fba2128063eef933a82ebfc838856d4803889ad37693c4a042808f2f82c4"
+hash = "21ed55d21aad53788cb3a64e3af8dd1900d2dc13ed2a53d49ac629e8211646f4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/sheetmetal.json"
-hash = "8bf490d58448e6c9a96b680126975429844cb07978d4201a8ee53fc06cdb283d"
+hash = "73298db3c8218ad97e167c5cc9b96d9c25b927bd356a83f18585ae1a51aa65cb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/soulsteel/wire.json"
-hash = "ed5a1a7efea065283a6b9590d17e90940bef31831c25952cc6b7450be4d6bc5b"
+hash = "07aa6196815c1c9679fb618452ac34b2b00d7345956c1433d176593a003f3f45"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/block.json"
-hash = "a8af18f29a635eae5af74f3fb5e417d8b05c01fe01804ea1078fb1fbab336940"
+hash = "2928a87107deb8911eaf88580648a02b9b050edc28d932f7d138d173f8b6284f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/coin.json"
-hash = "6accee48959c5afdba649bc412e6f2583bf280edc5f3597132f546336e80e0e4"
+hash = "d229a103717f60c3a1189a0a4f9d1459e6ceccf4dcc4484e2e70ded40eed6250"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/dust.json"
-hash = "be53d019fead38584d638eadb31471867121131df01bb1c3b4df4d9bf396b94a"
+hash = "5ff4614df449b8ae518304b572a500fb61881410961d78994aa15a3f53096dd4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/gear.json"
-hash = "04d00c0d261a331e80ca6c7381aa7ca4d7f21f2cce032f1ca6e81681d5cad7be"
+hash = "c26af165c85bf947886716298c7f52355d3e642314e11cefa5bd74d4cdf05f44"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/ingot.json"
-hash = "e33bb4223d8ae8d65b99b01f3452698a6e4839927df17a2e1537ea7f827bf729"
+hash = "2fd2c5e0820fad6744297091d8e59de88c7259ec158adb01e202574c26e98f5a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/nugget.json"
-hash = "b0fc3def424efcc7b9c03a849be88b201a460760dafb086a64443a9bb5fc9250"
+hash = "ae2a47074e3429c40516f274e5e83ecbc9768e84ee8927f186c9f0d7d8c77ae5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/plates.json"
-hash = "38919f8e010b7824f3d992fd2110ac855f67f4e79e8991544173616b69948a08"
+hash = "d7cf519dbd417c6bdfcf96d37a67cbaeb23f60adc56b8c9df6cbcac677740f01"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/raw.json"
@@ -12394,267 +12406,267 @@ hash = "ded854335c13d5cdb426cd25a50a30367469ea1bc6d962cb715b9c30641fbfbe"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/rod.json"
-hash = "8b31130e5c9be7f0648d7a4e0c20adbc76e52113834fa8a8aebf02d42da24d14"
+hash = "79745d9ed427df489f22062fdf5166369514c63d9f45ff8a5b092be1184810b4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/sheetmetal.json"
-hash = "4087b7e7a3aa65709cb69a9f5a558ed68fa9412e26932620bac0ad33d53b1314"
+hash = "1740339eb43a56ea72c0211e9118f63e1cdbaebf9bbc944b421bb6ba79ee9b28"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/steel/wire.json"
-hash = "e74ca98ac506f75f283493bfe7f8e51b6383f438a3e6fb78474434bc2b781f73"
+hash = "2cd092f8bacee138546dbae4c914fe150e37721545f4f3b31e45dff3ef6fa907"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/block.json"
-hash = "1af1673f91dde8da8018b84bacab04b8a30664711b6257240debadc320e333f6"
+hash = "d061643cc671a9b466905de8475756631f93163d2f64216a3dfae641c77956f0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/coin.json"
-hash = "e0d5f9393fce2d601a2246d425f8bf7e1e206a27b03479fb9cfa5d718d5b3ba5"
+hash = "54514aad41ded6300a4723f4402cad692960ac399e1894f174bb30f79a691487"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/dust.json"
-hash = "351b7ece3d4549ed1c2699c70e0a832acc49fb3b167a4667b6fa2e28a01afd09"
+hash = "9159d42b9420353df142a3cbb559e527fe39d2f853bce393c064aefe3db543f8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/gear.json"
-hash = "5ef25b543e5c659a2e7df193fbc9f4cbd8a3b5a4601ba221e88a0990f75cb01b"
+hash = "837e402247835d019ca46faf5338f1fa0aa0294507dd57e93ef51620069c5a1e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/block.json"
-hash = "ecfd298a6e5ca77dd0da6de824965615af5b2e43756bb59952d567ae1c7e41ba"
+hash = "da7dc849e978164fbe8325981b8e77ea6b886d04c0d98c6c847e333570075a75"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/bud_large.json"
-hash = "63276f39039c3ae3714942c6aaf797693bb526956b9db58533488805002426dc"
+hash = "847fe6333e50bac091bb18ee3254a4f06d7c64ea6d0cfc318ae8fd1c6bca7363"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/bud_medium.json"
-hash = "0706d6557999948ffcaed6d6b669858bf14a2061a1c4cc40e20014d7f28edb6e"
+hash = "55443ea3e8e8551256910be63baab9048ffdfa9191dff451dbaf0299a92f6230"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/bud_small.json"
-hash = "721b1ae7d4640c28e3a1650cb627a395fb023ced60a0bd3bd0b527ae072a2f62"
+hash = "61986754666476f29b01ac104ee4f88078d965fea8bb8213a69e6a90472918c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/cluster.json"
-hash = "990a2b248919c912363f59939f83865126a33b42a563b08300a2975725f2cf73"
+hash = "e3f55507ff3526ed7cd659a16427311dbc4a8d1cc44a7cd0359021c118e2ed94"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/geore/shard.json"
-hash = "72b78378522c1ec06e333e6fe49a9c782eb57cfe7544bd30301bc1fad9ded901"
+hash = "9655c449b25781b096a2cdabb0bfddda91d0c316f166f2f0f7fb2b601b204f85"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/ingot.json"
-hash = "b7d82b5dcacc67f49d862333d1e40f7c67bf453d518bd084747787f287aa494a"
+hash = "6ce6db685bf8cea19586c2106cb8bde0c62a1b4c3174e71aba75ccc53da1c4aa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/nugget.json"
-hash = "b0a8cae08adf9bd5cdccc016f23b01db6c7bff9828aea8e4eaa995f4f05b36a9"
+hash = "b740c0f8eb538b59a8dab15b1b8be1c25db6a05f00f3483c0f7d683a52475273"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/ore_dense.json"
-hash = "60daf4344e8954138f7cd9096647cd89b5f859ca4eff42a16be14bd1ad71e8e7"
+hash = "1c726b71c7aad79910940678699025f0b5034156aeef91bbdeeea55d5db52b97"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/ore_singular.json"
-hash = "7300192c9d5ca6c279917e30bcf392652055006cfd0ca7db342576f0914e9806"
+hash = "8325d66a8f5cf014deb35825e9011e251b0837577d0facc0ec96ff7a8e60eab0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/ore_sparse.json"
-hash = "478f477e7f2109d5d94a1c1f4c2cb435be9a61e192abe2f4a84e93bc571541b9"
+hash = "fddccb4a4e91b7466c509d10467bbc1f1aa634f543012c5043b5417386584d6d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/plates.json"
-hash = "26bfb6268de923f19e984a31122209e6916c4a8a3c60ab11dfdfb7bab2b14920"
+hash = "9766e528c29f1e964d0d91887402f8274b220cb3a1a0654eb06b19732b7f4614"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/raw.json"
-hash = "b823e488e44b4b4a588929072b982998ac75c51ebcd4bd348b44806ff919add1"
+hash = "0e33453afc8205984aeaab47cc099cc869d97cd1f0239435c6c059a26f24ff52"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/raw_block.json"
-hash = "2c1314b7909d1a2a9746c36494b7c86f87feb1ddf7db7a509eb09f2c3aaaad4c"
+hash = "e63b7097bd845845ae8436ad353d8db62709fa8ef3e2da02b32cefaaaeed1efc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/rod.json"
-hash = "31c375d2ff24e8c8afc02636a3b2ebb32afd7fe8a222fd7172b47ed51d43222e"
+hash = "b52c0bde76330f7a76e632c629ede814af36dcd74019214c5b88f31baa331c9a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/sheetmetal.json"
-hash = "39a93a30073747911afec9b2e11ea808729740580357d01c84f94fd4bc0a6c14"
+hash = "fe118cb9c8360ada636795a44c5e448e51ae61777decc1f9317269af189349fa"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tin/wire.json"
-hash = "504d9dcd7c6ea8f5d940e648b2f406bb628feda1aa09ebc0582900570cba3204"
+hash = "cb8d58832ef9c5e152e98f77829b9e07aea3eef9ef3a5593f82c6c97df1b9c9a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/block.json"
-hash = "e641d736adf6be8dc69039432430309531d5797ca39860d0f43de3d0378b6dd3"
+hash = "9ec93ab6289e6ded8f075f713ae78ca2d1edab2ddd0a8d1a65647a3a5dff53b7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/coin.json"
-hash = "4b091a60aa6ce365bbf92e1003c761ce07b066efc95f2a9921896f8fd408528c"
+hash = "594a37329cc81f3d1bad1d14a1b726b7d2bebb9ec85643af1501761e46245990"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/dust.json"
-hash = "430238151e20248fd55ded5d3a2ca05558e7309229aac2f1740d5141d21207fd"
+hash = "176007b940986781b3b68938332d805dda009c96a2a43345867866c41bd1447b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/gear.json"
-hash = "51163c179545242d886ea7ceb18a1a9a738e81a9c3eecb2928ab7501fdc2aeb8"
+hash = "17377a7cde1ee4fbf78ac6b164da318b0d20bad7faa3b9cb3d1d65b7679d5f52"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/block.json"
-hash = "039a1f30049bfc7610618347d27001834ad636487355137805d9e269af15f09d"
+hash = "7920cadcfcae30db0be92c361491a40368182511c6c2317bbd54ada59855ddd1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/bud_large.json"
-hash = "368624526ef36f8b599e3f4e36a9cfc16995e6896066ae2faa9be0a233b1caba"
+hash = "17c50277052bbcf2e5ad67787922b0897dfaa54751c2ef5e0843d353d96d93b5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/bud_medium.json"
-hash = "7e8ec8769e9a626774632b0113cbd1e345e1a1bc0f3c842d0c3b6dab7d949f99"
+hash = "64d46fc5360da8ebf7218e0546874a07e3fbafbaf6a2ed369b347658ecc8eee8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/bud_small.json"
-hash = "bee47583507e78f1c9e59b5eb45de00a4f05d835cd62a9422339e366acc6a23b"
+hash = "a86a5c0181fd678e634c54a1523fb041de7a1323890c8448846ea99a45eca625"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/cluster.json"
-hash = "473ec503aa20fda0c909b8151a48a79f858c74ec1faa4521b4f1fad2e16f8aa6"
+hash = "a4d8c1c69e5ab03aba2376a51580307081f34cdc64eb8dbcfc1f0017e8431560"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/geore/shard.json"
-hash = "2024fe5295bcaf26404f7a060f1b777ce18f364d0f4f79d9b036f00b5c205551"
+hash = "0bde98cf01539607b3a05bf24bafdc8ec6732f933af593cb0eaebf96260c9c94"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/ingot.json"
-hash = "6519d9fedb2cb04193c38b32b64f01d77221f33be0d0d0d1e9948cc406dccdad"
+hash = "d7d9b7ae3db25387949d8485c21d25e227b9017027685be25d9afe0a87702360"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/nugget.json"
-hash = "7bd322129ede8d19f0b1f6480d054f2c50cd81293f78e221f0f8e021eb695ad0"
+hash = "caea092596352d0a0dc4bc778abdc16316865118891a40179352f45426f38b66"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/ore_dense.json"
-hash = "88d750186031c4df1fac6c4c7968101f8816b76e3c8e55d147670bfaba1aaa1c"
+hash = "5a75883e007d166545a877086770479ab99e88cf250749917ae3e69a4f65a232"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/ore_singular.json"
-hash = "d43b0a5ec710a2d6463b65d98bcb203282981f17fce575bc0c2dd5cd064f89d9"
+hash = "0824c0f83d40072a412ec88e753092475734fd9147fe00f7d7b4d1a7bf61aa6c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/ore_sparse.json"
-hash = "b988577ab97b225ac4d0d708c259fe51b4f3964ee3ed7e03d4d4ba1aacf6c222"
+hash = "557ebe46a1c23d489aa54b28a64d9cf4b8961da83a27984c65c7166cc8742af7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/plates.json"
-hash = "c32c6e1b1bb29289c35375f16340c2c1d7b944bce8d1a460cbd1ccaa7bf03337"
+hash = "3ac8dc4a0662377cff073b3f97c316449d1a09d5dae6c3110fd2152a061b0257"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/raw.json"
-hash = "51cb5f9b526c0374815a0ba2fa4b31466302f740190bdd6cdc5647e76e9aa33f"
+hash = "8ac4935faf2e4d5e489ef3cb086b459d8f82b24388e180391da9a9e8b323f4fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/raw_block.json"
-hash = "f1e8f4fec56fefeea42807a12e3bdaeb3e1732c1b3fdd8a4b5195601ffd1cb4f"
+hash = "fccda17201b7615df0ad52e3e49be47c5b612555d1d1b36925926a757e092091"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/rod.json"
-hash = "d777cde69ce75717b1e32cc9602b9bf489dec66e4d310c9e2e9cde4a74bf5f4a"
+hash = "8d860154fc41a9dfd0c7ad1d4a4c8398675b36b1409684798211fcf2baa1ba64"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/sheetmetal.json"
-hash = "0243e8c67a5dffc855b8c2b3a44a03b898cc6419194cb47af4c52905cd025f85"
+hash = "9378675209b8def864e8f7d35d624cf3e592b4c1758661db35bd3486c9de718d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/tungsten/wire.json"
-hash = "d6a04cc75c10abcfc1cca904a274f7d25932a97e52bb2a97a023ca0e9b3fc013"
+hash = "5eb2e07a6cb204d034776289dc3bce2ad7dabd11c9069ad4ef5baf5d5a0f23de"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/block.json"
-hash = "121eab376ae09df2d27ec306d8655c630a04c790244ebe96abe97c2eece43fbe"
+hash = "f7f9acb3c725db05020d9c97ca1487bd670d4707cc17924b334103ef42ee4393"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/coin.json"
-hash = "d3637afd2308a2dd3aa3717ed51c9a2fcf4050177ce3562337166d7d3db3ddc8"
+hash = "22c522a016942c9eb462a00afa28fce7591ff5233e6fe1cb5fa3375c68d6d95f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/dust.json"
-hash = "26eb59a1de4091024e0617ce0b1d7adbf5c34c2af5b1ca07bcef53b391af0363"
+hash = "159cdd936150067e4712221663539205ab952946083f9693ffddbd528a274b8d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/gear.json"
-hash = "322a6a00c9a453fe90b08e83e531eec8965c65bd8dbf01072868e88cd97309ba"
+hash = "abe2608143e589cd257dc1c16e9d298f15a47285c0e1d032a98fc79c129c29ad"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/block.json"
-hash = "14506ef202cd4f7fd7abc47b5644f18dffa4eaafc0dc446da440da1884db2d4e"
+hash = "965e4ad21cc411cb7c3421a53acb6236b628a0877163a506378aaffb7ef9c579"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/bud_large.json"
-hash = "254b53e22435ff6089959b072d0f3ae741ca6861f14a5b9053d7d8620cf322b2"
+hash = "5029d2bb26d0405f64f146a2602a3f195b8015526b372b0340fd60426383888d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/bud_medium.json"
-hash = "b136168234ce41778eafd74d3764177d769d4b02130c3a09dd79a6bdec39de95"
+hash = "cb38f3e8e54365c4df76f07e03462179cd11b971f2e830bf4761f2019047ab6c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/bud_small.json"
-hash = "6567b65385d9abd953f871870e5827321f5944f118878d1d057a85cae6e31850"
+hash = "8b2832353a34882dd27c6492ddbcb37f571c907bf948022a3752dc1a1569f559"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/cluster.json"
-hash = "c29e1642327dc9f077053795e95cd06bb377a20ff6390ca31fe29b7c136f2c9c"
+hash = "4eb77fcc3eb5ac1ed418d40c92a513bede952c2fa428883ebe03d996517b9e84"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/geore/shard.json"
-hash = "cdeb2a2bd9933a06c4df275551bee383496a87598090ea4ac3114ac90e47382c"
+hash = "36d011617deb36fb1efeabd02f4ef14386541d19e9bc1b7b3c46a23d2738ecb4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/ingot.json"
-hash = "004b38859f1c559d8b646e61fd747b7dff33cc49f4dc78418eddc73f73832263"
+hash = "4be187ece76cabba0b44cb35eb084f1e130d0849893f82ac07125e7fed5e9e58"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/nugget.json"
-hash = "4e6db4ba31d97ccbe6103929974502008de5d7466d350d8590a8e1ed72d2831f"
+hash = "24b8792093565ad5348f9ad8cde756de879e41bedc07a6e097aa9826e38545f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/ore_dense.json"
-hash = "629c6ce3b0fb7f02083db809c57f143a51494b0bd840613420a2182b6dcb8d38"
+hash = "88650ffc92e3d40cb1e3f7c7a7a52f34e55809fd5645d072b58255c91de565a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/ore_singular.json"
-hash = "9d48d44a3f2667105454e68886f521759ab04d625891117186575863b879ec20"
+hash = "974272f143ce753199a83d307154d851acefc2486f7699df0099e27e1290cd6a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/ore_sparse.json"
-hash = "2987a70758e40f155d3f4d679c6e408a1463520c2fbfef39e51f8218364e4f14"
+hash = "03606adb0bb1ab3c5f07482bd2e8d638b31844861fa5688f687386eaab96959f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/plates.json"
-hash = "85d46d15260c1a7b5fbb8539b1df1e45f66cd7a74a9d695d276260f53301c941"
+hash = "4ed066b50191ea829a6401eec97410c06629c66039bd935f945483445c920303"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/raw.json"
-hash = "651aa469f801ad0ed9169fe685d8fd0ac1b7355a90b1b637d4d539c6660d9f53"
+hash = "1af83507a5917fbee5271293f6c693400f1beed349a853d206aa4135557f0df9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/raw_block.json"
-hash = "5351d95fef9dd6c5d102633b0349a028b3b3d9ffc8aa381f57fa7cc2012dde0b"
+hash = "cefabd3e9f180490e777f99fc6e6ff0ce8f2e17f4c9fc1a4f6dfa2fe08d1fcd4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/rod.json"
-hash = "39979575a65d0f9573289da59442c5f673d22e0d6f67e9d7d1299b6a554e7330"
+hash = "a17d590910b08298496f6d214066063b57378d9bfd21b980e0c23426fa215158"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/sheetmetal.json"
-hash = "9f0796b567d48de18b11329c7b55441efcfff409c6edb23a8763e354f2a3c38f"
+hash = "e266f3509145989e11481141f047b1674b11768eeaf53283268d0b537258b504"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/uranium/wire.json"
-hash = "4ba1db1cef659d14946637f0c081d1b0ada6f120463134fa60dbacf7048e01ce"
+hash = "03a114d4b0fcb2c296b5482c682300e7fbde9599616e1a7fff41f4ae01ff61b0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/yttrium/block.json"
@@ -12678,67 +12690,67 @@ hash = "15eb0caaa532846c9094712d82257163b51479583a2f1967b51a4e8a2d4298db"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/block.json"
-hash = "8ef87ef949b7890bdf949a16535a058b1834fbbb3be44d376ec5bd10bb972551"
+hash = "b406bfe01adc913e1644354dcff4a1c71e36d0d65bf14568466ec769790bc12f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/coin.json"
-hash = "8f9d4ac59b2ad7041a314cc393b14d6421bf446b6285ad70dfcee98a821e556c"
+hash = "1f6f8b36658fcfcc140cdf963f9c9afbea02f1e20d12bd3efd5f2df5266e86ce"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/dust.json"
-hash = "1990014a0c447c54ebf020c7e5ce93321807c98393c8d774fcce58b9ed6cb754"
+hash = "9c86fd57bf751bdde5859ef2098e19ffac940d650f4ce59bf291a0db62292094"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/gear.json"
-hash = "413d34c081241331bc7b8a2982adcb3df0ef2e3a719a87658954d5e4fe11b4f4"
+hash = "041114390b4f4aa0cc1c763293ee0d354e43f71359d543a514510c4b3474726d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/block.json"
-hash = "5d461037cbf8a03f7b2349d372ab811d1e4d3b25c5359ac3cd4892400e3b54f5"
+hash = "a01cd2f3faeb3716fa7dfe75d3c353592f81d977de7628bda3c4ce9aea497919"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/bud_large.json"
-hash = "9f757bbc0f60d211a2266fe1349bb7abc89d66e377c61eae3bca9f2cba1dcf9b"
+hash = "d19d2692f7d710a1bd5c4ed63e29f26a6a4db7e509bf1ac41fd6b8890f604a21"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/bud_medium.json"
-hash = "ca93a6cf90f3dfc4fed592d1cbecac0cd76a420869cf099f38166b6038a7f240"
+hash = "d4b55f5904f6b664648459d590be15ff77ac9f3021657faaaa3bca27d01667af"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/bud_small.json"
-hash = "3286b6520204d630104aa29511d83234b92ba4d4f60f27f29bd4da3e21f27933"
+hash = "97de52b30e26a15cfd136c2f843d37844bc195375ae4386a413c652c1b854943"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/cluster.json"
-hash = "e7b3cfb1c0e21951a6c311c01a3470d0a88e94b22678951fa66af9de8d0c8eab"
+hash = "6bfe5c7c73164c1fe01f1235de635f1a87a08f098c8b83ddf93f79633e6d855d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/geore/shard.json"
-hash = "e8b1a14343c238fe24635d45306e721bc02ce355f5b62eb43553aeee591ab997"
+hash = "c03a6e914e7256c2b1faadc508841319fcfd0ed66e6de9d60307e89f1660f737"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/ingot.json"
-hash = "9aa082cddcb37d6fd727a92899246c462310fe654f6f3eb0640bf1b92d3cf825"
+hash = "e8e5f558e4c1a996c4ad6bc5ec920816b5e496be3bc202f691015fd16ebe55a4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/nugget.json"
-hash = "8ee94fc805178cd5324e8a87d6ee79c375d807eb6c7ffded26ae11b4cb910fdf"
+hash = "4977b1c1e06e6d51d65dc68ce40bc0d53f038e7a9f836a526400794c079c62e0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/ore_dense.json"
-hash = "f3e0ef03cc238b736bb7dc0658667f7433887534f38238e83bad79cd6afddadf"
+hash = "49bbf6247fde8b71fc5f045bdfd379c2ae74afef52b4936cfbcf8af68f7e9be7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/ore_singular.json"
-hash = "08754fdcb21fcf9ea17711bfa4415e715d8e2a43d6047afe1d16c340f4ee4eb3"
+hash = "ec909409c614a576a3066640f23c07477dd1387aa7fed65ab23871bc6fc76fcd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/ore_sparse.json"
-hash = "8578a0058757c863d735fd774423922e6bbac3744a7cfa6daf20899a55fe1680"
+hash = "6357a1da9ba0e79773ab20b7ef6275be3de29b54f56451820772675e02a03420"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/plates.json"
-hash = "a14c9f2383f69b3dabb105bb87f97ca89bafb9eeb933cfa57bcd4130e63b0a34"
+hash = "3ef4b306f0bd5d4740603a951126eecdab75091b3867d437f75b97f5f479287b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/raw.json"
@@ -12746,331 +12758,335 @@ hash = "aadf7de5d820d4d4244bbd15f003325a2e29acb6f7465c4452442e5f8c903634"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/raw_block.json"
-hash = "c1786be3e5ac11066ac25dee86072620547698b37fcd6c84339df260ced1350d"
+hash = "bad3f9c42b3780e5d552a4364cbc6a078a97d9c551a03375429a9214ed39981d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/rod.json"
-hash = "df4fdd0985d7c81f1092a2bfbadf91fb4b833abeef0dbce2eb54df3098b7840e"
+hash = "e8ad2b97990a3d9f93d207b2d958910f6b721bb7506f25826d5980fcca6a466a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/sheetmetal.json"
-hash = "31d86b61dc51c405bda3ae2596e2c8c94f0968cfebfdb615c5a824accf97ecf8"
+hash = "3acfff68188cc1866422b98595904635130bead6b4a1b293863942c1e4275a64"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/metal/zinc/wire.json"
-hash = "cdf510b0b51732ef1413d6956abaf999ff8e25b2a4115d7a54b5981d619e39a4"
+hash = "4150f7ec150e533bb823d8982fc49cfc11b06e8fd0b900fa744964d2e9dc6fb1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/beacon.json"
-hash = "94646a7657d9e39938cf53df63956203300edb6e5715f84625f8e83f5ffbf317"
+hash = "6fb9cf3f2b8762dc0e37b7e2de29680f6f08dc0751aa81341e9969285b333214"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/block.json"
-hash = "77bc20136816dd8c4212dd6cd0c2176019eb09461e1ca9681b9848f03af6c897"
+hash = "09025e3c0ced565754770bff115448f210c8d622de45498f2a8bf580f64ffccc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/chest.json"
-hash = "8d8097442fb78b8c1afbae9f37b4198960577b798c9eb35ce1c6e44f7f29f6d6"
+hash = "3a3032c9fab85dd5c3c07c421593121558e08e72c0426e453b7dfab8209e759a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/dust.json"
-hash = "38d7b6eaf074b7087a161548ae5ca34036b3b8840c607d8b4bc95d13ff3828e7"
+hash = "b900dfdbf5c170eac094375bdd181ea24aec9227274ccaca604bcd927c7ed514"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/foundry_controller.json"
-hash = "ae48993b1cb85f9b1c8b197a348fd9214af786a04e982f4239cd2c8ae35e4afd"
+hash = "3f4b76c6ace2a39fb601e6c55faf0745733db8e79123c6c073e8442fb26e7557"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/foundry_io.json"
-hash = "1c3eb3dd6b1de75519817e9c7dd8ad63c6ea522a6e64f08d16b459c7621993f2"
+hash = "35245c05f0c9f2e5614fe8b5064c078d7f0d236c5495f130291956f79b7e05e1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/obsidian/pane.json"
-hash = "0b1c17e074af22a47a9d7c6b34e1ac7292402738e2090eb8c53b035958b9a896"
+hash = "2cd1970f90879a3a18ca92d5c03e311e568e4b9a535331e4ce62b9191efd6fa1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/block.json"
-hash = "7dd97909348002a1fff5f80a4a2ccb6c2d118b7b93f70e741b756073fbde623f"
+hash = "2ca1b7953813a954ee2d83525e3fb558933863d2873a2653c68233c174fa5328"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/daylight_detector.json"
-hash = "e23b17b77f9860c2c04cd222dd31df079dcfb8529649409cfea216e758dcaa08"
+hash = "624794aafa099a4dacfee61c597eae5ffadcf1b115ab91632f43156b7121ef63"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/decorative_block.json"
-hash = "82df90163c7352aec11b7ffe1e7bf3f1feec774e0042c709988ce531d8e54146"
+hash = "ad9e85217a17936f9a9fca86693a35c77b7e077acc93d5620b96ec5766332a8b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/gem.json"
-hash = "59b65a685b61f716daeea50f25c4930438d8633ec0cf9a0904e0a6a040b12ec3"
+hash = "590e820f02dbcec9442369483725b02b60e219d50e8dc9138fbab36707f8868a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/gem_1.json"
-hash = "f8d48f2b84da5ad5f72c8a75b823489942aca72de4f5db91979e4239d8b13d7a"
+hash = "fb3dd26ca4f2d5d4c9aa42e7ad4ebac60bb3c6f253845712ecbab9dd59258120"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/block.json"
-hash = "1e7e53273bf081a9798abc64e4f9beeece7b6f89b5bcbfccf471c46a8d4fe155"
+hash = "38d42ab887bfe897f824c2894211bf90ddb54b44bb73b639c379fe4622af201f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/bud_large.json"
-hash = "1a0acaa89156fbefc1035bc14448036f79ae6f658b940ba4f02e23aef66a9ac5"
+hash = "5bb4f747b8dea3f2ce5c0c61cd07b23507fb16c33065215d0050b2a062accdcb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/bud_medium.json"
-hash = "04f69173cd17dfb5bd02d7e1b4d14758317cd7f66f00183490fe4c492184d3af"
+hash = "ac3513afdafc269aa8392d1e533deb2441363afdfe845f53853a59476e0f0470"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/bud_small.json"
-hash = "d4fdc80d3c1284eebcbed98f159353bc252fb0087207d89b168aa80ae5ae0d12"
+hash = "34a7ed62a8f4dd9c5402c9f6ff23480a930d823c7b51a5548a53311779bf1d02"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/cluster.json"
-hash = "32815712a830cd8c5fc06dd81b2f27d18d229ba51f8339e0a9b5a23f4be580bd"
+hash = "ecea634d9c10ae82bed3dbce96426dd7b16162e92f321a928281a772cc607947"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/geore/shard.json"
-hash = "77f0fec46c72c7211b64bb51ea42256928f961cfa4454c094277dc7da379c3fb"
+hash = "84c1dd0d58bf3b6fc94d5e40557f711f450e3d2f104ceb3021e6fdd09ae55443"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/ore_dense.json"
-hash = "397d70ef9eb2fa7c73671850a45e05509a46ea06db2557adc70a2c02d02ac0b9"
+hash = "d9a574842ef6567641564c0f51320f964b836469bfe32b0094be88a7f8f7d2b5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/ore_singular.json"
-hash = "791aedfa689e492794bb4e9e2bc586006ac3d9b4982aaa8e9fc867025f823857"
+hash = "276e61d9f64be47959075a78430d7d386cee6345be704de1f37664712b841135"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/ore_sparse.json"
-hash = "4d62cb02877db5be24abf070a008349fd734c9ee5ebfd663b0a303216e18023c"
+hash = "e60f365154fe5e74eee661e2ee57bee700f4067b2fe3640f890ebdcabe951a8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/quartz/slab.json"
-hash = "0ad77f1e872056eaed8baf8738feb9bc813af54998aa7d62095d9b8c527700d3"
+hash = "b7c88225b6b161fab8d9ff168babd279ca216e9eb74a244f7720b5f96c187a7b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/block.json"
-hash = "5f85d9ce32cb1eb6c96a9bf31e57eb50ac296d3deafdfde10cf78d87823f9d03"
+hash = "a789d2fb45ae7a589c1eea3f7769eaddf5c591d9ca1308c076776232f4035a7a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/brick.json"
-hash = "7c548154b44c4f83e747d25c6a5b34631fad2846d3e335b9e27db5c7d26cade2"
+hash = "ded0902efbea19d283d8d4fc3cb7e460f1a48d4383356e1ccd58dc2f60fc9dae"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/casting.json"
-hash = "896e53577711b4afd546c5bd6473d2e6a3e8e03b2c5bf45d379655400573b521"
+hash = "8fe3eeec1682cd4b9d1cc3314fa426559c693afebabfffe5c40de40ce551b1d8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/faucet.json"
-hash = "57759176b22fe2a6fbf4d5c79ea880c6c90a7dd8bae524e32632e6b3f46b7bdb"
+hash = "c434414ce49aee50147baefa1931abe678c12af2939e26c2b0c26d9af8b0b953"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/fence.json"
-hash = "239d6d3826e0553f744c4fef037ae8658514c6a9cd0522278b1f232fb70bdb33"
+hash = "7317660cc3f02aabc6d9f202a0f0c75533b0b31dbdc36ba8f287fd06898aee51"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/fuel_tank.json"
-hash = "29a854ef53b88541bda1d8f56bec742f41e203fda2f760997ec98fe86b3a913d"
+hash = "00fc7f21a8a926af391fa5eead06d627dc6b45c874b8174d567ca78790fd6bee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/gauge.json"
-hash = "44187789af1c6de8d993902194e09f69bcf5cec374e10916180d2aefef977b2d"
+hash = "d4b6b99fe13c7506ba899f24cfca20e4319e66bf67ddf6029671ae244ee83859"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/glass.json"
-hash = "992ca94eedb6fff78f4545c52cba988864cab148e4fa89c7d3cd7175d2e27c2f"
+hash = "9ed57475438aa5fe20908fa63667bef5917478518567fae4a2d71bffd359e38c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/grout.json"
-hash = "7193804d9f0dbb8d392a3c1e9cb92bb7ed6a247423a80db911090a487a1c6e9a"
+hash = "32049e376447bfd43c8e08895470fc45e8b598324bd90a14beb42238c07dfc10"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/ingot_tank.json"
-hash = "690be18a3f4de34a0c577d21a31709f9b9c35c1f7fd4cc5061095d0cf87560be"
+hash = "7d4f4406b0c7c2a36f5b17d15271540fcf739ed7aef2f6f303d1afcd761a520c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/lantern.json"
-hash = "fc125ff7348e15649e7d30de8fc0e5b6eb517e52b1b37688a51469980e26f383"
+hash = "27e321dd6d94393a110dc31c8f074121cf1d219dd94a9d45f05fd3487cde11c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/melter.json"
-hash = "d21c1ee0a307778aba7a452961e26642948cbd2e097f9c02c71690ce053e1cbb"
+hash = "010d91e703274753284beea1e3e0a756864a7eb3152249e166ce17eab45f53e5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/pane.json"
-hash = "5d7e2517c2c923e7a897503247f777a6d4f8dd64efb288c43543fe5c44f11e6f"
+hash = "ce71e498e1da78602d859d91dfe3ae1c37fef8f0dc88696f3f2f4d1f5f2c7214"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/scorched/slab.json"
-hash = "349698a44bef2801a21a9c3a97215a55b885edfd4e3aca19a738b32d6bc8614e"
+hash = "746311d097b22daaf2931732719818d454344effba0c535304087b82c00f459f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/block.json"
-hash = "b69af0040bf2cf8424834d18431b80661b30cad21b697fa2961bd94f2d3aaa70"
+hash = "bd8635b028e7fa27fa5240261329fab4a7e0936c3b068516d2a27376591cbbfc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/brick.json"
-hash = "b003e7946464e4f409ecfe3dc832c88362606688c2b8e46937522cfe0ee4b5f9"
+hash = "e99a67424e666a7295c7fd40970a8371dc130dfbdeac1aa62729379767d45867"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/casting.json"
-hash = "ec04afaa846b78dee9e38e33503af07ef178e26181b42e166a14192f68fed857"
+hash = "8e93adb653ff1416cd8f70787de469f2fc2fc3c18da1882a84e3f340d27c48d8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/faucet.json"
-hash = "d79421f5ed7bee730c774a72f0214bde7eead3fab281dd1c0d73055d5a18099f"
+hash = "32026374e731dbb1364794e77a3a310122a0a565fea830727dac0ae5a9581f2d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/fuel_tank.json"
-hash = "3a2507f4b7c827aacee3ba87d0bd2c128d5e0da4737efce9074f10c0a0a11875"
+hash = "6453412764b07f18fe58a93d9401429d84e604bb90877b45ba8472c98f3d1e5d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/gauge.json"
-hash = "9b5e318cb43b721a65f5e5b5aa1217c071617840821adc3e7e3a8e2d51a854d0"
+hash = "c8eea811f309c3c8689bc5e410fb71f146227d50b6c8ee79fc0f98d356bc79d0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/glass.json"
-hash = "301d1d6c1672db54feed82fcb288e2a16c155b2b69c8af5916ae1358f01a2a2e"
+hash = "91f3913f0407f70c6b218259123830dbc4517bcc0910f15fa8f43ecb2ca87f86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/grout.json"
-hash = "afd66fbdd81242d7eb9fae9c8f49e26db2c599665fbb8aa94dfa1329bbb82427"
+hash = "ec45c9c814c5866a69601d0d02180c90f6b4ed949c159d497bdbdbc2c28008c5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/heater.json"
-hash = "cbded985ca826847c7a4c421aa693636dc93461c27d4953fd03ade31aad34122"
+hash = "120752cfeda191b364d81017c3c5eeb52a496153b6e1a6c2d3c49c70b70d085d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/ingot_tank.json"
-hash = "453890c900d110e9a1ba8547b70d2e43733728f0c8b970a77b2149cc57442c8d"
+hash = "d9279ffaf377d1243ad3081de76b52ca5af5227ac6a171550c398e78165f7108"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/lantern.json"
-hash = "323dc98e7ba8fb3d7844b6350c94aaddde1492e974cc6194015e94bcc5f31c9f"
+hash = "87a9d3be1096c9e259cce005d83f13067805d2c8a914d2b0e2c9cda431356a3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/melter.json"
-hash = "07b97e5457d6b52ef167b22e02c96abbc51b006b1c0ce106b84d4d9f4d9cf015"
+hash = "26daf7684b88151aa339142b2c564d35a4796f9adfae83a6ee3f63b903530ba8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/pane.json"
-hash = "f9d3d9a58ada1f5c48cf667feee4b7e216dffd179bf8cf8372e86847a24dc100"
+hash = "99b0fb239d8e701c5ac0cf0b1be7112a3bd697492e8df81a4a3ae6b762a24138"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/reinforcement.json"
-hash = "3e3c10d3676da23a79d1e87a1dd23113da1b47743e48bf035de0127d0921625f"
+hash = "bc6755aa921c40d14918c925dce63ee0d9bf510ff58df717db923ddc00df1a49"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/seared/slab.json"
-hash = "bb122c17dcaa87db2d17d1f546f6591cb49e128b40782eeaa64a153144e15b9f"
+hash = "dd41fec8b9ff815b95e92eba7fed51830b7f246a441bfa429d35d2e1eb7d921e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/beetroot_soup.json"
-hash = "c0aa318d503b24992a72a2e6fdf351e95690e14b70978d52513f62a39b68220a"
+hash = "82ba5a1db17d0ad235f1b4492e79efd6d2ee21c1674e62327b6fc00fea5d923f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/blood/ball.json"
-hash = "b8c94c3d3ef79e6e7121857a7e0f1a44a04752bca83777f40178837b66442c27"
+hash = "ca421bcab57a5710062078df2a442f8677368cd65d30036e72d667ed5c1a71fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/blood/block.json"
-hash = "4f1379cceeab2160d78159eb4a6eaf3583d3120e41fb7092867f57d388593481"
+hash = "53c5724c1efb4e078c04b7c879086573a95000471a742e41a6225fe9e048b116"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/blood/congealed.json"
-hash = "a2b4a8d2b0141998cf5accd97267a2479d30ce58d5a522c587a6af3bea39a491"
+hash = "f188282edd4d1b925e5cc35abeb938ca9f01b5130dd09e9bec1cb977f0612e86"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/blood/flesh.json"
-hash = "f72494351ad40e409b0de214354a7071e1c282cd02737715c66012cc8c3f5fd8"
+hash = "314d4c3f9acdb3dfae22cb4a1fb5438d01282ecc48609114a1de221aa7442ad7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/ball.json"
-hash = "1a34a3ba04f18539af748f7cdb2e895d5102c9a210b53d718a06349cfbda0d73"
+hash = "227adeb0e01396d4916f57b39baf37becf22cc73ec78a30be6b8e65b8bd6c68f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/block.json"
-hash = "16afbf26b33d9728bfe04da549e532bb1494ddbe61ed4ebdb5539fdd6ceff7d6"
+hash = "5ffff7fea9ce9fcb5f4389634ffd451a5b8e7a076666e026211a53d13663d45a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/bud_cluster.json"
-hash = "42f2e9f4337b400950ac2d9d1a1ba7c6cf1a7cb9de61a2572245916fcd9beb9c"
+hash = "b775ade4577ce89a5c916dc635a1a354d91b41192843b57d8764b202c6374d8c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/bud_large.json"
-hash = "e2562d82dbb223703f6648c5e3afad2007004caf0ac3f582a1d6d47cacf641b1"
+hash = "870f80fff7f755709472654e3289227daa11a78c93a9d414bdecd4caf2cfbb18"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/bud_medium.json"
-hash = "5605096984d436c385f1cbbf0ac7e3a3d640c93511c260162c516ff64c954dc1"
+hash = "ac0be0bb279ddb3bb33649ed5dee6e24a207aa05bcfd046298bbc47eca4253b2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/bud_small.json"
-hash = "11ea54696d9f1007bc77f1ec0c8f2e00ec9f63ffcc47edb618d743206d5c335a"
+hash = "64a6948e0b440c7b74421618e640a2d87f02dc182799ee88a02972c082a68160"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/congealed.json"
-hash = "27e436bd278d8a779c250279a4916161a427cc83ea697b220cfe590278c175d0"
+hash = "2fdbafca538e034f7807db35ff08ad5e84002e44d089348e8bef32f86cf5a0f7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/crystal.json"
-hash = "0c7df65043ee175b17da1eeb5eec4fc7aefc8082dfc72c88d381bd0f23ccc60d"
+hash = "9d4f6731187623046f92046849d26f0645e36419985d166d5addb2109a472ff0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/crystal_block.json"
-hash = "35cd00c8e013f9f5e9b7a5034b57311154e3170e8878b80a41f10f2b73b29950"
+hash = "63edd4aa2fd0a6d0e285e537a5868ddb7043647e738dd8083a1f9e1960ce3fef"
+
+[[files]]
+file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/logs.json"
+hash = "6828f9c9e5e5cbf2458237b1e31d619bbc6d1e9cb053fc98c56e93357d7a84a7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/sapling.json"
-hash = "dc9afcdb49d720aa5aca9065452107eb3e053a580191631463eed2bace65e2b6"
+hash = "af6e885fd524d40c5e3f6e4d941527a332be93b3fc01ea0e88b724a7f6f8ec2f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/earth/sling.json"
-hash = "2c2533889d34883480ac124fe582cdc082711e06a421d8ad72e18ea472f7cf3f"
+hash = "68c20173202ac4a7f217a915b4a6292eca1715a41cb319a04f886ac19bf4bd9f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/ball.json"
-hash = "ee5971c8fb09ccdb8a7a24d6f4556796311af71b0c321deaf0edcc6b539fcc14"
+hash = "895122d0bad027d37e233692f724f731cd896d7496c1e7c0d04b003d13979e8b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/block.json"
-hash = "aabf08f9115f19a5d298db7f9bbcfd6f5b7bdd00f3fad894fcbb64d81d7f72d9"
+hash = "8c9c2cc1d092b2ea229491cb5ee4d83046832440d2205d68e4172f643a5e4c20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/bud_cluster.json"
-hash = "ea94656796a0adbdecb7dd7977b4174a04cfb0870d09697d8aaf1e29cc55d20a"
+hash = "6a4f8fcb7a6cdc1f58f5c750d821cc0ee03033e27bbdeaf7ae927acc585c33bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/bud_large.json"
-hash = "a557c99d6bc90f0b4c7d701407e218d828bd36b316bfc4bb3a867c75e7a6f374"
+hash = "6a5903aa7517e4301ff96bb543bce537f8ed691a04c465eae6383bb39be316f3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/bud_medium.json"
-hash = "153f68672442d75fe870f412441869e50a78d79a17812661a26bb4e6fb99b54a"
+hash = "175d530f7e2b9c80551cf28a8e3c7b9cd2924db8d04d5d981ed114d5b527c704"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/bud_small.json"
-hash = "287b7c227e0679505f9c5c0ef66a256a71a45d50bf7f6e46c9ff700861a5e585"
+hash = "6a27c61a5be78f587bd2367e6c36d76432cd87e3aff1ef50f96af500712c9052"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/congealed.json"
-hash = "f8592fe39687aa3fd7c00601e59e48a31ec6e6e84189b0c187550360601f9960"
+hash = "5e7e09da568b4551f78fc51c71fb1369e4bdbb576c900793104d343f317927bf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/crystal.json"
-hash = "efa1d2b57b08b76ac00cf876b545b3fa75cb41fe56e4297d79906e7b1ec48786"
+hash = "2daeaf070fb6de2bffc7a646b7c98631d7a014fbe4f111f10d76594ae340f9d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/crystal_block.json"
-hash = "53fae6b27f5e1d292cbafaa547a2365df7969421c82bb5265e80ad3ecd18da7e"
+hash = "161622e67d352f26b1e22fb49edd28adcff3fd63da8dc0bccf23028a991c0f7e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/sapling.json"
-hash = "eea06ac79f69bad8b55f3bce7a26b00ab9ea7673e87ee82592be50462f2ce7bf"
+hash = "e1a7d198c1d580277721c31d1b8c01bffc88f68ef711bc535177afb979120b9e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ender/sling.json"
-hash = "89a6137ab82d86fa6785a3ce9db79deaf43a73f5a25b49fa062d89f1150808ed"
+hash = "51e0a34ac873b882b6a2d8395a6bbcd82f835dd5eaa229a0e5e098dc6193d0b1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/honey_block.json"
@@ -13078,87 +13094,91 @@ hash = "ebfc557b4c28f93f4fbd8ab38104d28a92997165856f6b6b2e1d82a034484ddb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ichor/ball.json"
-hash = "7444d6ac2d68851f5251dccecfb4521f79f75497d96ae0d2374c0dd07b6f9ea8"
+hash = "3fb07ef5e67f0a26b4d3042176af0ed73f0a6b2f6209dce6fc63ca0d3ce3f33f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ichor/block.json"
-hash = "1798c4fe809b0252f788cd6a082bf0c250c58d34eb228c8f71e2db932ba4eae3"
+hash = "1a16b653b7fb8f55f3856e98ee451eaf170f9b4aaea48226934e8aa97ba3ab2d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ichor/congealed.json"
-hash = "5eaded0743a8cd362f680c77c9e76051efe15a7f697e5587445f3922a79681cb"
+hash = "a3fa4055f3a72375f16366bc5f73598c56a9981edc16ea2aad9c944ef18def50"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/ichor/crystal_block.json"
-hash = "94c81fb84f63397a401709cb6ab40d4277b5925706ffb23ace4e34415827bc7b"
+hash = "7f3966b9986832ff11bc32a7e42d119e4d54469805f0d64749777b97bc6ece4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/magma/ball.json"
-hash = "d1b0246ca4a0c9f4e881114e335af75d91fc7c873e7454d951a945a9f7240bc8"
+hash = "dd94b089c98d05525d597ba6b43b9672abd4bfb5f862f091a6457db1bd072a38"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/magma/block.json"
-hash = "30e7b53975ad471b794ee2dd27f249a1f48c1599f6cd6504c802fb03fb9c664f"
+hash = "4e8ec655ed1fa1d3215793e456e626383050345234db435b1bd75cd4b77a3d3d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/mushroom_stew.json"
-hash = "29d3f5d00178d094489282e12ae1baff6d1bcf698c812360ca50907af1b4c1df"
+hash = "ebc6eeab211f9a237f1608b11364e70ad54d1512130ea393bea5289e0856fb9e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/ball.json"
-hash = "b4239dd3d55d44575c5570b3b15e1c2fd61ae3b8c406b3641f76f2136db6dd2b"
+hash = "e003e9e99d1e90ff811b621e183143198e55a9d5dba5ec3f395e341d0d29fd53"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/block.json"
-hash = "5ecf6a37e583435ece76b78204e56f5e35fa4ac84231fac5af23f42d474f7c97"
+hash = "98f444806283493cb261444cccfdc3655fa9359bfe263157c4408f340ac060c0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/bud_cluster.json"
-hash = "6613e1dcd1e1893cc6084b5e905114464984222605ad95e94dec45694607d2c7"
+hash = "8503203e72560625c80a257ed8ae40ae2d87cb5e765f9b60ced7bba82df19110"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/bud_large.json"
-hash = "06d6125d5e4717068ac61990336e1f69f03c5882effb49e80a09c3760249d685"
+hash = "963c17ea13600bed2a6e020706e2fb804b4c810dbc41df2df03bd96196b148c1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/bud_medium.json"
-hash = "98858744a635c92756d395b7b8c74743070a6b50b3cc0308ee0a38f93ec7a189"
+hash = "42c7cd2a0a5b41d0e4a39723307f8067c1a86770d5c7cb403ad56bfc59cacf20"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/bud_small.json"
-hash = "172cafaa8fbd13edcab72f52573fc78e871bee1f42e263705833c8354d37b102"
+hash = "e88921ac41c2843508d782c5d82a2e30fc47b5fd75e54e3281f0a575c3fd37c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/congealed.json"
-hash = "48fb979b81bb6d6dde9285dd8fb4f98ec552c203cd7d40f31a20f234d498a486"
+hash = "50dfb8787134ba87b78b7a3bd0b0841998ff3e8fdceff7b57b7a5ac18773b60d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/crystal.json"
-hash = "92b53f89aed5560b46c06c2d2357a3b721995ebc0d35233b8439e02af9edc074"
+hash = "1fcf137ee15f60ec126429a1b0ce214c4f162ff6e2da430918228a5173646427"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/crystal_block.json"
-hash = "3160af2b5c0a75e8bc1409954a3231020728990339b93b6329cc9eedb2872ac7"
+hash = "30a10ec92425a364c702a46a4bbc96d32276c552dae6abcd3bcdbe41d8323092"
+
+[[files]]
+file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/log.json"
+hash = "29d055ec189e8e5e168bd3b779a78b9c2d124ead004473531e8fe6b92bfdb67d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/sapling.json"
-hash = "c137377ed2da732af643b88ad5669b45a5be397a08e945dfcdc299e509bdff9d"
+hash = "76469556b4e630b899d9a85527c495d050afa370694a9d65b50ac1cc333bf527"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/slime/sky/sling.json"
-hash = "200a6f1786a1910ed391c56374441262657f078e30f7c25c5fb85cd2030a798d"
+hash = "d11a3254d5bd63cbd934cc5fcf2ea228f554aba6328efbf9c9153fa65e58f9a3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/soul/glass.json"
-hash = "ff2856a3facf5f6e449954751d49094bf8e099b9e5d6d73750840b0d331a136a"
+hash = "c524691e0056a911aad9ad5c5dac7a6824ee76ba9b4f593457aeaac12da9bb1b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/soul/pane.json"
-hash = "23e2b58dad8eaa7d7d1f7b0103f6bd7ef59b53abc0db5890de02a6c67380172f"
+hash = "f1942a36ac23f7c000194e875de37215aa9e473b4798d5a23ac81efd1dc69b2d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/soul/sand.json"
-hash = "0239a24cacfd0bd075d51626b838b932c3a3459d466b84f78ccc773330b3c20b"
+hash = "f52c79f80ec1abd1b87f72d122f5f3c844da708cd3c6047de59017169e77b43e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/sulfur/sulfur.json"
@@ -13166,99 +13186,99 @@ hash = "7f271d247774ddefae1ec5ed5ab321abee65e1ade45354ab4597ed101e4a449f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/venom/eye.json"
-hash = "b1b20bdc6a3a7806cc0f69daa16eaaafd793ca5ce50536e274108724b3030801"
+hash = "58eab0be9bd76e12740bbcba9ec8f1861a2153bfda0fb0f2b9dcc8454c8478c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/venom/fermented_eye.json"
-hash = "c8bf1192381ef53edbf4209d0e5a22317a9cb00e93314efb4c6608303068d758"
+hash = "ac869c93ec935801a0bbb425d4540e1459885ac9c16b039ae1ea31466b8b5969"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/blue_ice.json"
-hash = "08f9e059b048c7e97578dbe42128f9d069449861e42bdc30d0a6e428a3d0f34b"
+hash = "60212a1bf9fe2e15feb88b2f3019b0840002ee7ec1c51efd0a0cc71de7f26a76"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/ice.json"
-hash = "9a6414bf354af2821292ead723a563c50c99f0783cf9b2c2424bf282e9f98004"
+hash = "ae4e02b2255b1ca15c2048774772ac2d21842aefc501a8e1f9003bce90dc170a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/packed_ice.json"
-hash = "ca67407a3aa1105581cee34f7d65683e23a4d46ea3600a1561487cf40a07a919"
+hash = "f72ea8e37bf628de4248bd537b3518e08067676225ba6e23e24b289d970fbe4d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/snow_block.json"
-hash = "4852e671171aa61fc690f9e330fb8a0f2a8eeb51b516c2db1f6c9d9b4920a862"
+hash = "adc9036f7105198b372297ef5832ea1310cbd87690bb9bae0a462c740a84f2e4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/snow_layer.json"
-hash = "a0b64cf934c29facff605ab281c55b6391fe0534705c0a9b01ec8d1e1fc0de12"
+hash = "8cb77dfb0bccf9d8e0fe8a53b8b5cf9211df01ace01c5f6391bdd929909a95d6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/smeltery/melting/water/snowball.json"
-hash = "28d1f9ea2d6f4638c58d3663e528aff9b4815e3defb22ec7e603c343502b8d6b"
+hash = "7a53fd3ec626dc646605624d2794f651d7131c8d071d71cdeaecc646ed9d3986"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/cleaver.json"
-hash = "094104eb8f557666ea759b83524daa3fd21d89d93e7efd56d319f4880e95bcd7"
+hash = "cf61c8b316df98967cba7f9c8e4a4378bd0f0c7299c2203250beaab1d30c2821"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/dagger.json"
-hash = "b8f344aaa2b2d4b2c1a19d2c0f6c10bc60a0f5e5764e24b9a0324b557835ace3"
+hash = "48be5ef31f13d67f5106a7d6adebded6d608834c1700ba400edcb7010190f8fc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/excavator.json"
-hash = "1fd1cf67a3a742113cc570ea3cf77782036182c336faf5d4211acfb092654c83"
+hash = "66718dac64f621bc156828727724c2fb94735c451c165402e44f71e6476029f5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/flint_and_brick.json"
-hash = "959deed919fd343d7321959235b35aab46bb013a1166f160ef7c19b51a3bedec"
+hash = "bef1bdce4bf5d12c18ecbe74d593f5bb9672b1524c062d6ebdcfb7e782319756"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/hand_axe.json"
-hash = "33c9d67e1171925e1cf2b34e66a9ca23323c1686d4019e36634004593dc23a91"
+hash = "3d8fe02ad347ffe8c4afe69360956f87e905001a225a268770676c0c30b807fb"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/kama.json"
-hash = "38a27931398db9a0d90bb08add8033a1eb76955adc77003f4294998dfbb47dc1"
+hash = "ad6df0500af10e1827e74f33219b5d403b8d47fd39cc86f39d07c38203cfbcaf"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/mattock.json"
-hash = "2bebd97c20158814524da2ec106e55213edcf2c2bc089769727fec8ee11d1ed8"
+hash = "3600a67d36aba87908601f80b6e5ca2e84bf57bea79e34cc2ec88e331ed07b43"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/pickadze.json"
-hash = "3cb45249dc3043588682dc622e82f33e732ca755a8012c810cb036386e60318e"
+hash = "aea67732de23e1b8a8fe9713a6f9035168bea1e1cf14409c995243235047822b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/pickaxe.json"
-hash = "bf3f63128ee576b455175e2245538df64ffde0bd342a193f9429d3004ce17390"
+hash = "28fd0cd57c350e40c89a468de8b3935d7072bea7591cfcaaa4d1e8509f886cad"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/scythe.json"
-hash = "1f1f62ec29a8abaec5577d4798297b25154976fc6436023e0c4f6f91b43c5f4c"
+hash = "43c4237cb1fd7a2dfb1f1d29cd747423f3a96c6dc8dab6872188c55299875629"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/sledge_hammer.json"
-hash = "26356ab59014e31388347773de0b9c218233ac57fedfe5d209a027037fa1c60f"
+hash = "dd357e8a7ba39441cd2197e57c03f45b8b6112f7c40c3ab9bd7c59ab28cfab96"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/sword.json"
-hash = "e90ffe4dfbafd0d8a46c4a788a9536a95a7e5e83c3d688458e8b8f9deb34759e"
+hash = "ecc74f81629437d4c631702a13e0130675b4a85d61d4d16ed38ae78ac2fcb2e5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/building/vein_hammer.json"
-hash = "3da137956dfe1afb73bcc251cba126da7e0eac47405e86496acd2d1ff4bc65e7"
+hash = "ecc9f18566dd91661ca83292ecf6da52577788e3f0d7e56c78a0c2b3b7eee116"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/casting/calorite.json"
-hash = "26bdec2e67c898b3041b29d0113d8a585d0589c4869ffbf6c57425b8d5f0edbb"
+hash = "a4078f3ffb9ce12b053f683d7c8cfba464417ed6cd1e8163426701a2c1374384"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/casting/desh.json"
-hash = "1a2b3d0a033ea69bebce905bc65eeb419fa73aa1b60743cdfaceff0ac7c8a725"
+hash = "c745d2e0216ee69dea08792ddaaf5dbe256df136dfa231b2993d07f74b9854fc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/casting/ostrum.json"
-hash = "acaa205859e8092c779ef2e3a9d8bebf239896256940b48968dfc829f34dfd2f"
+hash = "55c012efbe43c45229cac398dbdc1832741d6c3a4a9a448c969f56e9bab03301"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/casting/radiant.json"
@@ -13270,7 +13290,7 @@ hash = "79b7e058c675a337bb29294dec7915ea5eeb6b223c313cd60b25d6a9986733f4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/melting/calorite.json"
-hash = "682c0bbd46be6d03af2661c3a160efd2a348ecb17bc14a7a1bba59a489739569"
+hash = "5b814d8de3f26d13ec576d426186688e1ed9c0168d79f845885864ac9f9f7298"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/melting/desh.json"
@@ -13278,7 +13298,7 @@ hash = "0518d8e06b29c1bca7fb636b05046e5037a7285e9cb88a9d928034f5f6467677"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/melting/ostrum.json"
-hash = "9880a720a13ef75708fbdd65e46792adf156ddbe57de5fec5b53a8522a7a5fbf"
+hash = "560fa515cffd2fe5bf252129576778e5a72e2597bbe231cfd2415d1d67395e64"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/melting/radiance.json"
@@ -13290,11 +13310,11 @@ hash = "c64e66314dee7a57e79d31601b5d8d8b50cbafc665b68fe24c827f6dbd342ec3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/radiant/ingot.json"
-hash = "941524e564cd3b3de5ca41429bdc9b596645f3453c975123999c5e774bd6f807"
+hash = "1ae00ad0cee505e6d6aa7ba3f398e0cc400128c5ce81db046c97e965a0412242"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/materials/shadow/ingot.json"
-hash = "466801022e749e8a3a507d83f9552b5379eb0fc15b61f9cf546889c19392fcbb"
+hash = "77caf74e48518f1ca913b4ece9a78f8b8450e7f71f0d6337193521ae41213f0f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/ability/double_jump.json"
@@ -13302,15 +13322,15 @@ hash = "4913a305d12fedd58941be831f4052d25cba85a1344d79b033d87393a87f6111"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/ability/luck_level_1.json"
-hash = "a52017be6f84ef429ed6ebc2ec9fb4ad12ab56625f0e1d8b6e2ef6a807e6bed5"
+hash = "2d735114aa765929750b9085d7af276e9fcb117b987599c14fe2b3604eca795a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/ability/luck_level_2.json"
-hash = "53f6809ff6dc27676116cb481e6cedf5eaa9fbf177bf4b0468793b9b71920c5d"
+hash = "dd49fe0bede9a5d00ad859da5836bf08d0dcab5ab7e361ae50a6f930f01b2ccd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/ability/luck_level_3.json"
-hash = "2b956dc1d51328bcf42507cfb8dd7539e0fdc5b73d80cf30e1b2148725702e3e"
+hash = "febb8da377434448ab2d6dc0e71fdbf51fb47c1067746275a65fcaca5b1e832c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/ability/reach.json"
@@ -13334,11 +13354,11 @@ hash = "31708b7229493100cbaa2caa175c9d02ef6f05199dfabcb286c5069d2f191157"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/slotless/resurrected.json"
-hash = "edacad13fdc172f8b1f457e6d1680f0856d284ffa8d60ddf52aab5b3a660eb23"
+hash = "5be5f77b56419fdd9e20309ae1158b81f55c05072ea548591bf5ba6646223451"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/slotless/writable.json"
-hash = "0c333e6bd7c4f0ffa8a77e3d9cc7724965ca68bac961ad57dbf34caf1d5f7b88"
+hash = "fc1c3f4ed320cf40652220812c72870b1c49fcf3054d4ff4555af843d5f88ecc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/upgrade/killager_from_block.json"
@@ -13362,183 +13382,183 @@ hash = "28f983f9d426cc08932306db73cf36f7bdb178fe11e7d4ed267bf89ac7e44b2b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/modifiers/upgrade/piercing.json"
-hash = "adeac98f1023235c8aa5473234e684653cb244fd1b8463e68abfa7f17650252c"
+hash = "25e3f75a64b0b8f666168f8120602d7109ae4dc565a71653aa4feb61a5eb26f9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/broad_blade.json"
-hash = "bddc6d954cf5568261d7a43fb0cee1dba8f359b41f459ddd5295b18d64d0bdfb"
+hash = "a5a760a4ab594e9da93a2aea196ee6586745043ce1d5794eac691f671d750ac2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/hammer_head.json"
-hash = "e95ed4d49df979e61755246cfa57c8c7182bdcec9a028fe9eae9bdeb3fc3238c"
+hash = "1180f93805583f95f5f5ffd75bfd9f6f72c73bfe77ba6290738da063163dc47c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/large_plate.json"
-hash = "07d6523960e91571a1e2cfabe1609eaa8e752405afab8302b9be7013044f33eb"
+hash = "79e3ba07744a58002491413a04be81657c7d5acfadac0a66d7eac8ddc10f7405"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/pick_head.json"
-hash = "160f75aa47050adeb232b62253132984ffd08481a038ed11b01c14c47a9e1387"
+hash = "a0229aafd10d90e412065fd78646a80df5a45cb5f3d1c103e21f8e06dccde65e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/repair_kit.json"
-hash = "1f81e68095bfb94f4230c0646002d359bab5627bf64b3cc41cb6514a65c89602"
+hash = "fff08cb3cf71765a4551d323ec82a7268c97fc1f32a483a873dbb8f859d4316a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/round_plate.json"
-hash = "48a5800c9265ef987971ffa79b81a66a5b4af4dcda84613e1bd3933c3777a7ba"
+hash = "4a9d18cdbc8f025b965b7b9d44d5cca343e3c5b99c3c96e497ba5a50a2acf6ee"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/small_axe_head.json"
-hash = "a7c2467edcdb3cac2bf7d7bf298365c0f7b6f797bc0472d40a5e2893da9087d4"
+hash = "051a8702294e373e1d8bb11c2e6a1293548d1a4cc7421c92f6481f57a7d1a6fc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/small_blade.json"
-hash = "9b54dd561c975cc0815c22bfb1ba6a164131d01d06502a1c20dab8eb0ea6e93b"
+hash = "6ce9ab60ea6370b2a0850c40836d1af87263146cb65a13d9b63ad35ffde7624d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/tool_binding.json"
-hash = "a696fd17327dda9d5cda3d29d19e8c21139a0f41b87870a49de34cb214c9fb02"
+hash = "2de846cac92065f4ed516386a1e0070d017f349edf8a22bb9a8839238c18c612"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/tool_handle.json"
-hash = "bdda4e6390e128e8249cfc5ed09f8e3f76e919c9bbb9477e09ca7cdc9a321b8d"
+hash = "d30d66deb7bcbbce854fc22e4d71e2030a1e88410791110db25d3d2fb324cc10"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/builder/tough_handle.json"
-hash = "ecd117f261bb6793f6a3b592de6b13513dbd9e6cf6d4b403700ad27982bb0ebb"
+hash = "8d85c63f865c09567edf716b28c5aa4d3f3056a494373e300eab19be7a826099"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/broad_blade_composite.json"
-hash = "7a1f876de6a8cbc77a26a41add71a288fd8e4afa3a2c28c289260be26c1f9323"
+hash = "5cf534e1b395077c66ed18494273d1b2fee334ced8cb87856289ce7d6101c359"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/broad_blade_gold_cast.json"
-hash = "6bce5c1768ae84bb6dfaad75850a7b1fb5a166bdd684125cc3feed7f2ac999b9"
+hash = "d446849a78515588174fde392505a66876b799b0422d5270c85e3e7e3fa488c2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/broad_blade_sand_cast.json"
-hash = "6086453d0cf9522ae65eeae9d05136a1dfff7ff0c058027d73ebfc4b43dcad5a"
+hash = "55b0e7e5975c1e68760edb3edd91384bfa393a4afa1b784664bff80311228024"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/hammer_head_composite.json"
-hash = "60a14d340c5e431ab58ad5519d1bb7ea0d0a4d350b3856aba25e032d0998d779"
+hash = "d06e65dc28254b517a08c9e286fad8ae51b02d2ee219a4afba3f8e29184eeede"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/hammer_head_gold_cast.json"
-hash = "f597167fd24c396f9892fe2421878993ce59bad57933920cd40ecda127c8c446"
+hash = "6afeae2f6c22e9a1e0790355e4e14fe3993879e5feb9dae9abf934a4a8d8a4ed"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/hammer_head_sand_cast.json"
-hash = "16920ba0290c4c120a236dab94077a6d12a798b4c446b5b6cfc2ef58c950272e"
+hash = "2183350c9e7f40eb8893de87405fa7e11cf6583dfdddd7496f5207b93acbfda0"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/large_plate_composite.json"
-hash = "29e68ce7541fa80ec46f37ff2db4c28d918e26cc057eb2c8d3affa8edb00d151"
+hash = "697ec4d623965076407c9b76e21fb0a47db935bf967d038946372b21011a18b6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/large_plate_gold_cast.json"
-hash = "2fc6f664c42ec70cb9428990c9a4ff7f9b3501100b8c0443024f2b8195e82c45"
+hash = "c8175f300a9e3cac92b4af78b9bd685142172535b2a154ef69be501f16eb6778"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/large_plate_sand_cast.json"
-hash = "f6b87e69e3df1ad9f4cf18072ee294e37f18706394a39b86a51d8fd3b19c6e63"
+hash = "83c9383021e36a9a5d66f2b49f17ccf4d11c4515605ee66f05adc7eef65312d3"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/pick_head_composite.json"
-hash = "3eaffd8c25dc8bd0d0acfe48f5160686be6ee5c22700bd6e1ae56d2995ca3e90"
+hash = "16f61ac9a4b9fbb1baa687ffc52c5c096cb1556dcc9563f400061a7b8635bcf9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/pick_head_gold_cast.json"
-hash = "bd2515d097058401d47190349020a769b1ab25d639b047f973ad419e6d099ae8"
+hash = "8b510f38e3b8142767d414977f002270c490252c57227cc1eef72aac48e615c2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/pick_head_sand_cast.json"
-hash = "d922aba1202e2ec4fb23395883b8e0f72f4403a60e9b0c41889607d1351bce20"
+hash = "39ec509f7699a78e9354dceceb969c0765201ef455d73ebcda71bc5c3a729595"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/repair_kit_composite.json"
-hash = "b252337c31094d678e83802656d76298cdcc932cdbdeae0278614d177d1a4e20"
+hash = "a5b33cbafd1c17860c60c166db32747bef8001dfc9c5dde35fdbdf66b0d6b4d1"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/repair_kit_gold_cast.json"
-hash = "3672ed8adb0483211006787a21dcef3ce89b34073e5a9a8655f726297cc2de6f"
+hash = "3bf33f70f79c3b420697dff706a7eb2e70fdc354976326ed454718b8d7b10ff6"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/repair_kit_sand_cast.json"
-hash = "decee968b8e62bb387f81b6c12fc111ae0358723e5753b28325501c0aa7f949c"
+hash = "586196a778c191ffc4fb12982b7c1f0811a1aba456011dd1fe2c30b8321647ac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/round_plate_composite.json"
-hash = "e83b41e91cdd6fb2f068a664fa45ab4526865f697626265aa7863b8bd89d0413"
+hash = "3fc6f337dc19b3896e64354048c2eae5766188e24f43334f08c9161f22ceb21b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/round_plate_gold_cast.json"
-hash = "89872285bb4a1005f492805f686ada0c83214cda441c9dbd7953e0306d52916b"
+hash = "9ae9187a76fea0e61001d9b61c447d3f6527256cf723db428054548d5488bd07"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/round_plate_sand_cast.json"
-hash = "36c1449eeac4591d207bbbf51a5acc38abb4ad3dc09d1960bacb3670380d58d5"
+hash = "0453ffd2b935208a2eaec75498fe3200fe6844578c444b61d546b5523bc5ce66"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_axe_head_composite.json"
-hash = "d4ad628bc186442113819bb300217b5ed014aabd31f812185ae5998998ec4fd3"
+hash = "6385fca0dd71148d3186562a8bf3affdc772b1db5f2a13ac4d5bfe0aead8458b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_axe_head_gold_cast.json"
-hash = "f637a3071ec07d56bebd02a6336502d1c8ad8829c5a48a75984c43b1a6aa63c3"
+hash = "eeed797d865c800a2e9bd52ad01c7ee1b7aa4ee999a37e1cc2eaf5b1b6a79a93"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_axe_head_sand_cast.json"
-hash = "377be434383f93ce4f0ae474c999a880fd38f0810bb044a1934a9f67b71b18be"
+hash = "259506bb76193dd3b09648df2ed097fa94c76a52b1d0bc37c1b3e48a8f8a2dac"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_blade_composite.json"
-hash = "cf2c1cf9678bbd49147f05993807747f385197c1c840411e88fe7bd5728fe6b7"
+hash = "1f9c14aa57dccdd48cd72742e7d1a609022e83b68d47aa5764a131dc25e84d83"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_blade_gold_cast.json"
-hash = "4acce6f375f7e69ec42df04f4a29358b906e2472ec14f14052754fac4a9a7200"
+hash = "3b5d63a3be9bd0a2792f41ee87f624624c49406d99ef93234b1554f24709ec3c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/small_blade_sand_cast.json"
-hash = "9391dfe330aba6cf5ae34fcbf0c0c490c2d20974ee9eb18ce00e796a251f102e"
+hash = "ddbf530ff15246e9db7922d17dd40f1b724a73a8458ed29353bd6acda82094e2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_binding_composite.json"
-hash = "bc154cd99f900565327e1adea5d40b8ef16e657d3b4f4a788cb57221e4b76c86"
+hash = "38d3098f8ee2d4dd5a80f506ffd310a9f3bc7c48995915f71978c96ee422768e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_binding_gold_cast.json"
-hash = "6751908855350c39248225f17e018820b7179a50beddefc339e822f9a1964684"
+hash = "471d8fb41468a175ea0919e6652d85cd9dae7ec99b5f438aad4dab165f80e1bc"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_binding_sand_cast.json"
-hash = "5771c6194bcd5cc477b10d564578fb211be963b248bf04a2b33a846dbdb22114"
+hash = "506f4ac661dc8e756a581324eb15a3ace13f6a4b6d18aedd9092a982880ed2f5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_handle_composite.json"
-hash = "ff5159efa6d9385ddbd346d8408dc09df56e90f7138da00aa742048ac04ef143"
+hash = "742599f7c34297b72910992eddabdaacd363c2be058b232c9dfc1a88e8bf4f5b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_handle_gold_cast.json"
-hash = "43096e04e501354d6ea03194dfecffa15e7918a67c74d787cc6300e5e37c3f86"
+hash = "e73e9611843240915ed4d59461e9ce882800a837277633e69cdddab1867004d4"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tool_handle_sand_cast.json"
-hash = "96445d14111c02c872773cfc9d80932a80034699064a34aab15e8d6ef80b0274"
+hash = "96a432be6cda89f4fcf5130a6c84986108c66de941910ef075bb0c772ec46420"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tough_handle_composite.json"
-hash = "ecd45737e3b8e33ed1b928e9d94a93c93d457a34fbdf317498a499d9441e1499"
+hash = "4eeadbaa05847a2f05c98e6881f280276fc5cfdf8c37946c02032fbf188a18fd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tough_handle_gold_cast.json"
-hash = "49f9a59c18e750e04117d9fc7e21132d2032edae2b708d1be3b4d11ac00f3f61"
+hash = "2226658641a581fe17611f52c4b08c43954f357b4fecef96b3b4f6d7c68d8950"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/recipes/tools/parts/casting/tough_handle_sand_cast.json"
-hash = "54e224bf7607a87dcef5f4232d45eaee008a1ac920c7928159982a6c8168c251"
+hash = "64a0d08d789b9753d5dabb67a470ce469c5f0a17e299587def5ff43dadd196d9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/structures/slime_islands/blood/0x1x0.nbt"
@@ -13682,15 +13702,15 @@ hash = "928200922241a5b44c3192ddbab70951a41c1797f53da1536e8ea365886f3b09"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tags/fluids/desh.json"
-hash = "d061b2f719c0e9f13038f1767a0117e7afd8cebd9c0e29c3bb05bd0a3b29c187"
+hash = "fa166b615544889592b1f8c6bf059b580585461663e2538be4a70387f303fca8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tags/fluids/ichor.json"
-hash = "54801946f44ce2913b27b67e9535b3503e0a2b6c2c03136a655250e93533f1f7"
+hash = "be8f867f17169437c5123d20505d956d7cb97d3aa5a0dc5dfe1968241b2d9264"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tags/fluids/molten_desh.json"
-hash = "d061b2f719c0e9f13038f1767a0117e7afd8cebd9c0e29c3bb05bd0a3b29c187"
+hash = "fa166b615544889592b1f8c6bf059b580585461663e2538be4a70387f303fca8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tags/items/stoneshields.json"
@@ -13698,15 +13718,15 @@ hash = "00e53d46f6fdd93b18d1ceb3c2e120586cbb239fb8b1d3f35bca59baba4c747a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/definition/calorite.json"
-hash = "f506bf0ce4bd2445df5959f65137920c017df5860c11e557382fbbe7d89e1303"
+hash = "c8091178d963ac67e6631d59897bc2e3b4b6e17ab54be22c9e62f4caa51ae40a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/definition/desh.json"
-hash = "f506bf0ce4bd2445df5959f65137920c017df5860c11e557382fbbe7d89e1303"
+hash = "c8091178d963ac67e6631d59897bc2e3b4b6e17ab54be22c9e62f4caa51ae40a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/definition/ostrum.json"
-hash = "f506bf0ce4bd2445df5959f65137920c017df5860c11e557382fbbe7d89e1303"
+hash = "c8091178d963ac67e6631d59897bc2e3b4b6e17ab54be22c9e62f4caa51ae40a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/definition/radiant.json"
@@ -13718,83 +13738,83 @@ hash = "f506bf0ce4bd2445df5959f65137920c017df5860c11e557382fbbe7d89e1303"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/brass.json"
-hash = "7beb82227ef058743b13787fb3bc3ab628e67cb1de90fe86df7919540cf80cd5"
+hash = "43cf1436b13baae60ab406710a18e432aae02810695ba0a451eaace0db47cf4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/bronze.json"
-hash = "d69a03b4a21c9de23a4cd0eb511fdedccfd4fd7753240d236024b6ce256928d6"
+hash = "29bae67e536bcd2a7f75d9bd3284fc38cfe84f18b9292d81381178a7530b1542"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/calorite.json"
-hash = "c698093ee2e6b24eb50ad86bb5a4468844303c1813bf1fb1c51fcecedbc05622"
+hash = "ddab03f23bd8935ad234d6c456c79b622c8075a973380aabd4ac010f445b351d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/desh.json"
-hash = "814a75c85215f5f0f79c003b2b5efb7609bda80929151e2b68d0c510fe5cf7d9"
+hash = "bf4ea4c3fbb76e75bee594dc5f272dd1bf49959d736e427dffe1d8d7f96d20bd"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/electrum.json"
-hash = "af12afe286f32914aad138b64441005378bf22dc613a26b69b7b894ab65c29f5"
+hash = "55df0ade50f0fb6e267aed7a7a25d96030ef45f71a61f2f9b458dd8cbb94f7b5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/lead.json"
-hash = "773f951207eb4f3b729046ac0787f602947f6e2b451782008006083b9fbeb4c7"
+hash = "0eb98e86b442fa92aad1341471098c95520db988cbea5defe8b85a0facea4632"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/ostrum.json"
-hash = "d84e3d0db1b04ea35f2cb581ef1e3bacf88a385f16ae5bd91901e8fe8a2d73fd"
+hash = "f1e5deaaa9632df26cc89fe0fb9972626556c10e072d121105293d2d14a6157c"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/radiant.json"
-hash = "1014f8b5477e54747a4df928f06314a830bed5674e1ed51b50c12b5ef56a5ff6"
+hash = "f00715afce2529916015d901d027a91788f3bf3579b421a99b0d64153d090472"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/shadow.json"
-hash = "b4166f498838ba4650a99825aa976dae8a53b95737aec39e9c1853cb177c2113"
+hash = "0750feb3f2b9a40a1f218fddae2e8899b6bf2a7bbf397c82b12e4443f8204728"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/silver.json"
-hash = "c293a9176b81d74f7b7c6fe85a51094d066eb71eb90015c9a9ecae7c6c1a7920"
+hash = "a12a3e5c0a127ba665c5e3eacfb68c2ed089917263edb52c19452ea5f85dd0c7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/steel.json"
-hash = "2970f20adb5b48c4869a2e006a875e04e83af043821b7a820ad07d807ac0ccd9"
+hash = "8169d1eeec072facc8db3279706bcca36cd109c40f4c34300cd444427ce50389"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/tin.json"
-hash = "7beb82227ef058743b13787fb3bc3ab628e67cb1de90fe86df7919540cf80cd5"
+hash = "43cf1436b13baae60ab406710a18e432aae02810695ba0a451eaace0db47cf4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/tungsten.json"
-hash = "da16b9d757de55366ab4940a9b87814355e5725237ab9af2ebc017ff209f5649"
+hash = "3e3e73de1e0e685d2ab7afd684140430fe376ef21ae51766cfce7b91d1ee0e1a"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/stats/zinc.json"
-hash = "7beb82227ef058743b13787fb3bc3ab628e67cb1de90fe86df7919540cf80cd5"
+hash = "43cf1436b13baae60ab406710a18e432aae02810695ba0a451eaace0db47cf4e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/bone.json"
-hash = "f2677d4599e7afa7d97353c32e3de7b2318caf8fadfeeb2eeefe1cda087378a5"
+hash = "4b01a6cd97d2c316c8b146dda23a12e6a8957eabce457f2c3037e7040a2136c9"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/calorite.json"
-hash = "43dc9b9926aea4a6a1cef5cee48e679f551fabf0dae07e1717352a261a08460f"
+hash = "2b2090c64c91661cb6b1206667a8636d5d113a047d0ea60f798c13eb1582594b"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/desh.json"
-hash = "bf74f9348d6e1fe09e61c1dc0b12431a5803577d564a9dd3a657a4989391cab0"
+hash = "632109c437ba589e0c90d475a8afd7f8e3602ee28e578acf5f8f443946f697be"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/ostrum.json"
-hash = "925de2ac2f0b03b46353742c464645c5796a525d2cc785fd5a78e91aa3bd9610"
+hash = "6a00b9e26ecfa288a77a934d235291f968aa95e41398fbc1066bffc9ec41015e"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/radiant.json"
-hash = "f8b59e33d78a1e03b918040ab53f988d6f42228f377afb128011b8d320791b73"
+hash = "64b83455ba891810363d6921c78a254e0d3f856a2a7c5fdbebc7ee0abd479bec"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/materials/traits/shadow.json"
-hash = "86b2fdefed5172c0f182342929c03e77fd4f5b500d57d4fbc3ae84f306ce8c9b"
+hash = "83ac4c9133c2d78882da827789e31d92d586ed2f5e0cae6ca55fedc5f185199f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/cleaver.json"
@@ -13806,7 +13826,7 @@ hash = "8580cb3c702662beafe23c428247c22e3a6cd5f12c4401347f80f675d979941f"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/pickaxe.json"
-hash = "53605ef2853d520b6a57b7cc38d5dfb88cfb5112ff4ac4790f5103740cf73ce5"
+hash = "d4e2cfc25ae9911a68d19356eb3e3847caff6286355f122de11349020fecc30d"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/tinkering/tool_definitions/scythe.json"
@@ -13822,39 +13842,39 @@ hash = "93975bc537aff42f0e8042fb6991235c197b9930e1531e14858f60fcc15100d2"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/broad_axe.json"
-hash = "4c4cd916c357bc7ac18908dd4423cfa50ce9ce6a3a358a1befbc25e701fb857b"
+hash = "317921cd6a6d9e109c95f7379173bb2b98ca9453dffc0470aafed4640b3773a8"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/cleaver.json"
-hash = "178b356865750b75eeb850e910bca744427fd28c9dbe206a807ebc76f28874e7"
+hash = "a375fb7f5af3a1d229f1d68d31844965f86371ff58a3c86d6a97cb10ab4d4c06"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/dagger.json"
-hash = "510a5d1d1e51924eb75b2130238478c64b125e9f5a4191c613384cd67538170f"
+hash = "c273727c7c891e60953b71ade8ac6013337f3fbc06e9bb5e64c785c23c24bd32"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/hand_axe.json"
-hash = "cdffc75a9e1533645b9d5816fb37c7ad5fc5e3b7d7e84ec642149c1a52521854"
+hash = "64b8e6f39df650763e7af456d3f313617fecba8b2599055152f67f9a26a4f575"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/mattock.json"
-hash = "cdffc75a9e1533645b9d5816fb37c7ad5fc5e3b7d7e84ec642149c1a52521854"
+hash = "64b8e6f39df650763e7af456d3f313617fecba8b2599055152f67f9a26a4f575"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/scythe.json"
-hash = "cfe2dd35c35f87ae0b3b4f218947db5c87e9870ebf505272872c30cb7cc15d37"
+hash = "ca123903db9c922984e4daeac894fef6a47d4b6fe8567fb22d03d951e45fb075"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/sledge_hammer.json"
-hash = "42d4388d10461a5986bfbcfc7a512570adf6b7aee79287ca59107ad4f3f78959"
+hash = "ad9007491ff9f3fda043867e4507ac0848ccb41fbead8a08f65d492cef2afe22"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/sword.json"
-hash = "e809708878fb599b5285de589e07bfaffa6904b270dcb0e60851b4ba1149db55"
+hash = "ca0345df780d16467b0a1f8d300c35b235f39d0bd4161b3e41c7422fdf2bacd5"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/data/tconstruct/weapon_attributes/vein_hammer.json"
-hash = "dcb2f96dccbe0b70d1cdef7fb471d3672b57902821d17ab53e671b1c1f283ec7"
+hash = "071071a836be0776bad28c39807838634072ce8f3cb17f68b5e3fafcbfdbf4d7"
 
 [[files]]
 file = "global_packs/required_data/zTConstructAstra/pack.mcmeta"
@@ -13863,6 +13883,10 @@ hash = "5aae84efd20c951553d0fbefba1f41e4290ea28c6472e230112bf9947791aacd"
 [[files]]
 file = "icon.png"
 hash = "c4c858bf25e6e4e1c99d297cc4720c4cd9d4a10ef6dfb090c120a5a9e81cf8f6"
+
+[[files]]
+file = "ideas"
+hash = "eab09c3e435f8238826cd3535bd1052a6aaf43d5aacb4631fac09bd1b732e8c8"
 
 [[files]]
 file = "journeymap/colorpalette.html"
@@ -13874,31 +13898,31 @@ hash = "4240bba36d0a16707e4617b279fdf0ba43780c5312baa64d1487f60809d26ea4"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.core.config"
-hash = "15db5befe701088c0947e6929dd05e1daf8a6de63c9570d9e22a1bf3bc44456e"
+hash = "bc6f6aa0e2250bf89d153daa7b401a02490d078a8c3ddff51ff881c0b20ee7a3"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.fullmap.config"
-hash = "ca77f28b1e7c1e941133006e6791ca8d7ca97f6aa42ad5593c30fe1079fbab84"
+hash = "e1da459160aaab7b60cbe24052eace1feeb7b8a3cdb77c5d195f21f3656c3e69"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.minimap.config"
-hash = "a442e2f481f3b41453a298a7bb76340b85d35cfbb57d6737144e6f228c164665"
+hash = "0585377ee89d204a2a73d1e09cb0ac466f727513c3df7c4aaca35f33236f0995"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.minimap2.config"
-hash = "02f8446c670eee6c4175c46348bfe3f51c8b4414ef484b63ca8a57bcd1a00683"
+hash = "d866f454354fc844013fb7d8f2f54f2913186f347706fac478ed2a8e5329d336"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.topo.config"
-hash = "c769965d64bb895d1f712b179f18d942c8a10773ff669f9f820cf407fce7353b"
+hash = "d94bc2c027b57c4afe505c6e7ef4414d0656746038176b6a4a939210a13d54a7"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.waypoint.config"
-hash = "a824d615d079172fb8875d38976bf43c51ead71784d8db28fcc87b1acc8b7bd2"
+hash = "6aaedb33d25acbff340680fa24b81d6fc7560c7d0dcd2e5eecbac7f5692ce66d"
 
 [[files]]
 file = "journeymap/config/5.9/journeymap.webmap.config"
-hash = "2375a810d1996fff4ec5941bf7ac86afa62078264d0a995aec9c4ab17bf42090"
+hash = "83261820523619d7e4e77fa8182ac6e4a794fdbdda5ebf72c312e385bc830998"
 
 [[files]]
 file = "journeymap/defaultconfig.json"
@@ -13906,7 +13930,7 @@ hash = "7c40fb308b8be8815ef24b6f940cbf8e0f9bc3b4da639b2f7027dcfd56e4afd7"
 
 [[files]]
 file = "journeymap/icon/theme/default.theme.config"
-hash = "21af30bf8e646b63fdc52a25e1dc0eb20ffa0085d688767e424333d767be8629"
+hash = "2a62a6fb050a78d9dc76587c4053cee942a3381db98222d4521491f2d0003a31"
 
 [[files]]
 file = "journeymap/icon/theme/flat/DesertTemple.theme2.json"
@@ -13938,79 +13962,79 @@ hash = "7119f6e937e2f5e3268b5868b5f11919c8fe142554b211354b9af05bb22dba09"
 
 [[files]]
 file = "journeymap/journeymap.log"
-hash = "749ee045431542c867b5b5bd5adb73f976142891a2224b173444e52a3795fce9"
+hash = "e2bd3dd994fb81fb18e5f5b7f359a260ba2e49d6f3a733a94f08077842eab806"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~earth_orbit.config"
-hash = "f313211d4d59a1df11cae5f15486b5f5096613d185413fe4c7f6853ca554e51c"
+hash = "250b606b618e42fe66f9a3a6663d4de214251e49b769ccd136e03432ab0700b5"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~glacio.config"
-hash = "e0bbd687b39775aedb4a3849c4a84e2f36dca192a1af1c15b5f79faa81658df5"
+hash = "6b889a116860bcf0b5cdc774a213e6330214786bf4fe3dd8a2c53240b651981a"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~glacio_orbit.config"
-hash = "d0b9a9cdaa4cb82f4cd1ce2ed57406e899d38ec146483c18c30a76bb2be3fe2d"
+hash = "8bab6050726fb6ba8e5548a912ce0fbad6844e3bc469264f8660b0557b1e25f2"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~mars.config"
-hash = "e745b4375f7d801990278e4c91850d9d7d37f95d527c92725b06a13682b3b252"
+hash = "f40021630939f709e3b01edfc5061b36814e2fc5a287ab95f7542b790eed165a"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~mars_orbit.config"
-hash = "64191e2bea23fa4eed7feffd3e23fee5cf5769799537d9369754f334739c6ec0"
+hash = "2d04292da05da952f40f52441c6213bbdc41c3f50779ca27ab27b6fd154365ef"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~mercury.config"
-hash = "85d9f3424b460a5f88c28cce455ee473c7592a09f09fc11b2a161d1abc2fb0ce"
+hash = "ac9ecf29c720621065feddceba25d4809b8133d72e87c08fd6aeee6565707cad"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~mercury_orbit.config"
-hash = "d8dacbf60eeb96da3ba46687017872ce2ef41126a5101553a83ff44659132ad5"
+hash = "2620231c922bd7abdb11c9e9d6151d3698822c1eb18a1a30283f11e40433eb5b"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~moon.config"
-hash = "d893c2e59ee81adfe7203d3783e7228835a19cf284da1bde4eea8afaa5a826e2"
+hash = "3657b01678620a2adb1e8c5c103459e4ec7b06452c4e0b6c29fdda04d7372e60"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~moon_orbit.config"
-hash = "3ef413446bfbb7d067c930de60eb1145a1cee9d1320b17bf3f5c2ac8faa24897"
+hash = "673d21ac282888fcf54aea9406d9852bc999d97390f6ba89f697b0b0e0849c7f"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~venus.config"
-hash = "06b66179f9f0ec9cf2c0ef9cd8b95ce89a30c5ecf46d77083c1a993b13df8ddb"
+hash = "ecc8e0c65ae4c055c2cb7b61bf8316dcb4b6a7186451b79834427c2804296b60"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ad_astra~venus_orbit.config"
-hash = "08ec8dc0d4721f3c3ed985d4df5b0cebad4466d692f19e2fc49dda8eba87e42b"
+hash = "e93ba6825699c8dd2ae72661d7831531f022771b36aaae1c7b8a0677fce3e116"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.ae2~spatial_storage.config"
-hash = "e8a2c3900861875e13b12faf4b9caf584b33575a460ea3922490a23afba52ee9"
+hash = "91da32768b1f78c09c4c6a12aec9d7f0e409520aefb2e2e24f962b8ae89fa58b"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.default.config"
-hash = "abb282bafaa507b40bc27557af455eda4da8bdb1700df78f5175d542f81e68b6"
+hash = "981800c7dc796f84d0d633a8a9139cab39a953e5609cb704e5205370b91972f4"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.global.config"
-hash = "3547fa3cf5b89f1b3c39d3f01de91ca83690b85fd14232fac157da682e1a527f"
+hash = "ac7e9e1562b72198a50c81ed8455cb721e066bdae40e7632e2c8f16631cbf679"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.minecraft~overworld.config"
-hash = "1ea126c04fa1937e2b6bdd8fb2f8bb8ddbc76a80bd4317b2408304b48aade0ff"
+hash = "5889d9668d8c177c9452279a3fe00d02a7f30ed375b892d0967dc3b34c551674"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.minecraft~the_end.config"
-hash = "963a5ed825dfd9025cef9178856cc980512ebfd1aee8f8c3dcc307db736b5f10"
+hash = "23f21ebdb00795abc9f3ee83b67cc661c364f3c892aa24a99cf151db222baa6a"
 
 [[files]]
 file = "journeymap/server/5.9/journeymap.server.minecraft~the_nether.config"
-hash = "450466ae8fdc8039dd33192fe52f9a7595824cfe0cd48fe1c689c02a93d1c5a8"
+hash = "152854ecd6ffa3516be63345ccd6c39ccf05d242774a4de0e937821425af8bf2"
 
 [[files]]
 file = "kubejs/README.txt"
-hash = "02d6feb3afe1d9c96e137f8baaa71de982f1af0a2b37fbcba73f34ee59ebbd4d"
+hash = "9c2e224068560b5942f4a0a9fe8a54fe7382dbc37c36043ab402a0ceecc259f6"
 
 [[files]]
 file = "kubejs/assets/astralfoods/textures/item/astral_sauce.png"
@@ -14358,7 +14382,7 @@ hash = "2c621f408f8efbb495530c472ae895d50f9aadecc2ce716653fb47ffedbfaa81"
 
 [[files]]
 file = "kubejs/client_scripts/hide_from_rei.js"
-hash = "21c3861c514ed332ac5fcbf4971af6a6ff5b3977578052bc07dca277b0d2c1e1"
+hash = "ed28902da60f72c1204fcd2e2d4953064b3397b0bbed2d4816e87cc87173751a"
 
 [[files]]
 file = "kubejs/client_scripts/ponder.js"
@@ -14402,7 +14426,7 @@ hash = "8b6b960b4e34cd99a95305bc24b06a626640c0451baebbf7ef05de5a74a7734c"
 
 [[files]]
 file = "kubejs/client_scripts/ponders/stone_growth_chamber.js"
-hash = "62d5831c4b67ec2ebf0e12ace21243b51e7f3f300fe640890a534373696a842b"
+hash = "ac782beee0075b1ea1d607ee65fb3f9e96a42ce2fa7ab4ebe9efed27b9fbb808"
 
 [[files]]
 file = "kubejs/client_scripts/ponders/stone_growth_chamber_dummy.js"
@@ -14430,7 +14454,7 @@ hash = "cdc1eb02684b70f15631ea298e5094dad4caf6e54e043b594163650ea9c5784e"
 
 [[files]]
 file = "kubejs/server_scripts/Bloodyfile.js"
-hash = "7936a3fb149726799bcf20425fe3d66e71feb3287e77f9e7a8148f61db7389b7"
+hash = "8c5164f2a71800f6689566fa863ed2145b2d48b0c4f172a03208ff97faf47c06"
 
 [[files]]
 file = "kubejs/server_scripts/astral_generators.js"
@@ -14454,7 +14478,7 @@ hash = "cd5c8ccbcbb6fac0913c504b2241f361f6b4b8f422111c934636d101732604d4"
 
 [[files]]
 file = "kubejs/server_scripts/create.js"
-hash = "264757776445b18ef212cecb47a7221fe016b8df4b672ed1d635a66506f371f0"
+hash = "032598fad738b846fe4cb64720e5b26930adfc597d8ce115303ad9cce2a84bb2"
 
 [[files]]
 file = "kubejs/server_scripts/createaddons.js"
@@ -14462,7 +14486,7 @@ hash = "3d25fbc7eebba3b3fc689af80450025e75e29c825e16d1d1266c1da2b578051b"
 
 [[files]]
 file = "kubejs/server_scripts/crushing.js"
-hash = "3c02809f030476b03d0e511077311660fa95dcf6a6e4846ab72ea009c96a9ef5"
+hash = "24a8bcac1a1a19feefd22ee89a0c58cd92056f662ca4312a75c6bb8bdaacebb2"
 
 [[files]]
 file = "kubejs/server_scripts/deathofinfinity.js"
@@ -14514,11 +14538,11 @@ hash = "1becce5642c6ca74f664127d62e3039cec9ac69a95b0e0f650113cd6fb56d393"
 
 [[files]]
 file = "kubejs/server_scripts/removals.js"
-hash = "03de3d4d13b3c51b5cb77e105927b0a40cb7b44eaba5b1f0972be87fb158277f"
+hash = "535c890cfa9b6daebab3fbf19c9b833c6da7fae188a1f76ae189f92ba4cffc17"
 
 [[files]]
 file = "kubejs/server_scripts/replacements.js"
-hash = "fcf4d958a18f525d25a18eec47865bdf9557b48327e649c1be00e322a65ba7c0"
+hash = "f14fb1955c72f515d774fa3cb10dc1e3c71f2480a91e999469ade0683ce733e9"
 
 [[files]]
 file = "kubejs/server_scripts/resourcegen.js"
@@ -14530,7 +14554,7 @@ hash = "b14d492175c12c237a35159c6621010426d5249fd9720b100ac2e73d8d35fb7b"
 
 [[files]]
 file = "kubejs/server_scripts/server.js"
-hash = "46b742c9197947dd5dacaf87fe50e156ede72885d53a022b68907ec51692cfd6"
+hash = "7a51574e39433779eb383e3453ca3ab15cb4983cd11aaf0a804776695851ab04"
 
 [[files]]
 file = "kubejs/server_scripts/sheets.js"
@@ -14542,11 +14566,11 @@ hash = "5240a76f5aeb7e51e0ecbbc98a404be5cc5228d69be5f07cc05b789efc2bd0c5"
 
 [[files]]
 file = "kubejs/server_scripts/tags/backpack.js"
-hash = "c6ac962dcbe0df6b629108be12d9b0ef5c7ec7d2fcfccdf7c53a30e89c8ac266"
+hash = "7880a338890070cb09d6c05f7d20d48c62e5bdffc488ad1225117d358fba24ef"
 
 [[files]]
 file = "kubejs/server_scripts/tags/for_recipes.js"
-hash = "94319f8810850828568d18980ab4026bfa87405b64029211d1d2b0afa91f0479"
+hash = "6699846e21add4567812240e8c7c430a28aee690330eec0a6d1dfd6018db00f4"
 
 [[files]]
 file = "kubejs/server_scripts/tags/graveReplaceBlacklist.js"
@@ -14558,7 +14582,7 @@ hash = "3d0d14d9f4dc930b87c4a49be8411c63b9a6e871acef359b8d5aec0098bb310a"
 
 [[files]]
 file = "kubejs/server_scripts/tags/wrench.js"
-hash = "393073dffdcfaa332d714a804f636cd5bc5e1725228f7f7c580097b305896bf4"
+hash = "1b2f0eb8e80cdad4cd17c2c2176eb285b3734ceefb55b0b6f55ea3add16caa7c"
 
 [[files]]
 file = "kubejs/server_scripts/tconstruct.js"
@@ -14590,11 +14614,11 @@ hash = "fe2d692cf4620a48e397f7dbef5e96de072edaf77240619df61bdc02d12fd62b"
 
 [[files]]
 file = "kubejs/startup_scripts/item_registry.js"
-hash = "c9534c8451f4e266b328e99d8cb275e17620a2fe7f017ea78dceec6e34f3b13e"
+hash = "063141897cb63795a7d88e3889e67ec98e72f2b5907b228c6b8b835f32dbd58d"
 
 [[files]]
 file = "kubejs/startup_scripts/item_tooltip.js"
-hash = "780bdabb3302f402bb521643065bd0487ed4a170d5907d6c6841cdc037e4b9fd"
+hash = "cc43a6c1f69d5d8cba9f54d6e82497507e95af3800a995995edc6708a8ab196f"
 
 [[files]]
 file = "kubejs/startup_scripts/startup.js"
@@ -14606,7 +14630,7 @@ hash = "82b1cf183cc913dc55965bef2bfefb8cb0c510e42eadfb43f41a52c235121c83"
 
 [[files]]
 file = "mods/ad-astra.pw.toml"
-hash = "27e4e6741ce59a7224fb5ecb5b3772de3ac374d6082309ecc27c83e58f8985eb"
+hash = "61ad3509475357bdf231eae841dd1d36f4621c94eb4ab745ee5acfd118043220"
 metafile = true
 
 [[files]]
@@ -14626,7 +14650,7 @@ metafile = true
 
 [[files]]
 file = "mods/another-furniture.pw.toml"
-hash = "7b699d0e627afb97f4c12c339a7d40152ef4934b5a50e3f477997ba777be53e4"
+hash = "d7af7b14e795fd981fc3f0ba5eabca8eb9ff9bcd2b6c473978b5b3336566e413"
 metafile = true
 
 [[files]]
@@ -14661,7 +14685,7 @@ metafile = true
 
 [[files]]
 file = "mods/auto-config-updated-api.pw.toml"
-hash = "206361fc4ab49417af286176c7428fb755a3b471cfe1e8bc42987faece105a40"
+hash = "1b4d333af405a9f2b1efe24be61b1bc3ac277c15574845b7d8d9623e4cd6dbde"
 metafile = true
 
 [[files]]
@@ -14680,7 +14704,7 @@ metafile = true
 
 [[files]]
 file = "mods/badpackets.pw.toml"
-hash = "f67a1a6fb0a835bed4ec0e6a7908e20bfcd0d4ba3e15553c78fcd1a5210926b5"
+hash = "ccbff1ee81fad90a0db944996bc864b7de363e190bebbaad3c39d25bff32772e"
 metafile = true
 
 [[files]]
@@ -14700,7 +14724,7 @@ metafile = true
 
 [[files]]
 file = "mods/better-combat-by-daedelus.pw.toml"
-hash = "f10ba4e03e49bcbc77699cb1948680b2346a135d21740e5f42bbbf5b9f77720e"
+hash = "ad8985a91d0699d7c54c0534921c49f0440c29bd6c075f6bc8714f014de49c78"
 metafile = true
 
 [[files]]
@@ -14710,12 +14734,12 @@ metafile = true
 
 [[files]]
 file = "mods/campanion.pw.toml"
-hash = "fa8cbac8e9175b6e6fb3494f16006ecac48dbffa30702672ff3b1539adbc43f1"
+hash = "2f113561faf7fdae6963be8a7523e044b95153e19486bc83f8b254eb7c8c028e"
 metafile = true
 
 [[files]]
 file = "mods/cardinal-components.pw.toml"
-hash = "ac1d55fcc8a74f5483e82fc7a931244164a426446bc9f9db2c6b259252a66baa"
+hash = "1c39c4deccba7fb27fddf627dd42b9ac3dab663b61fbb196237b74f7455ef410"
 metafile = true
 
 [[files]]
@@ -14725,12 +14749,12 @@ metafile = true
 
 [[files]]
 file = "mods/catwalks-inc.pw.toml"
-hash = "f37aadf2df91c294b4a4e5572172f9513b2356cffd294734dda57822da394cab"
+hash = "7e688542cdff8dbae1e392c868396f2256c77b0c0bee80227779049657244229"
 metafile = true
 
 [[files]]
 file = "mods/cc-restitched.pw.toml"
-hash = "d2503c3614f53510e8e9d2ad3d8f63dc18cbf26636ee9b6b902a0058427b28cf"
+hash = "f6b0ad7d1d143135d88ff73fd3468d23df10dacb3b9bbe5af89ee7ea9520092f"
 metafile = true
 
 [[files]]
@@ -14744,7 +14768,7 @@ hash = "9f71d97edb6a2103d63c08f852fadc8329d211cfcf2696bdb2d36b2ff2fbef90"
 
 [[files]]
 file = "mods/chassis.pw.toml"
-hash = "4fffe995344aa29686e9da955f5ccc5df20c99a9e4c3b82464a1e7b5d2a539f9"
+hash = "7f3a288e12348c746317f238670c82d28e4035bf07509d9c2a66af98bc9165a2"
 metafile = true
 
 [[files]]
@@ -14754,12 +14778,12 @@ metafile = true
 
 [[files]]
 file = "mods/chipped.pw.toml"
-hash = "676ae368a301b57ae5444354b418f2f24a10da586825f6789090aa4b119a93e4"
+hash = "209308ba3a0412e03661a269254970d0f281d6427fbe0b1ee777776103b5ea75"
 metafile = true
 
 [[files]]
 file = "mods/chunky-pregenerator.pw.toml"
-hash = "e31bacd941856b7771b962683ec15ec9f0f062d88be2ccc73c64eb77f7e70ce8"
+hash = "6a36ed3668b811936c52bc942a2e34a1961d32350143639b8c518a960c35ee56"
 metafile = true
 
 [[files]]
@@ -14774,7 +14798,7 @@ metafile = true
 
 [[files]]
 file = "mods/clumps.pw.toml"
-hash = "5a0329070ef3b261efbdbf488638661e650c67594b1f544c52dec2a84fc10030"
+hash = "b3bd65286534a16a36449bed4c1ee52994707ac097741e8fb6d115d71c0882f3"
 metafile = true
 
 [[files]]
@@ -14784,17 +14808,17 @@ metafile = true
 
 [[files]]
 file = "mods/companion-fabric.pw.toml"
-hash = "ed4ba0e16335a186ff3b2f2a4a19ba48c28c73ee5fbeb747d31b6bcfdf235520"
+hash = "b10bf14821cd75e49ec14a42742b1b6bfac732378ec9d055f1f3b984f60ebb68"
 metafile = true
 
 [[files]]
 file = "mods/completeconfig.pw.toml"
-hash = "ea83006cb153f3bbfd35d0e4574bd5c5ee444f2c8c718035f297091b00269a68"
+hash = "4d8bb1a41cebfee0cc1e79603ac0f03b34165df454a21f6d51615cdf2c402f2a"
 metafile = true
 
 [[files]]
 file = "mods/compressor.pw.toml"
-hash = "bac9f4a9e82d0be5db577568f7530e49acabed42417b6a73a8bb1bb7ae729741"
+hash = "0c35d9f27a66b32d716864f4a57ff08d5473be7558dea4172ec29c565f97c8be"
 metafile = true
 
 [[files]]
@@ -14814,7 +14838,7 @@ metafile = true
 
 [[files]]
 file = "mods/cooking-for-blockheads-fabric.pw.toml"
-hash = "47bc301a9d6eab57e4e71763c88ddde5f37f3b8464c750d355b8873d594c9ee2"
+hash = "885dc46bf3e651564cd57fdcad4aca8af122140549d6255ab8d9b7987bb33a43"
 metafile = true
 
 [[files]]
@@ -14859,7 +14883,7 @@ metafile = true
 
 [[files]]
 file = "mods/ctm-refabricated.pw.toml"
-hash = "62ded82bb3d72667ba403525e73c587c73a757929622094bb7fec7bd521cc62d"
+hash = "6d02b5be176d9f557f43d0faccd5c837b2d1cf4be70c5c3962c2d1f69ed19fb6"
 metafile = true
 
 [[files]]
@@ -14879,17 +14903,17 @@ metafile = true
 
 [[files]]
 file = "mods/datapack-portals.pw.toml"
-hash = "9f60a17bbc39148016d6d7e916b0974022a67e5769e815a4c6fb5392e7a83cb1"
+hash = "e85182af356ce7c7d513008b3d76935970b5c7a5d611ec7729964349bf0d5930"
 metafile = true
 
 [[files]]
 file = "mods/daves-building-extended-fabric.pw.toml"
-hash = "b30e38e1be28e02241d36903ce9fa2001ab5b8068fe2521539e8258cb4f505be"
+hash = "cb3ad2c44dc94f8d628e867e3d28ae74773d85eb89be3173bb6776c045f632e5"
 metafile = true
 
 [[files]]
 file = "mods/debugify.pw.toml"
-hash = "ed245958a858e8a3903a98a58924772fcbbb4ee29f9171dc9b4be61f71f86dff"
+hash = "855d1b2db892fd3b89064abfc4c9be1cf32546ef6484bf256e0e895ddca8500d"
 metafile = true
 
 [[files]]
@@ -14903,7 +14927,7 @@ metafile = true
 
 [[files]]
 file = "mods/drink-beer-unofficial-clockwerk-edition.pw.toml"
-hash = "932f8d17309e17997060d6507ae03ef562296186209f8b23ca03e16b0bc3e841"
+hash = "625636361b8f0bdbc348ecece36d8f0beeb8599bbde4eaa495ca92d93bdd6d13"
 metafile = true
 
 [[files]]
@@ -14913,17 +14937,17 @@ metafile = true
 
 [[files]]
 file = "mods/drp-global-datapack.pw.toml"
-hash = "40f2cf6d79226144abcf3f94dd24723c9d7d5d8714f4fc42bfd24d31c1df73a6"
+hash = "1af38c7c7120045a868000476f8b75a766e57e4c07b5f315fb112b8b98e0dd6a"
 metafile = true
 
 [[files]]
 file = "mods/dustrial-decor-fabric.pw.toml"
-hash = "a702c49e95820c4325c62cb43b4ed23b75b3cce65920d893f392d4120280b3da"
+hash = "a76f48e1b719fb06b5a340119ca0cabadd208c0a410a65c685537048cbccdf73"
 metafile = true
 
 [[files]]
 file = "mods/ears.pw.toml"
-hash = "9d9d729b193ac1dc7c3d3e62412ec45b953619bcf0f72628294e83255c879bdf"
+hash = "ea7923d568fd52277a91ddf2f2219096363920c437a92b45332f90499d392faf"
 metafile = true
 
 [[files]]
@@ -14933,7 +14957,7 @@ metafile = true
 
 [[files]]
 file = "mods/environmental-creepers.pw.toml"
-hash = "b1eff587a37f4725cd0cb8b461f6e775113f74c5c8798dbe95b8ab4cb8eb1e35"
+hash = "0e183d62812376db7cd0acc0d6d13cd30896eb8cb95359ecd4506baf2345bd0c"
 metafile = true
 
 [[files]]
@@ -14943,7 +14967,7 @@ metafile = true
 
 [[files]]
 file = "mods/explorers-compass.pw.toml"
-hash = "0910a3283eb049bc09df76dfda2bd98c25ea47aac549253cb59606bd2de44348"
+hash = "c1c623aafc26dd429edea1c6b814c766e078f31bf73a0abd7b7ae3ef79b4aef3"
 metafile = true
 
 [[files]]
@@ -14953,7 +14977,7 @@ metafile = true
 
 [[files]]
 file = "mods/extractinator.pw.toml"
-hash = "3ea6037b906a63d5efaf02fb82dfb3de460b84b681cd54fa3e7a70335c46ef47"
+hash = "d612b926e281e20031f6b8be5c474ee00dd016e3ad61677a8671abd9b2b1a13a"
 metafile = true
 
 [[files]]
@@ -14963,7 +14987,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-disable-custom-worlds-advice.pw.toml"
-hash = "f515cc1518e32cd4ebc4a248bb532b4c03f9521bbe4d7ed78a2e97ab5f83b210"
+hash = "bb98cf750ce0ce86685962fc5a14d4a44a0158b26c359c43ab4d84a351389f02"
 metafile = true
 
 [[files]]
@@ -14983,17 +15007,17 @@ metafile = true
 
 [[files]]
 file = "mods/farmers-delight-fabric.pw.toml"
-hash = "3e30af5688f6ad714252b4eb8ca621169ad5bdc7f9ad5b4e4e52f5d679052fd0"
+hash = "cba67ab33c34f358022f9ff05c67b05ce6980504a2e8e62f5967b06ab200dfe8"
 metafile = true
 
 [[files]]
 file = "mods/fast-furnace-for-fabric.pw.toml"
-hash = "05cd70e8c17f591494e544134dd863f7d93dc8febf382a14e41cf1aceb582c49"
+hash = "c05c9c03723f575633b45e75086cbe5b76467d7107e19a546ccd3c1d4bfcb2e1"
 metafile = true
 
 [[files]]
 file = "mods/ferritecore-fabric.pw.toml"
-hash = "ab5bdccea6fa2af261aad860f1382ef41a395ad85ae1e59866600fdbee7169a2"
+hash = "db203da9e9d0cea7480422f1df91590469609952850fe575195166e13778dcf2"
 metafile = true
 
 [[files]]
@@ -15013,7 +15037,7 @@ metafile = true
 
 [[files]]
 file = "mods/ftb-library-fabric.pw.toml"
-hash = "77dfac340bd10dba36e5bfa277872cfb7a2525de3374a7cefe4c1bbf3274a633"
+hash = "c14219550a099d552478268963134a26aa6b905024f2cb94376c29d9c1174c74"
 metafile = true
 
 [[files]]
@@ -15028,12 +15052,12 @@ metafile = true
 
 [[files]]
 file = "mods/gearreborn.pw.toml"
-hash = "7781e7c96a7407e0fea6e942efc5472748dc36925dd83a662bcb82bb11a1f6e7"
+hash = "45f5ae12daf467ea3aaed6f030d88942f49af7430cf9db82be3631c286a7e64e"
 metafile = true
 
 [[files]]
 file = "mods/geckolib.pw.toml"
-hash = "a2bb46e1e29404ec1cbd4e1e310ff3516b4e8e421d890ef9bd404fe96e4fb8b2"
+hash = "e7af930df3bb9a7fd478a239e59c1c06bf71415318d3b362eb590faeb5afd80a"
 metafile = true
 
 [[files]]
@@ -15043,7 +15067,7 @@ metafile = true
 
 [[files]]
 file = "mods/hephaestus-fabric.pw.toml"
-hash = "c179b53cbd6aa283dbf1b270c06e7ecd399baf983da37be81bdff91bfca126c1"
+hash = "81d4d7ec2d3fea37a07489a74331d8838943e26ee568d64df8b96344aa127134"
 metafile = true
 
 [[files]]
@@ -15063,7 +15087,7 @@ metafile = true
 
 [[files]]
 file = "mods/immersive-aircraft.pw.toml"
-hash = "cd72c238364b2be0d33ccdbd9aa0c56b3ce877d87b9d6f7544b119bcf28ae189"
+hash = "6969d3117e8e5419626b076f6ba90a1afaab386e2b2fe5195df41cc5660354fc"
 metafile = true
 
 [[files]]
@@ -15128,7 +15152,7 @@ metafile = true
 
 [[files]]
 file = "mods/krypton.pw.toml"
-hash = "c6ae545188ed3969654e103c91906072165883fed71374f48e757f5206c672be"
+hash = "7e9dfa873d3d57d7895d8aef7d731118b7a686f4b08e1faaf41f589cbb640431"
 metafile = true
 
 [[files]]
@@ -15143,7 +15167,7 @@ metafile = true
 
 [[files]]
 file = "mods/lazydfu.pw.toml"
-hash = "eecd7cc24ff532915e059be21ff677a912e32c4be1409199ef5cd87c39139c85"
+hash = "d28c0cda8936121f500ac0fc5a4b21671a9ad1146f5718b1dc9b3a61196cd2e4"
 metafile = true
 
 [[files]]
@@ -15153,12 +15177,12 @@ metafile = true
 
 [[files]]
 file = "mods/let-me-despawn.pw.toml"
-hash = "5b9275f6c1ccfebe010a2ae99c6806df83f3b427f0f401fcbd83f4d14218e36f"
+hash = "36720ccbc8a35fbf70e765a0cd3524f62edeb34360d79b4150ee659c0405e7a1"
 metafile = true
 
 [[files]]
 file = "mods/lets-do-wine.pw.toml"
-hash = "1ef357c492e335b52b6f05b7fa2dc9d484d54f7ff118a35d010022bf8d85c26b"
+hash = "2498f51f3de75dd076611950ea27bef3f1eb227819d8c0dfbb23381ca811c4f6"
 metafile = true
 
 [[files]]
@@ -15168,12 +15192,12 @@ metafile = true
 
 [[files]]
 file = "mods/limited-chunkloading.pw.toml"
-hash = "c669393647d2105aa302b8cf78468b4707d4118bbe4aa9a43068627f08c35184"
+hash = "92d5b23b4161774425f2168f6839ea2e8b7fb9e3e34b0c3e36e091c8311034c1"
 metafile = true
 
 [[files]]
 file = "mods/lithium.pw.toml"
-hash = "2ae15f4d0ec26381aa1831d19fa8a03f2c7e324587bdf79341684dbf44ca70fc"
+hash = "a2244caa24a99574de986f0d06c3238bdc937946dc82eb84030f1ba4859f88bb"
 metafile = true
 
 [[files]]
@@ -15188,7 +15212,7 @@ metafile = true
 
 [[files]]
 file = "mods/mcdw.pw.toml"
-hash = "8c8c54a882bc0c374bf2c5a956d97da1a186c079836a38d0da787c3f0cb00f6e"
+hash = "6185f7193e5be3ad3ee162adecedf134efca4fafdd2468e800354abf6e28fe23"
 metafile = true
 
 [[files]]
@@ -15202,17 +15226,17 @@ hash = "a9fadc6d369e6bbfb10eab4c00780c3295292c634b6551d2e1e2897ec38b63ab"
 
 [[files]]
 file = "mods/midnightlib.pw.toml"
-hash = "e67c7e7feae9476c3340ebdee78bdda6f2e5867091f8563e23f5dbca5726c9cd"
+hash = "9005e9810db0c3e4280572e840db025717b15520d0443181a962054c8712e205"
 metafile = true
 
 [[files]]
 file = "mods/mixintrace.pw.toml"
-hash = "fb174b578a290004eb778c860e4fc46eb263ee5a92c0d5729a0670d130efbdcb"
+hash = "f67c55c784dd43224706708e28c4af3bc4a1afe492a8b700714de355ff622b4e"
 metafile = true
 
 [[files]]
 file = "mods/mobvotes-sniffer.pw.toml"
-hash = "a956f8a6f080183a76546824e85dd152bb4545f5bc9f4370dcd8d88a0e679b72"
+hash = "276d368cb39572fe09d1c50d97aa21557cfb969c098e5902d2cf238d177d60f1"
 metafile = true
 
 [[files]]
@@ -15232,12 +15256,12 @@ metafile = true
 
 [[files]]
 file = "mods/mystical-oak-tree.pw.toml"
-hash = "899cfc45762977c2158aa5aee9910563307f433ed882c8d79902a231ebec5043"
+hash = "8337edce42c51422dd78b20800e651cd6ddf4ca7e728711e297b02fa2b49feee"
 metafile = true
 
 [[files]]
 file = "mods/naturalist.pw.toml"
-hash = "38f1a162b1bcafdd3121f813da718002feb1109d3938b7342aea24388b2e84fb"
+hash = "19933ba2eddf9942bcdb564ed797c88bd1d5865b7e38f0ebd7b287ebfee8ff6a"
 metafile = true
 
 [[files]]
@@ -15252,27 +15276,27 @@ metafile = true
 
 [[files]]
 file = "mods/numeral-ping.pw.toml"
-hash = "1329d5154e720a455a772bca77f6ba5beb3e24aac6da54336635093c54731040"
+hash = "b149c02328a369e847853eb0d807391de45fc516c3f86e10b1ebae8faaac0d9d"
 metafile = true
 
 [[files]]
 file = "mods/observable.pw.toml"
-hash = "9d51635f5c2b3545f40f05349bc50921a67aaa79f5b7b9b138a2e8e120f81758"
+hash = "a72510f2e1b70dbc67312261271f5e5dae296d38e21a26df036afa9acf4e2586"
 metafile = true
 
 [[files]]
 file = "mods/packages.pw.toml"
-hash = "cd77c2b2a9e9e5ae7f752f9b8c2c729f8edb3a750488ae33dcbb3fb75182db97"
+hash = "c043afbbea4781db4a1b76a528752aeaeb01a71379edd068e9332dfb51e81652"
 metafile = true
 
 [[files]]
 file = "mods/packed-inventory.pw.toml"
-hash = "a39ddc7c2cc2137837b4a850caaa3eea3faa85ff126fe49f77479e2fff1bb6e6"
+hash = "87f94931111f9e6f20502a4ac28f22e76ac1ceba00c28c0c0f14cef3222ea491"
 metafile = true
 
 [[files]]
 file = "mods/passive-piglins.pw.toml"
-hash = "6dc9fdd3a284a409bef13e39135b74aa3808e2cf2e7a1cbff44ab47582757971"
+hash = "1c2a01564cb9988b54cfc029fbd0f7b3c7aae9c055a5fd62b56c7534153316b0"
 metafile = true
 
 [[files]]
@@ -15287,7 +15311,7 @@ metafile = true
 
 [[files]]
 file = "mods/phonos.pw.toml"
-hash = "7075a5a4c5f4670cdf53b49ff2509461560638639a8048e07f6406662a085016"
+hash = "600d90a57d30ced751ca67d4fc6cd1c89cf455e2b2eb64f2fbb645c4a4b71f31"
 metafile = true
 
 [[files]]
@@ -15301,12 +15325,12 @@ hash = "ddf51bb0a38783af1e84e4987cb29a19164cb7f7891886d04cf7730f8d67f22f"
 
 [[files]]
 file = "mods/playeranimator.pw.toml"
-hash = "d116a63f0fe2a285642c79e592b4999aa8595b8fa7ffdcbe99b802642862ad53"
+hash = "f5e94ad8612424433f6d62c3d9461b17999cac4597105d4ad8be5eaa713a8e13"
 metafile = true
 
 [[files]]
 file = "mods/polaroid-camera.pw.toml"
-hash = "d99f2b36c8213bef417357a094bf248abd09b13616ac8ff41a86ae1ad5c48919"
+hash = "b5b851e036e29cd4d3d6a7a84f2cc3d2be693038af7cf346598d5153a5496d17"
 metafile = true
 
 [[files]]
@@ -15346,17 +15370,17 @@ metafile = true
 
 [[files]]
 file = "mods/puzzles-lib-fabric.pw.toml"
-hash = "ad0d1bc674e64d91287c2dc88a039a552e02145d0517913540c8cda08d8d0180"
+hash = "addefb4d5297db1d4d7569620f879da9de64cb0046924b0c1425264c6963c2ce"
 metafile = true
 
 [[files]]
 file = "mods/quarry-reborn.pw.toml"
-hash = "91bc7f3030de5f3874c1a11ebc5e3172714066155832a111c9d1203e10a42a8f"
+hash = "340bab35ee28eb2dc80a7ac94bed6b863bf27914fcc40aeed2018b6c6f645a29"
 metafile = true
 
 [[files]]
 file = "mods/quests-additions-fabric.pw.toml"
-hash = "8282f94d046c4582043e5eebb319ee677fb883de65375729e4da91606daa09c0"
+hash = "070cf9fc0092178c721aeef8ac3e250b21bb2ebec7f009021955fd145397a311"
 metafile = true
 
 [[files]]
@@ -15366,12 +15390,12 @@ metafile = true
 
 [[files]]
 file = "mods/reinforced-chests.pw.toml"
-hash = "9ccccff444f39afc49b78321746cf332655f4cfbd755bc14cca86c13cd5f8270"
+hash = "0deffda63aecb9dca1a30da1dbc6d0d5de342cd9f02fe7a156726373c1a76571"
 metafile = true
 
 [[files]]
 file = "mods/rhino.pw.toml"
-hash = "6740d0d510f08d76278778a4bedcf4c356ddef3b2bff1232245088f7d9e5289e"
+hash = "ce40f8922fa10946782f1bab0697b5afd366fffc641e078b1bd2fcffb8db5d66"
 metafile = true
 
 [[files]]
@@ -15381,7 +15405,7 @@ metafile = true
 
 [[files]]
 file = "mods/searchlight.pw.toml"
-hash = "c80cf691a2e2c1a203a25b533ad31b56ee36aa5b3f84dfc544138e9abc2590b3"
+hash = "f81345d6ba552bd53a82d7f75237973687875d3f95a17195cfdb315f3aa2b4a7"
 metafile = true
 
 [[files]]
@@ -15391,7 +15415,7 @@ metafile = true
 
 [[files]]
 file = "mods/servertick.pw.toml"
-hash = "187aa54c7be7a597bb2daf9bd313773b7806d1eae3f631e92c79cd3021393929"
+hash = "90b6c7711ccaff0e56ecff820125d2085a8d822468abe2616d78be1d869fc344"
 metafile = true
 
 [[files]]
@@ -15406,7 +15430,7 @@ metafile = true
 
 [[files]]
 file = "mods/smooth-chunk-save.pw.toml"
-hash = "43dfd36695cabbdf2f1134ff1fb8c7ca0c25da87ea106dacce1b2c74aa97b56a"
+hash = "7b8af3407ac102758df352d7886ca512f6f8248a9a86c379418ae52ccdbe4e1d"
 metafile = true
 
 [[files]]
@@ -15429,8 +15453,12 @@ hash = "c663a06590fdf49af5432b627e1bc2833d9873cfaa42d11e7438dfcf6447b0d7"
 metafile = true
 
 [[files]]
+file = "mods/starei-1.0.0.jar"
+hash = "339cf73aac5c581570ff5fba960d9627595109c6121a5324e2d3c3b4d3509f82"
+
+[[files]]
 file = "mods/starlight.pw.toml"
-hash = "374fab5e99e833ed1198ee9007ff4990fd237f2aba0fab35a7f8461d5f96cae7"
+hash = "568f9b7aa55b34c6ea913028e5145c3eaff3af4395f3aad3ddd3d26432817078"
 metafile = true
 
 [[files]]
@@ -15440,7 +15468,7 @@ metafile = true
 
 [[files]]
 file = "mods/subterrestrial.pw.toml"
-hash = "1e233e4fda57f4440850ee4c7c22ed4f474625ceba8855b342a45d46bb305e54"
+hash = "bd9bff2c92b59469afa258a954b240d3448a5f7fb9517e768d31ded2f0536086"
 metafile = true
 
 [[files]]
@@ -15455,7 +15483,7 @@ metafile = true
 
 [[files]]
 file = "mods/techreborn.pw.toml"
-hash = "e7241562e60cf7f65c775c2b5ca0ca35d1fdefda350ea05f8dec097456721f6c"
+hash = "3749c2284f10d3fe3248e3bf67f0c5b884791734fcebc5e7de122f1837593d76"
 metafile = true
 
 [[files]]
@@ -15465,7 +15493,7 @@ metafile = true
 
 [[files]]
 file = "mods/towns-and-towers.pw.toml"
-hash = "b73213b73639f927d93927bfb18c60c9ec69fcf39e77be00d6930271f5bf91e5"
+hash = "48461cc61f38ce81b423b26af07e0b53768b5174bab28aaa0c56f44fe4be1d9b"
 metafile = true
 
 [[files]]
@@ -15480,7 +15508,7 @@ metafile = true
 
 [[files]]
 file = "mods/trinkets.pw.toml"
-hash = "501ac6b921835b49ef1c44af85d75ae9571d892c32cc065a599a4c0151a7d4cd"
+hash = "d31e2c0fcb216081c5d00e830f846af7f1844f97798f6f33d00d908793cc564b"
 metafile = true
 
 [[files]]
@@ -15500,7 +15528,7 @@ metafile = true
 
 [[files]]
 file = "mods/worldedit.pw.toml"
-hash = "ac07b911c33501f0ca86609ce4aa948bfd8a1362d0724503ef5afdf8b9824e0b"
+hash = "30f21eae729a4d302d9e3ed4a16e723d33472fdadeb8b3ce06249941341625f5"
 metafile = true
 
 [[files]]
@@ -15510,7 +15538,7 @@ metafile = true
 
 [[files]]
 file = "mods/xl-packets-fabric.pw.toml"
-hash = "a0afdd70a5ac963ee3b20a053ce7a59b8ff74ba37dd620662b7046511a30e878"
+hash = "82f5b5019c8b0b0c98f11ac2364c7a26592b56901a3c95b11778c36b0bf55141"
 metafile = true
 
 [[files]]
@@ -25670,19 +25698,19 @@ hash = "72381699060101cb6db039262bcea870956d77b81f6d3dbbfcb79755a771c718"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/README.md"
-hash = "9696018f33c73b24a0dc0f83f8937d6d47a03a86c6922761ed51bc95529126c8"
+hash = "3fb99a23c8241bf76232cf8d026b10db26c8c699b92d7244b63763cb7d35c745"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/blaze.jem"
-hash = "dc24001ebc5f7b474faef9641b301d638a3a5c0a8b47d0a44ebff04bf2f86d6b"
+hash = "5bcd1070ce9350b13013cbe182646f72806f269de6d5f119059a3658224b55e6"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/cat.jem"
-hash = "d7683aaa6e8154c0159e3aa44c7d46cab47f009abc984cac349fba3f4ab2b1e8"
+hash = "75ef674ddf91539932b698a8b09cc727cdeac5e8d476e2340ec5e7adad444c76"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/cat_collar.jem"
-hash = "79e977f4e5dc19380af6d9d87621784db893abaefe643289b5b5c5a1607158ed"
+hash = "9734f3a3848a11a439addd3a3495bc322040e4304ed99448229e3826a4751ce9"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/cave_spider.jem"
@@ -25690,27 +25718,27 @@ hash = "883e42ecffa0eee3a330bf7c68af532723e67173f263106542c302beabfbdd6f"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/chicken.jem"
-hash = "8656223ed9a8a2678e6592d724926e2d5975cc73caf27b25a5f3976f17cb2edb"
+hash = "23e03c756a6425f43689525eebb89405606f8b1551d3a8d100fa316959cc0b1d"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/cow.jem"
-hash = "0963d04ae0c759597c3d8c57bd52db663d0efc63cdf054a89a684df88182f46c"
+hash = "e533b060808e958ed62025b306dbacdc3abb109a2e38cc7edef53a6f8255829e"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/creeper.jem"
-hash = "c2d1428114034075c07b9817322fc9fa14bd8e15da552730998124be4e5d40d9"
+hash = "a80e96ace3f8c99c6dcd8c71417e9c230b6867eb4a692463aa5ac43604aa6c38"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/dolphin.jem"
-hash = "d653a7d561c9068c02577e583447e08c8ae66af9b7f1a61a28d972ca853e84f2"
+hash = "733c26932f9832544b0169e662120ffad1d4e1d77689f37f06a8dfbdddf83df4"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/donkey.jem"
-hash = "f61b9b9bea1ab3803956bf9940a4de52ef7b2647f5c915c041184ebccc72c04b"
+hash = "51ca516e274a474fe528cccde257844eeaf7bbce568d249740a7ede65166dceb"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/drowned.jem"
-hash = "87bbdb3b1108ea9e782cf260c195ead824b3206b3fdabfc755c56fd125debf38"
+hash = "154dbfd42d6f783a7668043dca1308c97479dac16b8ef4ed46232ff57e76ce74"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/elder_guardian.jem"
@@ -25718,19 +25746,19 @@ hash = "210993a0bb8fa64631dbd6fd3dc21f16efceaa379f8752dc4ab1e6615375bb88"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/evoker.jem"
-hash = "9315dafd090ca8bb0f167951cba53a759c3c1e030d0e62d7e5c1a75c84ef4f68"
+hash = "31b187309eba0acb5c1c9ffe98099baa3c943ee316e74aa41d6077ea6c9c14c3"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/fox.jem"
-hash = "906fb91c012598e201acdbe0cbb791e118c4b50f5fb78f5ef85d64c12fa03e54"
+hash = "a10cd3960059e843d70a38cbe7393407d51e93abb84c413c125795bc34f36f35"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/ghast.jem"
-hash = "6d03587365709ce3c3b15bda96a5d3eaa3487da5d490fb90eabb86a54f385557"
+hash = "1bab83677c6e51b2584dbf5197aa3406d985eafb32ef720f15aa583598809fce"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/giant.jem"
-hash = "16a0b44c0cf079e7a67730044c5c40d16c56f47b375da65f32d78df5c583764f"
+hash = "544546bcb7fdb580298e06b383588fb1dc60597acfdc1c68300498ce353a1a40"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/guardian.jem"
@@ -25738,47 +25766,47 @@ hash = "7ad5984fc54370fc5d0389c9c96d083713fbe9adead0920a0da8b96a5646d2c7"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/hoglin.jem"
-hash = "5b80234ccea70eba391e54266e60ec85102f84197dfe0ebe2e9fe59f6e21ec88"
+hash = "0a7f87cc8997940bc91607bc3eea5780ca45a8ae38c485bf53609d5e8daf9121"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/horse.jem"
-hash = "f4bcbebebdda6822a3f16d0d3710185cc4ae6d4397a6d53d2a3210870eea4db0"
+hash = "7340c103af2ff2ac5948dd5abbb42e62949c92de030bb1bfe97be46f4af5c446"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/husk.jem"
-hash = "b2be1c2d8e5a449d69a4c43ffd5b9da904ad654650cff63aba610444311e661c"
+hash = "b88573872996fc6ed6750ffd2ec02d39da9d6b5cf49ab54b29914b726812c97c"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/illusioner.jem"
-hash = "8471dd600d9904c7681180f66b367b6728a3c38c66eccd356358232661272369"
+hash = "e6fec2d063f9b54c9630c5c0e48387a20ab7e5695c4479b005e5b9b3fc3ca52b"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/iron_golem.jem"
-hash = "575595fd87a5b25adee538cfb8a86f6e87465a898948a669be9183b69cb816b1"
+hash = "b210c6c3b4928c1c3fb39544f38d05cfdbd9751e24195c6c7483158798d10cf4"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/llama.jem"
-hash = "7be4556d19ebbd165f7262b5ed44e731dc2d47c411be72a1e31bfe562d4494e3"
+hash = "1af6b220fd2e5c651ab5622818809258c90c9169d223e3252009521c50cd6c6c"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/llama_decor.jem"
-hash = "f1a90d3746357ade1f6b9213525a53a41d2a5cd5a99d8c6e8af830fbcf713446"
+hash = "68919cf7e39e4f80b3504be6b67b5f41487b937be90db37965d26728f4a4fccf"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/magma_cube.jem"
-hash = "94bdc2bab8a3048a6798ddbd49f0a4836af52f06dcabc5001e67b198121a29f1"
+hash = "55c1f8370d0ae2046e06d0e2b907ff9b8cc1b22a8e1dce7ee70521124ce2f069"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/mooshroom.jem"
-hash = "ff3655a179a578fcc72aafeb8cf6876e47e62ad661bc5b233bd6e9c44fab4f1c"
+hash = "03a6fd195348ec7c72f94d64fe5575a5df678d01640835fea66c437307cdacee"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/mule.jem"
-hash = "d6ffbdba5b8bf68b392990bd172792e4673b33429a876b319f35edd4e4d2b0d2"
+hash = "fe5a79dcf5357395797db5e2e5a63a78070e22a2c1d1e4f9f82c61f6b6d49dd8"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/ocelot.jem"
-hash = "f8d25f97a7469167dc01221507d3ce8723ab179ca0a5c1921eac3b45af094150"
+hash = "0940cad52c76e44f4846bd9b2317029adae270bb1f64085a91d5bcf81956db39"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/parrot.jem"
@@ -25786,35 +25814,35 @@ hash = "517552dd2bd818a1f9547b9126ed35f04f262eb13914f923a9fa3d9513fd39f2"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/phantom.jem"
-hash = "6f5a837f2f883fc18340f8d894c0ff116a0753f1ebda7d723af370c2ed522a23"
+hash = "2c33aa3abbd911a8ba18385071dfefd2b0228650a7e0da6e9c7f795fab017abf"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/pig.jem"
-hash = "720846dc1a9bfd0d6e837b9f106397bf690e0192413710df50f6e1699224f9f1"
+hash = "94f76f99a7f97c543ff29eaf2f3c41bd98d15610b99030bc369f7048bd9fa410"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/piglin.jem"
-hash = "827dcc0b8f261130050ab5c163672a93c555decd0ad1b40e1f7b70c8b813080e"
+hash = "3986afcf1cd918d75de73dad1b0275548ab4279495ddfd062a1bd2682391d8d6"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/piglin_brute.jem"
-hash = "2bb416364f52a44a7f540069774fdce6bd9d45b1976aa6fdc9db137060be53b4"
+hash = "53904c266e1029995cf0ad7db4a3c31946954c5579a2fafedfc1f567f0e8edf9"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/pillager.jem"
-hash = "b612489f249a3344d83ba9e79fcaceb0ff4882b57f3ce0c36a61b274a5ef44a6"
+hash = "eaefbaa6d71bf0f66a4afff064033afcde10c84812f23f97e281a02894cb75b1"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/ravager.jem"
-hash = "17808f924f4345a24f7d7bd41c3ad540dab94c635c70a515e449c7160c417a7f"
+hash = "ac35efa2cd9677e3ac5280ca7377c196f898b119eeab57f99175e2c74e74515d"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/sheep.jem"
-hash = "875743eb226bbece280523a46222550b43494d40f28379b2d8f9a7ab65894f20"
+hash = "4bf6f11563a1797e8fc529c02d6d51a25038cedf98b89f377e996278a749f729"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/sheep_wool.jem"
-hash = "eaf181c402e415a5c75461490863f26ea6c93bff8f586b1f485c0a9f9fa961fe"
+hash = "eefd5c1c27a6624225a401e92f586bd758a1f2c83919cb5a9c5b37c989199e66"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/silverfish.jem"
@@ -25822,11 +25850,11 @@ hash = "aeff2f7ab8e33bd25b3d7e1a5487aec01baf19b13937c580fb6e2d8ce8aabc01"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/skeleton.jem"
-hash = "a3a455c74ee89bd6d54964f0fc969f1c58decdbd10de8c506a15b549d45d6ee7"
+hash = "9f573db12e1d590cf32075cf37db3702c4c7fcc3deebb024b9ad28ac09036c2c"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/skeleton_horse.jem"
-hash = "f4bcbebebdda6822a3f16d0d3710185cc4ae6d4397a6d53d2a3210870eea4db0"
+hash = "7340c103af2ff2ac5948dd5abbb42e62949c92de030bb1bfe97be46f4af5c446"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/spider.jem"
@@ -25834,11 +25862,11 @@ hash = "9a009c3329744ddc876ae7c4819e9d85a61707eced1341100743e9d139169b55"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/strider.jem"
-hash = "ef83c113b56508298878c5fc53eb5985d7564107a138f43bb62c4d947dc7032c"
+hash = "49acd9bd4e24b752b718ac18198c5f19c2c154786b4d4b56c25105299089b3ba"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/trader_llama.jem"
-hash = "2c9420e72e2ef1109a8cbfa2f749dd7d0551b98cd0069bf8edd13c289c2ce1fa"
+hash = "569b7498a384d26dc8c9c0b27c0d5939c45ff592b66405ecacc1199a651dd54e"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/trader_llama_decor.jem"
@@ -25846,59 +25874,59 @@ hash = "4adb9343e7b52fbfae07c46e76bebfa2d0ddd2ce23b2f9e7a2b3bc3715b4809f"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/turtle.jem"
-hash = "2f6b410f4a82b27bd5c474a25e8b5c4e4a653747d2a442f2ab77d033cefb717d"
+hash = "587702004e882bfdf4a16bd94eadba955d3c688365845d9b0cdc73e98b01a1f0"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/vex.jem"
-hash = "8982c3b7867d85ced3596257769c6dfce8c4144beb34385d7c1602108474d55f"
+hash = "fa447b8a9e33bdb8e0a530bfbe7a5778719adc94795a17cdad7a1ab47a85ca39"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/villager.jem"
-hash = "fcd308e61c811eb591aa77b9675b672fc3885358fac68136bbb6f93648e376fe"
+hash = "92c5a6d1b04cfcc89e16dbaf24e665f55fc5e5ab382cb370bc6aee5989929ea3"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/vindicator.jem"
-hash = "97f8c726d3cce32d5d4f7a33c577487da5fc3a10557ed4d8130fcf9448676f27"
+hash = "3f4ff13c77d382897b781a755f9f74f5d60c1755d9ba9dae7bdafa4f60b3021c"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/wandering_trader.jem"
-hash = "715e8a790da4d2b8a053761ba16910a71368af86304af40e6236c1640e255ff4"
+hash = "5fcf9317bcff5da25ebab61bb4027b28a72773e7b11a9a8fa14023e871be0e04"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/witch.jem"
-hash = "2465f68fdbbd6fdbb0b34f20ded83bdb498505fc552221b453cc1899a212e265"
+hash = "89440fefd8265fef5090d327dc576668fbc56eac099eee5c98256f545ade15a2"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/wither_skeleton.jem"
-hash = "5318579eb8db911d3ccc31cd0df8a5bc7d0b60d0d6e9d29bc7dd00210776978d"
+hash = "4d30370eb8739da5f7727d2ccd6f9c101eb693dd16017465fca472132f290995"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/wolf.jem"
-hash = "5ad7639bdf2091f27f7fde4ad2d789ef76599498ddb66644a014b89f64118f98"
+hash = "539ae706d19180a071fa2951f7669166027b56d65f952c3f58d1810c7e383970"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/wolf_collar.jem"
-hash = "6d7bcba47e4576dad8606980e9a37cb96b03f6930e270dc26c7f5bb042c5dd31"
+hash = "8507bd69622fbb80d468437d431b381fbd1ce6e21b61aec1ce9cf304ec2ac397"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/zoglin.jem"
-hash = "a72fe403112d823212e6884083908b4094d4f1fb43f2a2a9db1416911caeb3c8"
+hash = "56ff23c5c2fed114e76076e3a303021111bf7aa5a0d5060eb20cc05975604a77"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/zombie.jem"
-hash = "69326ca62a06bd366dd8337aead1e4d06ad91aa60f63b05f536cc0ececa68ed8"
+hash = "9bb7d827067fa6f71989f37454089044c72f2bae86fb807e871293ede94c60a8"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/zombie_horse.jem"
-hash = "f4bcbebebdda6822a3f16d0d3710185cc4ae6d4397a6d53d2a3210870eea4db0"
+hash = "7340c103af2ff2ac5948dd5abbb42e62949c92de030bb1bfe97be46f4af5c446"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/zombie_villager.jem"
-hash = "337b3f7954952bbe4f10fdb09b1cf192f0f231a52248f6917fb1411ca93e9511"
+hash = "edce4f7c4855a19bc8abfaba95530b48303f0e11e12832e05ebe5579dce83f2e"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/optifine/cem/zombified_piglin.jem"
-hash = "48db2d84560c8198773493b98fa90514c3ec3e2eccf987cfc486a6120959c652"
+hash = "31f61f81be61195b429860e54f02cfc8eee0dca66b4f6c37483e2e8368a152a9"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/assets/minecraft/particles/mycelium.json"
@@ -26214,7 +26242,7 @@ hash = "4641130a08a1631d53b7cdcda50f305ae63deca435f7459a42c7c4cdcf2cfa77"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/license.txt"
-hash = "0de818fe191bae1cc5731eabed5a22bd4d3b1c1d2979d83d917098d776361b7f"
+hash = "231b27076f97298f4176b19a781196f8af7187054327719ed4285eeae0925136"
 
 [[files]]
 file = "resourcepacks/Fresh-Animations-CEM-fork-main/pack.mcmeta"
@@ -26226,31 +26254,31 @@ hash = "562967b1729d6338f54669b7f403c5445e3546a3ea8eb66913dac01f623b3770"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/LICENSE.txt"
-hash = "9e502ba75fd0fd30cea5497b438a4bc12f07f02bc932a7a6041fd6a18b8f46a0"
+hash = "09ee9e203ad9bb0548ce248e0906ba3215d6feb47e54f02c8fbf82349fe07f39"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/README.md"
-hash = "ae51a160e7194fcb3b6b640b7b61524357c9ac7a3e2390b1fe45d7370d72bc1c"
+hash = "a3ba1637d86cf778bd379195582898f26698bea4b4c47ddd9ab4d325be951602"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/LICENSE"
-hash = "2b25300a4430eeae3ee3a961db698b597611011397748c0f1fa56f9539801a91"
+hash = "7fa32f975f03a6697469a2853c65d5bd4c767dc3e0e5b85f8d32c4814326f8cd"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/README.md"
-hash = "1b48af2d7bb954e6060244af77acc4fb196f8f4f53804c9f13087ed12f79cfbb"
+hash = "dda48a04299ea93e9346c2b5ee2afd7dbb175b914422e041224f10bbcbd74a32"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/adorn/color_palettes/drawer.json5"
-hash = "c3e3e760ad8c93a77a09d28bd2768c7502d9118a3d452bf80cf4908a96e9d698"
+hash = "9157d896bf83a2efd937da5e1a90f4278370537da7cb5810969ef6b5c7e299be"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/adorn/color_palettes/fallback.json5"
-hash = "8d70934e09061264197e27e731eb7110d51908fa86ee966ad474cd69cbf33233"
+hash = "e4076631974d41e68aebc207f5e1f5450a7ff2bf27aaed5c43972dfa513debf3"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/adorn/color_palettes/kitchen_cupboard.json5"
-hash = "2f8afe579fe34df3044179b5d0995df0120a4dbe0e7a9695ad666b0c13bfa57d"
+hash = "e617004d3d6fc4e9143cab581aaa9eab2e0667e7eeefc79e18cbf80c9d177a74"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/adorn/textures/gui/brewer.png"
@@ -26270,7 +26298,7 @@ hash = "437898feb94a59e2ad98fbfe3f662707963c947795ef9dea80c144f17d4835f0"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ae2/LICENSE"
-hash = "39676552fd16d3317f6e6af4cf810778060cda238f75dac9b27c0fcbe848d3d4"
+hash = "1d85626ef75ce27566e00d818619374d1013547e040657b1eb0c56547a6aae22"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ae2/README.md"
@@ -26450,15 +26478,15 @@ hash = "0de4f133ce92b59940e8523e6b136cd0e893221c8be430a9b47a14ff9e8c4130"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ae2wtlib/LICENSE"
-hash = "d61e8472fd606169227d467eae0fc46341256dc54ed05837df050b29ad0297ba"
+hash = "a906c0e6d3427339a7edf5d77fb6bdb1bcc945f046d61f518967332efa1ceba8"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ae2wtlib/README.md"
-hash = "b5f4048dae90bf2facdbda6463b1d805140526fcee9e077cc99d5ea3ecc363c4"
+hash = "91bf4ee134d2c91c98c7ef31240bd8771470e4db0caf5be4434db58ca489303c"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betteradvancements/README.md"
-hash = "062f037196a185f2ccf4c3ed316476b9bc794a19f0d68f313ce3ba5aea225b92"
+hash = "02fc2d48fbdc84e6ff29fec3b1ca61fa06ad0666acba397e5181922a91b42eca"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betteradvancements/textures/gui/tabs.png"
@@ -26474,15 +26502,15 @@ hash = "dc54da13952c013589255f014ee6e47b5264d1845a9e759ce71e8f81de507950"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betterend/LICENSE"
-hash = "1e32b4c725bceab7e91e495bf2848d5d48870da0756f7a92a55e5e479c8529ef"
+hash = "cbd12be92c00bebebce478f81518792a8a13bf00bcef9cdf7535aa19b8d616e2"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betterend/LICENSE.ASSETS"
-hash = "0bde32c0508f16775c7f0074ac0954b514b65f9b44af174e540ee0ab0a2ea5cb"
+hash = "16a0d82a00e08b92cca6a995401d9e15c79c26343b379a27ed5c6750355093c1"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betterend/README.md"
-hash = "61c405a0dec6c76548dee87be472a6ea798d1be2da89f5d302d49db3168efb2d"
+hash = "b9c74709dfdd22fcfffd6034d74bc057c18eba6224f050066599c9f2c91d330f"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/betterend/textures/gui/rei_infusion.png"
@@ -26494,7 +26522,7 @@ hash = "b7a685002f817647816a8270518581da97dc85f7a9f9ace96befc11b2e7afe94"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/biomemakeover/LICENCE"
-hash = "27fc3ee12c53e432a613d6a984fdb31c43aab1c419bae5aa84225bdfc861e022"
+hash = "0509ad2a9bd95352a54e82c827ccbac9fe92564bc131ca97c1c3b1b586b68202"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/biomemakeover/textures/gui/altar.png"
@@ -26510,11 +26538,11 @@ hash = "9e7eba8bd56938c2e33b49d4310b0f94f8b4a9d56bbaca5f721b07344eb7a15f"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/capes/LICENSE"
-hash = "20c17d8b8c48a600800dfd14f95d5cb9ff47066a9641ddeab48dc54aec96e331"
+hash = "7ffe1954587c77dfba1cf8eb9b2ea743671fa6e63f9e7a2f258119d42e14eefe"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/capes/README.md"
-hash = "ecf54529b68720d14f76ca882360b20eb47569a4d8c37e7a4a82f8e030f2b48f"
+hash = "69ce4ad65e9e8823ea86232bef75fbe413fb7bb802f1d6afcfcdf3cff309498a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/capes/textures/gui/options.png"
@@ -26522,11 +26550,11 @@ hash = "33c79c3bf240d5b32586463e737c9726c5ba1bcd628cc3e580cbed0655b507d3"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/charm/LICENSE"
-hash = "75dd194e69478e6b7e26db7713ccb7fa1c5042c43df67194a30adb3d54d68a69"
+hash = "cb46d50680a2378c12578a3ef5295a7298205b35093995003e512d9064720fbb"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/charm/README.md"
-hash = "b618d91a494a57c441a76ff2e32f324e60cca1317512a3e24f31dd1a24f05e8b"
+hash = "c09eb31032d208994189dc44750531db04f6b9bb75f6568cfa03d06c2859ef67"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/charm/textures/gui/atlas_container.png"
@@ -26550,7 +26578,7 @@ hash = "ee2f142e7875d8a3db07bd66a6e0618e7d2aab25a47ca2828b05943f2a80e970"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/cloth-config2/README.md"
-hash = "c2fc9f5fd65cedf935a0cabbc985d6640dafe6bf0d1802728045bb2c1a2cc1c2"
+hash = "448a136472a1234dc898fa56026c2fd26ac5268290f7f81d907a9e7491c43897"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/cloth-config2/textures/gui/cloth_config.png"
@@ -26558,7 +26586,7 @@ hash = "b05bef6798dcb0b2e7ac50250efe59798e20fd923de0144a835447100394b2b5"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easy_villagers/readme.md"
-hash = "1dba89313f8388971a3104ddec249416863a6a43ceadaf41d6aacb946de709e3"
+hash = "63aacaa6e963ed95d45288923545ce50ea257cf04e07ba1538921a4f0042feab"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easy_villagers/textures/gui/container/arrow_button.png"
@@ -26582,11 +26610,11 @@ hash = "2037b5b50526abb19896034d12dd6627465ef67d180d03b58a429a120be0ab53"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easyanvils/LICENSE"
-hash = "1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5"
+hash = "2684de17300e0a434686f1ec7f8af6045207a4b457a3fe04b2b9ce655e7c5d50"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easyanvils/README.md"
-hash = "eb5d98a37e61958d290b7e8284eb4cf426a62c0f5530864704b202273d579e7e"
+hash = "0f44d6bc568ae0b82c0208e04f9eb6143a578e765f79696a10a38ee6dc13211e"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easyanvils/textures/gui/edit_name_tag.png"
@@ -26594,11 +26622,11 @@ hash = "87f36e776bbfe85e5c18f7f67d3b06db3eb50b889170025849bef14274fa1cb8"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easymagic/LICENSE"
-hash = "1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5"
+hash = "2684de17300e0a434686f1ec7f8af6045207a4b457a3fe04b2b9ce655e7c5d50"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easymagic/README.md"
-hash = "e279cb1b96a431c1318b89728a58adee31ce36ac7d49e7c8ce321646757346de"
+hash = "916b3133f040a7d1803b35ab9a32b42966d88e1b75d468d9c86387c1825855e3"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/easymagic/textures/gui/container/enchanting_table_reroll.png"
@@ -26606,7 +26634,7 @@ hash = "cab1163dff84bacbb703ed956fa973c156d93abafcd40c2bb2848b4255608e81"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/emi/LICENSE"
-hash = "4623d7438a9f4216078f2ae97685858502fec529f0e220c165650ec134618fea"
+hash = "4b1b16f9ef71b08af8baee6aaa1e18992ea9a571442770e2aa52a7cc7d190c53"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/emi/README.md"
@@ -26622,11 +26650,11 @@ hash = "354cf29fe7ba8e358e15351b66ed9ff57949b1f4a650ce4b9ee9cab8aa3412a5"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/expandeddelight/LICENSE"
-hash = "e2500e4cba514cf2f3cdb4ed4b4a4b5b5ffff70a6122263e64588d12fd01b0cb"
+hash = "0803961fc4de861b5f70c55fd3245f3ef2656927abe230dc3090146f401aa53e"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/expandeddelight/README.md"
-hash = "b9590bd8f75d8b7fa9b8ab94b9a45f9cfbc28c6bbb7b1692b7a5f928401603c2"
+hash = "93390dde3ccb9534d0e4a42037f438ea49469b42e04c537553fd6d2e64455846"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/expandeddelight/textures/gui/juicer_gui.png"
@@ -26634,7 +26662,7 @@ hash = "3ad8cf473af013de951d75ac79b4d861462ad4c2ef051ba1a7f476e6a95a8cc5"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/expandedstorage/LICENSE"
-hash = "a605610033355e915ba5a3ea218ce3970606261496180861d8fdec37c543984e"
+hash = "3355a343ca0ee130b47b60d1c5965efe635d1d1e06144b34f4e0da11a0e62269"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/expandedstorage/textures/gui/container/mini_chest_screen.png"
@@ -26694,7 +26722,7 @@ hash = "a0d8dbb38a98fb28a1ff9665469726cae5cbe6ce6d7ebe4d2978afbb281c860b"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/fabric/LICENSE"
-hash = "b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1"
+hash = "e03ba41d7fab20700769fe4118bab50d800cb74f990353a05d2f5fff1c228363"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/fabric/README.md"
@@ -26706,11 +26734,11 @@ hash = "6cc16c14cf0307e08848e4913826534bae0738aa4574599d5ed5ce47c18cee9a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/farmersdelight/LICENSE"
-hash = "c6fe32e37a4cdf79db321b9592018ea65ec048564608cf721cd79201fb72e083"
+hash = "bb2d836eb770119315f0755ecadd222c2a1fcffba8c537579d42857bf3c5e33a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/farmersdelight/README.md"
-hash = "dd331424314c40cc15c50e4595e236dabd212f75fdd0fceb2f6cf6cc235f90a7"
+hash = "aa8a85cb4929a65d6bcad60d972b6b86a2dfbe81678d233d0b40d863d86d5991"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/farmersdelight/textures/gui/cooking_pot.png"
@@ -26742,11 +26770,11 @@ hash = "b4f887b06873d27a8322a1f6e35fdf0971ecea144d68b15e48d1e0befa9130a2"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/frame/LICENSE"
-hash = "4bf8ec6bfca27eae3006151a63d0ffa311d60f8fafc525b1c1a934fe40ffa989"
+hash = "8003cd335c3a4e713117b89ac2d72b0acc969f197414544334d4f221d7941f1f"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/frame/LICENSE_ASSETS"
-hash = "593fc912dac28a5922f46318ba3e20cfd2feebaacdfbfb79d7eb552da325e667"
+hash = "ac75cc859b086791467a850ca26f9a6afda32d5d459b1bc77d6e353d6a89cd7a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/frame/README.md"
@@ -26766,11 +26794,11 @@ hash = "db92f860316de7bfb3c7a23d52ecd9d4123f79b8f0fe3a150739fe73049c0b72"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/galosphere/LICENSE.txt"
-hash = "c70e51c25a307f6b9b664c30ceaa3fee8fe0c6427d258a19edd564e622f4bc8b"
+hash = "cb9c3361854b4a27bde4c58483a8e612b5045badf9560a262a9d20cc20a5953d"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/galosphere/README.md"
-hash = "1cb2a821022ae5e5b75d1fea32df8899cb8a0671f2d2a3e4cd36034da1523391"
+hash = "360cf9cefc4c5fb8de352ed1ca4ee14a6561914440062b56b75c760fa830ad22"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/galosphere/textures/gui/container/combustion_table.png"
@@ -26778,11 +26806,11 @@ hash = "67d2ea354568f6068389e371fd4917c8d829ec744afa39b8b276782ee79a09b7"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmis/LICENSE"
-hash = "8f6c3c65acc850f1b1f0e53cd603ac97d849d3a18196323a7bfc767cec12ebcc"
+hash = "1f7feec98f4110331a5fa7b04f55286d17346c0012e238239b14b35197aa32ac"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmis/README.md"
-hash = "261fc8a86da2a1e38487b25c90add84232b9ced4a01067f18e823e4449cf1295"
+hash = "58e9caf07b3e8e99c29fb1562981ab1d0862e03f698a21de6d6fa30e87ad8720"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmis/textures/gui/backpack_container.png"
@@ -26794,11 +26822,11 @@ hash = "73c76f6862a54a2c6708b8709299ca7fc5c2f4c02a758fbd07b578e58eff33b7"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmisaddon/LICENSE"
-hash = "ea68d0559f14c943c63a4dadbebb6ac8203087812cddaf83729e654a93e2ebbd"
+hash = "d13b49f22328b3da34559795ce9b7f98067fb8c1a8009ac15b3096e02f7c9626"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmisaddon/README.md"
-hash = "b9d17570f4785add595daa201733024c9773dfdd134bbf5494c289b5882acf15"
+hash = "5c7562607194bcc5ca33457f6fe9500197e65a1d6b7f5496c1e12d31839ff52e"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/inmisaddon/textures/gui/icons.png"
@@ -26906,11 +26934,11 @@ hash = "67cb5756f61bc8199cad1513d3a7cf23cbbf25522f85d2c23ba42c05041439c7"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ironchest/LICENSE"
-hash = "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
+hash = "230184f60bae2feaf244f10a8bac053c8ff33a183bcc365b4d8b876d2b7f4809"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ironchest/README.md"
-hash = "113d5bdf2a2ae1fe1abe7afcfc0c0c11a39286c5c4f63c6f1ebd940408b717c1"
+hash = "fe576d0e9fe60ecac8360480b0bd3e79e4c5c5eedfb3eb1e35ddac065b97c277"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/ironchest/textures/gui/copper_container.png"
@@ -26938,11 +26966,11 @@ hash = "e46ad89506e6d7ec70ca365f5c29dfb1820f3fd49c0b01cb4e670920c75df986"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/itemfilters/LICENSE.txt"
-hash = "a5681bf9b05db14d86776930017c647ad9e6e56ff6bbcfdf21e5848288dfaf1b"
+hash = "f831e7eed577481687a9bc0b48024e5e40b6f655fcde073ede964b50be5d55d9"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/itemfilters/README.md"
-hash = "34fd80e9347c3247ae4cdfdcc6c96ece5b48f87ac4b902882ef5585ca26d9844"
+hash = "11a14e0a353b6ddb00c303c9c840441dc84df6c5c151c1969f0ac12541b515b2"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/itemfilters/textures/gui/filter.png"
@@ -26950,11 +26978,11 @@ hash = "6cb257f754b74aa1b9771c63e8e819ef045cef35452388e47d180d2f771f916d"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/jei/LICENSE.txt"
-hash = "108c93a97f3011c196b8226f5019a9c09ade318fe3a802be2f7f5ddb2c3a0d04"
+hash = "094b70c436f73da3738343b244cf5057c547fc7b1e68dc46fbefa2849696c6d1"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/jei/README.md"
-hash = "349fb57ed9cee7eeefce685c3d9e5074206222e81921bd75dda10ecf66bbb2bf"
+hash = "e23f0c3fcba470effe44aed7edb16635fb964dfcd7072ed9151eab5345bf9940"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/jei/textures/gui/button_disabled.png"
@@ -27010,11 +27038,11 @@ hash = "1df9989a3a08bc803c44d6e17acd9fd64ff9487197ee7ed24d6e58907f0d0c40"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/languagereload/LICENSE"
-hash = "fd4ea5374bb87932fd3f65b831659ca02b65276055d1c752ba54434edce45c86"
+hash = "886330810efab331a458fc0a09dec9ea97b69d2174b10251324d765a507cc730"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/languagereload/README.md"
-hash = "6c70a7c49cf437506ba447a666f5ac22cf9ea5941269b1c607934b88728e71c4"
+hash = "c819c442e3d3f8abfb597d257fda296ae5998f05bb71e64f87503fdfec1b3406"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/languagereload/textures/gui/language_selection.png"
@@ -27022,15 +27050,15 @@ hash = "d80ac837ad130b92f4fb93412c148ea905d185fa46405b0bd05411036a68ca98"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/libgui/CREDITS.txt"
-hash = "4cd36a49a91221e5c275f3729e69a931790ff9f0886fc9df117802d31d6fe537"
+hash = "5b7b65c9a2faf4ae81a307d49ff0ba11bb5eb45377984f6e6876155e6257ae3a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/libgui/LICENSE"
-hash = "1ae10af9ff1076407f1b6e87bdb801f38ae9955396428660576434d79c91511f"
+hash = "fa6fb406aeaa72f59b3a5d5dd8676bbf805fa8b382f498bda0e8abc7c893e45d"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/libgui/README.md"
-hash = "d1f8c2efd2c2746b93e25cb8af06836c23cfdce2d1db635fca284d2cc9c3b1e7"
+hash = "7306cb3b054ad5b1f0fba45f02baf58759634715d7d66a70e977fcbb12988b10"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/libgui/textures/widget/dark_widgets.png"
@@ -27582,15 +27610,15 @@ hash = "1a33cb662067080727c648c69ccf5f7fb045e2064644fc27539615208c4cc3ad"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/minecraft/optifine/color.properties"
-hash = "93bd0671bb267d1829a5df98eae2346fcff65a9fca2fb0030bcd4957fee3d2af"
+hash = "40a154fe1be9a428d3d7e67935fadd7bcd19ad13d315a1c8e98e1884b5a217b5"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/minecraft/shaders/core/rendertype_text.fsh"
-hash = "d00a898d17b5ecd67438c5a6b5f79b034797b65c5e384fc8580aae3667123cfc"
+hash = "7df1aaac11a2bfc5e48c5403f83ff80409b79781673f77d8f9cdc08ef89825e4"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/minecraft/shaders/core/rendertype_text_intensity.fsh"
-hash = "5c4c9dc689161e660711ed92d07179b869cb067a1de55746163faab65aeba361"
+hash = "128343666b1f6b180826c682951aa0df83338de1537320bf5506b560ead5a68c"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/minecraft/textures/gui/accessibility.png"
@@ -27782,11 +27810,11 @@ hash = "56db25d2219d75303efe2ee0ba20b8c91b6192ee1065956cf9204a255a37500b"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/modmenu/LICENSE"
-hash = "b2ab036e21f4dbfa7b1a3d5b1b73bcd0ed4180878f99f137f413f2252a9a4aa5"
+hash = "866f48caad42e3b95ccb8930d182a6296833d896fadbc5576e9513b37770bd45"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/modmenu/README.md"
-hash = "aa8a1d86a3c8dd77a264439ff62805474fee322c937bc8fbff660103f6632886"
+hash = "418ce2b75b3ee86c8ca659f02afbc1d40004276be5551bae6812c59e19de33f4"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/modmenu/textures/gui/configure_button.png"
@@ -27810,11 +27838,11 @@ hash = "9e074d9360509d62601105a69e0937627b778f1c9fd40d22d73a18d153644b9a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/origins/LICENSE"
-hash = "d99d258d31cfa562a427264b78f3e5cdb63ff3d309ebba5ed8d79586fc2963d7"
+hash = "6480c4e0d0eaf6f77d2235133b1b5a1054f5ed8bde3108735b7e8cab910a4ae8"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/origins/README.md"
-hash = "5fc42a262120d615c8063c3c1e4b542927c72f287fea315d8161c1490fea1b8f"
+hash = "4065029d4f4b2f1ee49a59680590b569bdb3d40aea9d9ef007df9fd17ace8802"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/origins/textures/gui/choose_origin.png"
@@ -27830,7 +27858,7 @@ hash = "9e380be06022ab4825aadbd337be52017ce027c980e989f7a533e5804798089a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/owo/LICENSE"
-hash = "4578db32a0c60dd839a6d005bd115ff4bab94f1dbb0b181aa2062b2f8dc6cc48"
+hash = "2078405dbc08bbf6635038c7dd17c22a3a41759cea6fc15fca60d80a76a85c11"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/owo/README.md"
@@ -27858,7 +27886,7 @@ hash = "a1f5feb21efcff387a34d721efba8f2f2ab560662dc3a3339d59960f93a08ed7"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/paradise_lost/README.md"
-hash = "b79d62e0fcdc30528cc5988b3c5170bb2ba7232686b99daa1b9e18a87ce5f88d"
+hash = "c70c358ff67ae370c48a33af356d815f4cf793f4455e4f955dbd1eb04237ef27"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/paradise_lost/textures/gui/container/moa.png"
@@ -27870,7 +27898,7 @@ hash = "9f0552f651978dbd5eccf7bf222f49a86b06008aed79f0a99ff94320607808b9"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/piercingpaxels/LICENSE"
-hash = "45ddb7100088b1e2d1921f880a26e2a7ffc1a723ce8ba62d111ace85dc7ed6d0"
+hash = "4950aa237899baee8bf16a28e19167777d958e371c4caa51ee121fe522a85e4a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/piercingpaxels/README.md"
@@ -27898,11 +27926,11 @@ hash = "efff2e69fcbfbde71c5ac877e647919f1b79f74530bdd204320a9063ace47247"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/polymorph/LICENSE"
-hash = "810f2664de89d03c747f3db40c47a315c938341c1260c67cfdff9f22be02b3e5"
+hash = "0495444eae25262bd7a810cd64ddadc16d568b274ae0f041201d9fc853315f1d"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/polymorph/README.md"
-hash = "e3e949b412fc098167b70c4f1a37fa4e371e2950a50d153636b3cbf2acee1165"
+hash = "bbd95f086ccb6aa5533cbef709310f07262e18cf4bb3fa93af7a4b6b7a1f3621"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/polymorph/textures/gui/widgets.png"
@@ -27910,7 +27938,7 @@ hash = "ee38e2e903eeef3e9f2828e688e4917e488e8847e4382af510016e7f58c0b54a"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/roughlyenoughitems/LICENSE"
-hash = "6573dade580d21386ca66c7c72b5bd582befce4b1f412f4600f1725e54d910f3"
+hash = "528a5f0c95578dab330bd8f8a13995c85f5ce64dca89181ba7c6292383d7372b"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/roughlyenoughitems/README.md"
@@ -28010,11 +28038,11 @@ hash = "173a3f607080456845bc95761542e1a4a558a6a85a5e92ed6559113e45856e1e"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/toms_storage/LICENSE"
-hash = "683c918da894e32b8e0c2f715ecb7b910e6fa57ce9736f963824d4eb9ec11c34"
+hash = "7af7cb93f187f67212af699d44aeddf0c0ff5f559e324c771c911149ea430678"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/toms_storage/README.md"
-hash = "04a8e547c4071913720e0c25becfd4c93ea22f16a2026b2daead14542142e59a"
+hash = "d8121de15dcbb9679d43d9db4df8d1c63adc4e2d3983340d33e060388eac93cb"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/toms_storage/textures/gui/crafting_terminal.png"
@@ -28034,11 +28062,11 @@ hash = "f0d1218b30a655e815ee1a39fd2f297dd786b5e92ca19cc6279bbcf02609779b"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/trashslot/LICENSE"
-hash = "a2b33c6924b3ab232979e32486887158cecbbf043309285396568062133de368"
+hash = "04ec0405a6a211e55fe5d8c6f8425528264688f898a599709ce7c92998200d60"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/trashslot/README.md"
-hash = "daf052126a1a9bdf6f6f3398c9fc796c661789f70946841e6b4b7b3aee257f81"
+hash = "c3c022344a5085a9c13bc808efe67e6a349077959b8651d85dd18f40ea696048"
 
 [[files]]
 file = "resourcepacks/Reim GUI + Default Dark/assets/trashslot/textures/gui/slot.png"
@@ -28590,7 +28618,7 @@ hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 [[files]]
 file = "resources/ad_astra/lang/en_us.json"
-hash = "2747736274f16d1b093ef61ec5ea91b5b91e89fa28e650c1746b6dba20c81f7a"
+hash = "c4e57649b613927e8f6f6dc52041d576361f3da0301643726a3836da3b9b477c"
 
 [[files]]
 file = "resources/ad_astra/lang/fr_fr.json"
@@ -28651,6 +28679,10 @@ hash = "f9a917c6d4719014e8b7ed24f815acdef0b3cad140de504aec6cdeb69e84182b"
 [[files]]
 file = "resources/ad_astra/textures/block/moon_stone_bricks.png"
 hash = "e6bda8262823e452548edd347d7bf6e95088b0a596583a7357f4b1f59e4f3489"
+
+[[files]]
+file = "resources/ad_astra/textures/block/polished_mercury_stone.png"
+hash = "dfcb14dc1bf8a1bb2b8eeede3b56480adbbacb93c538f120046a2fa6e5df5b6e"
 
 [[files]]
 file = "resources/ad_astra/textures/block/polished_moon_stone.png"
@@ -29230,6 +29262,10 @@ hash = "e26361372485a3dc5bc41e1a191219cd1898b0091b17bde57a1c28f3bf50a0ed"
 
 [[files]]
 file = "resources/createastral/textures/block/andesite_alloy_block.png"
+hash = "60f5eb557327f0070f24d09d6f773c5c5d5371138a443abfe37662819e852002"
+
+[[files]]
+file = "resources/createastral/textures/block/andesite_alloy_block_old.png"
 hash = "eeffe4d36960281231515ef6be16d6d309429b1f8dd0189401c99c506f9b56b6"
 
 [[files]]
@@ -29961,8 +29997,16 @@ file = "resources/createastral/textures/item/t6_upgrade.png"
 hash = "c004bb318c8edbb0c3dff26a51a1a02542aaa21b5128238656080b67a7038f76"
 
 [[files]]
+file = "resources/createastral/textures/item/tested_rocket_piece.png"
+hash = "33cac6502d9e7afd16ce235b8bcd9c87878263484d466d8f79dd3982dfa83042"
+
+[[files]]
 file = "resources/createastral/textures/item/transitional_lapis_sheet.png"
 hash = "0c19b7e90ff4b2fe8f7c8f6e70b38bec299b1458ecf05b43109f39e564dff22b"
+
+[[files]]
+file = "resources/createastral/textures/item/untested_rocket_piece.png"
+hash = "c04e4a7f6c61c6fb6b0fbe1bacb3902bd8fe604786d7c3e85676b5c98e20fb5b"
 
 [[files]]
 file = "resources/createastral/textures/item/uranium_residue.png"
@@ -30354,11 +30398,11 @@ hash = "ed15df2a216a8b78c19f49e6b492709d41e5680b617fa93af295a02b826a23a7"
 
 [[files]]
 file = "resources/minecraft/optifine/cem/wolf.jem"
-hash = "87f951c96f4d8924a6c4b24893d5e4d6a7ec7e7b686a663db30578554f201033"
+hash = "e839dcd8241238459ae6c4ea06cb3ed3f9003bd8b1c20db169242d23d5c53fc9"
 
 [[files]]
 file = "resources/minecraft/optifine/color.properties"
-hash = "50eea19a1e010da6961316a9c0d49345060157d894ab67fc87aa6e5d8ce7ff16"
+hash = "05c0bcbc1a6012f3e74d6779eac7fdd5fb3fb16f8afa2f2ca14a714337f1f4b7"
 
 [[files]]
 file = "resources/minecraft/optifine/emissive.properties"
@@ -32798,7 +32842,7 @@ hash = "9bbef49cbe4eb132552b2f1d5347a66a824178c5b21d018eb0e2813a672ac54f"
 
 [[files]]
 file = "resources/techreborn/lang/en_us.json"
-hash = "a83be70bd4901ac0259ff05ced4a666562df4fd80a5e5909c0cd7c29c6d0c787"
+hash = "93bda0e4f9567ac3ff068c8e4bbe3bcbfdd19546192b80febb644c971c1b6c5c"
 
 [[files]]
 file = "resources/techreborn/lang/fr_fr.json"
@@ -33054,7 +33098,7 @@ hash = "5bd44777431ad8f707dc8bb913db85c1dcff1e502e4abc0937c8214988611483"
 
 [[files]]
 file = "schematics/[AstralExamples] Stone Growth Chamber.nbt"
-hash = "727d96f42e674252d3a08abbb768c046935fddfb1fc920ef3ed9f3f3c10c64fd"
+hash = "dbf525c9f8201fc1c5d7dcfca246c86cfc6c9860064ce170c88b14d84514760c"
 
 [[files]]
 file = "server.packwizignore"

--- a/kubejs/server_scripts/crushing.js
+++ b/kubejs/server_scripts/crushing.js
@@ -57,6 +57,17 @@ onEvent("recipes", (event) => {
             crushed_prefix: "createastral"
         },
         {
+            mod: "tconstruct",
+            ores: [
+                {
+                    name: "cobalt",
+                    extra: "techreborn:tin_nugget"
+                },
+            ],
+            suffix: "block",
+            crushed_prefix: "createastral"
+        },
+        {
             mod: "create",
             ores: [{name: "zinc", extra: ""}],
             suffix: "block",
@@ -137,7 +148,8 @@ onEvent("recipes", (event) => {
         lead: {name: "techreborn:raw_lead", count: 1},
         silver: {name: "techreborn:raw_silver", count: 1},
         tin: {name: "techreborn:raw_tin", count: 1},
-        yttr: {name: "yttr:raw_gadolinite", count: 1}
+        yttr: {name: "yttr:raw_gadolinite", count: 1},
+        cobalt: {name: "tconstruct:raw_cobalt", count: 1}
     };
     let ORES = [
         // Earth Ores
@@ -156,6 +168,9 @@ onEvent("recipes", (event) => {
         // Misc
         {ore: "iron", name: "ad_astra:mercury_iron_ore", block: "ad_astra:mercury_cobblestone", bonus: 1},
         {ore: "yttr", name: "yttr:gadolinite", block: "ad_astra:mercury_cobblestone", bonus: 1},
+
+
+        {ore: "cobalt", name: "tconstruct:cobalt_ore", block: "ad_astra:moon_cobblestone", bonus: 1},
     ];
 
     // vanilla ores

--- a/kubejs/server_scripts/replacements.js
+++ b/kubejs/server_scripts/replacements.js
@@ -36,6 +36,11 @@ onEvent("recipes", (event) => {
             "createaddition:iron_wire",
         ],
         [
+            {output: "tconstruct:raw_cobalt_block"},
+            "#c:raw_materials/cobalt",
+            "tconstruct:raw_cobalt" // fix cobalt craftable with raw cobalt
+        ],
+        [
             {output: "createaddition:connector"},
             "#c:slimeballs",
             "createaddition:copper_wire",

--- a/kubejs/server_scripts/tags/backpack.js
+++ b/kubejs/server_scripts/tags/backpack.js
@@ -24,7 +24,8 @@ onEvent("item.tags", (event) => {
         "automobility:crowbar",
         "doodads:slingshot",
         "doodads:paintbrush",
-        "doodads:glare_staff"
+        "doodads:glare_staff",
+        "create:super_glue"
     ].forEach((item) => {
         event.add("travelersbackpack:acceptable_tools", item);
     });

--- a/kubejs/server_scripts/tags/for_recipes.js
+++ b/kubejs/server_scripts/tags/for_recipes.js
@@ -22,6 +22,20 @@ onEvent("item.tags", (event) => {
             event.add("createastral:tank_unit_" + i, item);
     });
 
+    [
+        "astraladditions:ring_gold_cast",
+        "tconstruct:gold_platform",
+        "tconstruct:gold_bars"
+    ].forEach((item, index) => {
+        event.add("tconstruct:casts", item);
+        event.add("tconstruct:casts/gold", item);
+        event.add("tconstruct:casts/multi_use", item);
+        event.add("tconstruct:patterns", item);
+        event.add("tconstruct:patterns/reusable", item);
+    });
+
     event.add("c:slimeballs", "createastral:synthetic_slime");
     event.add("tconstruct:slime_block", "createastral:synthetic_slime_block");
+
+    event.add("c:raw_materials/cobalt", "createastral:crushed_raw_cobalt");
 });

--- a/kubejs/startup_scripts/item_registry.js
+++ b/kubejs/startup_scripts/item_registry.js
@@ -36,6 +36,7 @@ onEvent("item.registry", (event) => {
     event.create("createastral:star_shard").glow(true);
     event.create("createastral:pure_star_shard").glow(true).rarity("Epic");
     event.create("createastral:crushed_raw_gadolinite");
+    event.create("createastral:crushed_raw_cobalt");
     event.create("createastral:experience_ingot").glow(true);
     event.create("createastral:stone_dust").displayName("Stone Dust");
     event.create("createastral:stone_small_dust").displayName("Small Pile of Stone Dust");

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e6f4beca3f42e1b578f59a7efcc0eec42e5d6495a539704301626f8c2489191c"
+hash = "8d632223b90def465642c35a2d548018be37586b119344708d63537f2bdf1168"
 
 [versions]
 fabric = "0.16.3"


### PR DESCRIPTION
Added crushed cobalt
astraladditions cast can now go in cast table, in addition to gold bars and gold platform (for empty casting)
Super glue can now go in tool slot for the backpacks