### PR TITLE
revert blaze cake recipe

### DIFF
--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -1375,7 +1375,7 @@ function fillingRecipes(event) {
             input: "create:blaze_cake_base",
             output: "create:blaze_cake",
             fluid: "kubejs:hellfire",
-            amount: 75 * mB,
+            amount: 250 * mB,
         },
         {
             input: "techreborn:red_cell_battery",


### PR DESCRIPTION
Back in 2.1.1, I decreased how much hellfire was needed to make blaze cake to balance how much burntime you get from hellfire and blaze cakes.
Well it turns out that I tested it on a liquid burner where blaze cakes have a 50 second burn time. On non liquid burners blaze cakes have a 2 minute and 40 second blaze time so it was actually already balanced the whole time.