### PR TITLE
shelf moonset portal so that there's more time to give it a proper recipe

### DIFF
--- a/kubejs/server_scripts/server.js
+++ b/kubejs/server_scripts/server.js
@@ -1199,7 +1199,7 @@ onEvent("recipes", (event) => {
 
     event.shapeless("3x createastral:synthetic_slime", ["2x #c:slimeballs", "2x techreborn:sponge_piece"]);
 
-    event.shapeless("1x createastral:moonset_stone", ["1x ad_astra:moon_stone", "1x astraladditions:moonset_crystal"]);
+    //event.shapeless("1x createastral:moonset_stone", ["1x ad_astra:moon_stone", "1x astraladditions:moonset_crystal"]);
 
     event.shaped("createastral:synthetic_slime_block", ["SSS", "SSS", "SSS"], {
         S: "createastral:synthetic_slime",


### PR DESCRIPTION
Recently in commit 7fbde7f a debris portal recipe was added that is extremely easy to craft.
I think it would be a good idea to not include a recipe in 2.1.2 so that there's more time to flesh out the moonset portal and its recipe.