### PR TITLE
Dough Mixing Fix

### DIFF
--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -2146,6 +2146,19 @@ function mixingRecipes(event) {
     [
 		{
             output: [
+				"create:dough"
+			],
+            input: [
+				"create:wheat_flour",
+				{
+					fluid: "minecraft:water",
+					amount: BUCKET / 2,
+				}
+			],
+            heat: "",
+            time: 10,
+        },{
+            output: [
 				{
 					fluid: "estrogen:molten_amethyst",
 					amount: INGOT,

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -243,6 +243,10 @@ onEvent("recipes", (event) => {
             output: "create:brass_casing",
             type: "create:item_application",
         },
+        {
+            type: "create:mixing",
+            output: "create:dough",
+        },
         { mod: "create", output: "minecraft:andesite" },
 
         // Create Deco


### PR DESCRIPTION
The Vanilla Create Recipe required 1 Bucket of Water for Dough with Mixing, it wasn't possible to have a permanently running setup, because it would have to refill to a Full Bucket thus ending the mixing animation and having to restart it.  

-> Halved the required Water for Dough via Mixing

