### PR TITLE
Remove Prettier config and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+max_line_length=120
+indent_size=2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "tabWidth": 2,
-  "printWidth": 120
-}


### PR DESCRIPTION
We need a general config file for formatters and EditConfig does that well.

- Prettier [supports](https://prettier.io/docs/configuration#editorconfig) EditorConfig.
- Other formatters  supports EditorConfig by default.