### PR TITLE
Remove explicit type check in Hephaestus Fluid Sync Fix

### DIFF
--- a/kubejs/server_scripts/misc/tconstruct_fluidsyncfix.js
+++ b/kubejs/server_scripts/misc/tconstruct_fluidsyncfix.js
@@ -1,17 +1,8 @@
 (function hephaestusFluidSyncFix() {
   onEvent("block.right_click", (event) => {
     if (event.block.id == "tconstruct:foundry_controller") {
-      let blockEntity = event.block.entity;
-      if (
-        "tank" in blockEntity &&
-        typeof blockEntity.tank == "object" &&
-        "syncFluids" in blockEntity.tank &&
-        typeof blockEntity.tank.syncFluids == "function"
-      ) {
-        blockEntity.tank.syncFluids();
-      } else {
-        throw new Error("syncFluids is not a function in the Foundry Controller's block entity.");
-      }
+      // @ts-expect-error This should always work.
+      event.block.entity?.tank?.syncFluids();
     }
   });
 })();


### PR DESCRIPTION
As @ChiefArug pointed out in a comment for the latest commit:

> wtf is that overzealous runtime type checking in the tconstruct fluid sync fix js file
> 
> https://github.com/Laskyyy/Create-Astral/commit/dcfc4a49fa37952a5c440f4ad455398a4a85ec27#diff-764bd027eb9dd7c33d5e2f6bd560a32f8d6cd115bf0710bac097417ae406a635
> 
> 
> 
> All that does is slow down the code with unnesseccary checks. Heph isn't getting updates for this version, and even if it is you would want the code to throw an error rather than silently ignore it and likely not be discovered ever. 

 _Originally posted by @ChiefArug in [dcfc4a4](https://github.com/Laskyyy/Create-Astral/commit/dcfc4a49fa37952a5c440f4ad455398a4a85ec27#commitcomment-157969938)_

ChiefArug pointed out that the code fails soft, so if a tank would be in a block entity but types were incorrect, the code would just pass along instead of crashing Minecraft, which would cause confusing bugs.

This PR adds an "else" branch to that conditional, that throws an error.