### PR TITLE
Changed config

### DIFF
--- a/defaultconfigs/create-server.toml
+++ b/defaultconfigs/create-server.toml
@@ -349,7 +349,7 @@ limitAdventureMode = true
 	#.
 	#Configure which fluids can be drained infinitely.
 	#Allowed Values: ALLOW_ALL, DENY_ALL, ALLOW_BY_TAG, DENY_BY_TAG
-	bottomlessFluidMode = "ALLOW_BY_TAG"
+	bottomlessFluidMode = "DENY_ALL"
 	#.
 	#Whether open-ended pipes and hose pulleys should be allowed to place fluid sources.
 	placeFluidSourceBlocks = true

--- a/global_packs/required_data/zLaky Core/data/create/tags/fluids/bottomless/allow.json
+++ b/global_packs/required_data/zLaky Core/data/create/tags/fluids/bottomless/allow.json
@@ -1,1 +1,1 @@
-{"replace":false,"values":["minecraft:water","minecraft:lava", "create:honey", "create:chocolate", "techreborn:oil", "tconstruct:blood", "milk:milk"]}
+{"replace":false,"values":["minecraft:water"]}

--- a/global_packs/required_data/zLaky Core/data/create/tags/fluids/bottomless/allow.json
+++ b/global_packs/required_data/zLaky Core/data/create/tags/fluids/bottomless/allow.json
@@ -1,1 +1,1 @@
-{"replace":false,"values":["minecraft:water"]}
+{"replace":false,"values":["minecraft:water","minecraft:lava", "create:honey", "create:chocolate", "tconstruct:blood", "milk:milk"]}


### PR DESCRIPTION
-> Changed Default Config for Infinite Liquid to Deny (was already planned, but left in after Dev Phase)
-> Changed the Tags to not include Oil

It is still possible to reactivate Infinite Liquid in Config to "Allow by Tag", this makes the Infinite Sources work again, even tho its not the intended experience.