### PR TITLE
Remove venus and glacio in proxima centuri from the planet menu

### DIFF
--- a/global_packs/required_data/zLaky Core/data/ad_astra/advancements/interstellar.json
+++ b/global_packs/required_data/zLaky Core/data/ad_astra/advancements/interstellar.json
@@ -1,0 +1,29 @@
+{
+    "display": {
+      "icon": {
+        "item": "yttr:nethertuff"
+      },
+      "title": {
+        "translate": "advancements.ad_astra.interstellar.title"
+      },
+      "description": {
+        "translate": "advancements.ad_astra.interstellar.description"
+      },
+      "frame": "challenge",
+      "show_toast": true,
+      "announce_to_chat": true,
+      "hidden": false
+    },
+    "criteria": {
+      "interstellar": {
+        "trigger": "minecraft:changed_dimension",
+        "conditions": {
+          "to": "minecraft:the_nether"
+        }
+      }
+    },
+    "rewards": {
+      "experience": 200
+    },
+    "parent": "ad_astra:tier_4_rocket"
+  }

--- a/index.toml
+++ b/index.toml
@@ -15184,6 +15184,11 @@ hash = "c6ae545188ed3969654e103c91906072165883fed71374f48e757f5206c672be"
 metafile = true
 
 [[files]]
+file = "mods/kubejs-additions.pw.toml"
+hash = "70badaa3e3753617ec611721b562c481226be0ca5ae38123187784e760500334"
+metafile = true
+
+[[files]]
 file = "mods/kubejs-create.pw.toml"
 hash = "2e4e236d8faaed866a5ff08dfd7b946aa9f3cdce8cae6b65f9c01a5d988635db"
 metafile = true

--- a/kubejs/startup_scripts/planet_destroyer.js
+++ b/kubejs/startup_scripts/planet_destroyer.js
@@ -1,0 +1,19 @@
+const AdAstra = java('com.github.alexnijjar.ad_astra.AdAstra')
+const ServerLifecycleEvents = java('net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents')
+onEvent('fabric.event.register', event => {
+    event.register('ServerLifecycleEvents.EndDataPackReload', ServerLifecycleEvents, 'END_DATA_PACK_RELOAD');
+    event.register('ServerLifecycleEvents.ServerStarted', ServerLifecycleEvents, 'SERVER_STARTED');
+});
+
+//kill off the ad astra planets that refuse to die
+let planetDestroyer = function(event) {
+    const planets = AdAstra.planets;
+    //DESTROY VENUS
+    const venus = planets.find(p=>p.world().location() == "ad_astra:venus");
+    if (venus) planets.remove(venus);
+    //DESTROY GLACIO CLONE
+    const fakeGlacio = planets.find(p=>p.world().location() == "ad_astra:glacio" && p.rocketTier() == 4);
+    if (fakeGlacio) planets.remove(fakeGlacio);
+}
+onEvent('ServerLifecycleEvents.ServerStarted', planetDestroyer);
+onEvent('ServerLifecycleEvents.EndDataPackReload', planetDestroyer);

--- a/mods/kubejs-additions.pw.toml
+++ b/mods/kubejs-additions.pw.toml
@@ -1,0 +1,13 @@
+name = "KubeJS Additions"
+filename = "kubejsadditions-2.2.4.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "57cf161fcd8ea69fe905af743f84fc2ae19055ae"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4770559
+project-id = 594387

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e80686711759e740402fd3c6671c5139771113f0cd399c08bd72a2fc341d46e8"
+hash = "4f14c1a7df9bf61b4a12596862cd8d464e60b4652c7482e855f493fd148195d3"
 
 [versions]
 fabric = "0.16.3"


### PR DESCRIPTION
This pull request DESTROYS VENUS
Also gets rid of the glacio clone in proxima centuri

The Kubejs Additions mod is added to the pack so that kubejs code can be run on server start and datapack reload and DESTROY VENUS before any players can try traveling to it.

Also changes the interstellar advancement to unlock when visiting the nether instead of glacio.

~~I think this works on servers... I don't have a server set up right now to test it~~. Tested and it works on servers