### PR TITLE
Set appleskin to both client and server

### DIFF
--- a/mods/appleskin.pw.toml
+++ b/mods/appleskin.pw.toml
@@ -1,6 +1,6 @@
 name = "AppleSkin"
 filename = "appleskin-fabric-mc1.18.2-2.5.1.jar"
-side = "client"
+side = "both"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
This pull request includes a fix for #523 in fa67422a686195250b330e0f75ecaf83c611d672. The fix is incredibly simple: change the content of `mods/appleskin.pw.toml` from `side = "client"` to `side = "both"`.

This change is important because Appleskin needs to be on both the client and server to function properly. There are two primary bugs which arise from Appleskin not existing on the server:
- No information about food exhaustion is sent to the client
- Saturation information updates in only three places:
  - Upon eating a food item
  - When saturation reaches zero
  - When the player regenerates health (this may be the client estimating saturation)

fa67422a686195250b330e0f75ecaf83c611d672 reconfigures packwiz to include appleskin in the serverpack. Appleskin was included in the serverpack before #254 when b447e4673059150136b65d22fc37c296164f2d6c changed the Appleskin configuration to be client-only.

---
### Testing

I've performed the following tests in order to maintain stability. In all these tests, I performed the replication steps for #523.

- Ensure Appleskin is not included in the serverpack for v2.1.3
- Ensure the absence of Appleskin causes bugs in the serverpack for v2.1.3
- Test v2.1.3 with Appleskin manually installed to the server
- Ensure the absence of Appleskin in the experimental serverpack
- Ensure the absence of Appleskin in the experimental serverpack causes problems
- Test experimental with Appleskin manually installed to the server
- Test experimental with Appleskin installed via packwiz
- Test experimental with a serverpack built by the github workflow

All tests behaved as expected.