### PR TITLE
Fix foundry fluids getting out of sync

### DIFF
--- a/kubejs/server_scripts/tconstruct_fluidsyncfix.js
+++ b/kubejs/server_scripts/tconstruct_fluidsyncfix.js
@@ -1,0 +1,4 @@
+onEvent('block.right_click', event => {
+    if (event.block.id == "tconstruct:foundry_controller" && event.block.entity.tank != null)
+        event.block.entity.tank.syncFluids()
+})


### PR DESCRIPTION
This is a bit of a band aid fix for https://github.com/Laskyyy/Create-Astral/issues/429
I do not think there is a much better way to fix this though, without considerable changes to Hephaestus. And if the player is using the foundry they will almost certainly open the GUI.