### PR TITLE
fix lamp drops and recipes

### DIFF
--- a/kubejs/server_scripts/yttr_block_fix.js
+++ b/kubejs/server_scripts/yttr_block_fix.js
@@ -1,3 +1,4 @@
+//Block Drop Fixes
 onEvent("block.loot_tables", (event) => {
     [
         ["yttr:yttrium_block"],
@@ -75,10 +76,6 @@ onEvent("block.loot_tables", (event) => {
         ["yttr:black_project_table"],
         ["yttr:neodymium_slab"],
         ["yttr:neodymium_block"],
-        ["yttr:lamp"],
-        ["yttr:fixture"],
-        ["yttr:cage_lamp"],
-        ["yttr:panel"],
         ["yttr:aware_hopper"],
         ["yttr:levitation_chamber"],
         ["yttr:magtank"],
@@ -86,4 +83,171 @@ onEvent("block.loot_tables", (event) => {
     ].forEach((loot) => {
         event.addSimpleBlock(loot[0], loot[0]);
     });
+    //Lamp Blocks
+    const lampColors = [ //don't include colorless
+        "white",
+        "orange",
+        "magenta",
+        "light_blue",
+        "yellow",
+        "lime",
+        "pink",
+        "gray",
+        "light_gray",
+        "cyan",
+        "purple",
+        "blue",
+        "brown",
+        "green",
+        "red",
+        "black",
+        "teal"
+    ];
+    [
+        "yttr:lamp",
+        "yttr:fixture",
+        "yttr:cage_lamp",
+        "yttr:panel"
+    ].forEach((lamp) => {
+        event.addJson(lamp, {
+            type: "minecraft:block",
+            pools: [
+              {
+                rolls: 1,
+                bonus_rolls: 0,
+                entries: [
+                  {
+                    type: "minecraft:item",
+                    name: lamp,
+                    functions: [
+                        {
+                            function: "minecraft:set_nbt",
+                            tag: "{Inverted: false, LampColor: \"colorless\"}"
+                        },
+                        {
+                            function: "minecraft:set_nbt",
+                            tag: "{Inverted: true}",
+                            conditions: [
+                                {
+                                    block: lamp,
+                                    condition: "minecraft:block_state_property",
+                                    properties: {
+                                        inverted: true
+                                    }
+                                }
+                            ]
+                        }
+                    ].concat(lampColors.map(color=>{
+                        return {
+                            function: "minecraft:set_nbt",
+                            tag: `{LampColor: \"${color}\"}`,
+                            conditions: [
+                                {
+                                    block: lamp,
+                                    condition: "minecraft:block_state_property",
+                                    properties: {
+                                        color: color
+                                    }
+                                }
+                            ]
+                        }
+                    }))
+                  }
+                ],
+                conditions: [
+                  {
+                    condition: "minecraft:survives_explosion"
+                  }
+                ]
+              }
+            ]
+        })
+    })
 });
+
+//Lamp Recipe Fixes
+onEvent("recipes", (event) => {
+    
+    const lampTypes = [
+        "lamp",
+        "fixture",
+        "cage_lamp",
+        "panel"
+    ];
+    const lampColors = [ //don't include colorless
+        ["white", "$minecraft:white_dye"],
+        ["orange", "minecraft:orange_dye"],
+        ["magenta", "minecraft:white_dye"],
+        ["light_blue", "minecraft:light_blue_dye"],
+        ["yellow", "minecraft:yellow_dye"],
+        ["lime", "minecraft:lime_dye"],
+        ["pink", "minecraft:pink_dye"],
+        ["gray", "minecraft:gray_dye"],
+        ["light_gray", "minecraft:light_gray_dye"],
+        ["cyan", "minecraft:cyan_dye"],
+        ["purple", "minecraft:purple_dye"],
+        ["blue", "minecraft:blue_dye"],
+        ["brown", "minecraft:brown_dye"],
+        ["green", "minecraft:green_dye"],
+        ["red", "minecraft:red_dye"],
+        ["black", "minecraft:black_dye"],
+        ["teal", "yttr:yttrium_dust"]
+    ];
+    
+
+    //Lamp recipe fixes
+    lampTypes.forEach(lamp=>{
+        //this recipe is shaped for some reason
+        event.remove({id:`yttr:crafting/lamp/${lamp}_invert`});
+        //this recipe doesn't even work
+        event.remove({id:`yttr:crafting/lamp/${lamp}_dye`});
+
+        //recreate lamp inversion recipe as a shapeless one. Also make it not consume the redstone torch
+        event.shapeless(
+            Item.of(`yttr:${lamp}`).withNBT('{Inverted:true, LampColor:\"colorless\"}'),
+            [
+                `yttr:${lamp}`,
+                'minecraft:redstone_torch'
+            ]
+        )
+        .modifyResult((grid, result)=>{
+            let item = grid.find(Ingredient.of(`yttr:${lamp}`).ignoreNBT());
+    
+            let nbt = {};
+            nbt.Inverted = !item.nbt.Inverted;
+            if (item.nbt.LampColor) {
+                nbt.LampColor = item.nbt.LampColor;
+            }
+            return result.withNBT(nbt);
+        })
+        .keepIngredient("minecraft:redstone_torch")
+        .id(`createastral:crafting/yttr/lamp/${lamp}_invert`)
+
+        //Create lamp dyeing recipes that actually work
+        event.shapeless(
+            Item.of(`yttr:${lamp}`).withNBT('{Inverted:false, LampColor:\"white\"}'),
+            [
+                `yttr:${lamp}`,
+                '#yttr:lamp_dyes'
+            ]
+        )
+        .modifyResult((grid, result)=>{
+            let item = grid.find(Ingredient.of(`yttr:${lamp}`).ignoreNBT());
+            let dye = grid.find(`#yttr:lamp_dyes`);
+    
+            let nbt = {};
+
+            nbt.Inverted = !!item.nbt.Inverted;
+
+            for (let i=0;i<lampColors.length;++i) {
+                if (dye.getId()===lampColors[i][1]) {
+                    nbt.LampColor = lampColors[i][0];
+                    break;
+                }
+            }
+
+            return result.withNBT(nbt);
+        })
+        .id(`createastral:crafting/yttr/lamp/${lamp}_dye`)
+    })
+})

--- a/kubejs/server_scripts/yttr_block_fix.js
+++ b/kubejs/server_scripts/yttr_block_fix.js
@@ -212,13 +212,12 @@ onEvent("recipes", (event) => {
         )
         .modifyResult((grid, result)=>{
             let item = grid.find(Ingredient.of(`yttr:${lamp}`).ignoreNBT());
-    
-            let nbt = {};
-            nbt.Inverted = !item.nbt.Inverted;
-            if (item.nbt.LampColor) {
-                nbt.LampColor = item.nbt.LampColor;
-            }
-            return result.withNBT(nbt);
+            let inputNbt = item.nbt || {};
+
+            let outputNbt = {};
+            outputNbt.Inverted = !inputNbt.Inverted;
+            outputNbt.LampColor = inputNbt.LampColor || "colorless";
+            return result.withNBT(outputNbt);
         })
         .keepIngredient("minecraft:redstone_torch")
         .id(`createastral:crafting/yttr/lamp/${lamp}_invert`)
@@ -234,19 +233,19 @@ onEvent("recipes", (event) => {
         .modifyResult((grid, result)=>{
             let item = grid.find(Ingredient.of(`yttr:${lamp}`).ignoreNBT());
             let dye = grid.find(`#yttr:lamp_dyes`);
+            let inputNbt = item.nbt || {};
     
-            let nbt = {};
+            let outputNbt = {};
 
-            nbt.Inverted = !!item.nbt.Inverted;
-
+            outputNbt.Inverted = !!inputNbt.Inverted;
             for (let i=0;i<lampColors.length;++i) {
                 if (dye.getId()===lampColors[i][1]) {
-                    nbt.LampColor = lampColors[i][0];
+                    outputNbt.LampColor = lampColors[i][0];
                     break;
                 }
             }
 
-            return result.withNBT(nbt);
+            return result.withNBT(outputNbt);
         })
         .id(`createastral:crafting/yttr/lamp/${lamp}_dye`)
     })


### PR DESCRIPTION
Fixes lamps converting to colorless non-inverted lamps when mined.
Changes the lamp inversion recipe to be shapeless and not consume the redstone torch.
Fixes the lamp dyeing recipe and makes it shapeless.