### PR TITLE
Update create.js

### DIFF
--- a/kubejs/server_scripts/create.js
+++ b/kubejs/server_scripts/create.js
@@ -941,7 +941,7 @@ function sequencedAssemblyRecipes(event) {
                 ]
             )
             .transitionalItem("ad_astra:polished_permafrost")
-			.loops(1);
+	    .loops(1);
 
         event.recipes
             .createSequencedAssembly(


### PR DESCRIPTION
Fixed line 944 indentation causing KubeJS recipes for the create mixer to not load correctly.