### PR TITLE
fix industrial centrifuge certus quartz recipe

### DIFF
--- a/kubejs/server_scripts/techreborn.js
+++ b/kubejs/server_scripts/techreborn.js
@@ -197,7 +197,7 @@ onEvent("recipes", (event) => {
             {
                 item: "techreborn:cell",
                 nbt: {
-                    fluid: "techreborn:oxygen",
+                    fluid: "ad_astra:oxygen",
                 },
                 count: 10,
             },


### PR DESCRIPTION
the recipe was attempting to make cells with techreborn:oxygen but this doesnt exist so this pr changes it to ad_astra:oxygen which does exist