### PR TITLE
Remove Seared Ingot Tank Recipes

### DIFF
--- a/kubejs/server_scripts/recipes/minecraft/shaped.js
+++ b/kubejs/server_scripts/recipes/minecraft/shaped.js
@@ -288,24 +288,6 @@
         },
       },
       {
-        output: "tconstruct:seared_ingot_tank",
-        pattern: ["ACA", "ADA", "ACA"],
-        key: {
-          A: "tconstruct:seared_bricks",
-          C: "#c:plates/brass",
-          D: "create:fluid_tank",
-        },
-      },
-      {
-        output: "tconstruct:seared_ingot_gauge",
-        pattern: ["AAA", "CDC", "AAA"],
-        key: {
-          A: "tconstruct:seared_bricks",
-          C: "create:brass_sheet",
-          D: "create:fluid_tank",
-        },
-      },
-      {
         output: "tconstruct:seared_melter",
         pattern: ["CWC", "SSS", "CSC"],
         key: {


### PR DESCRIPTION
They were still craftable in the Seared variant, but not Scorched one.
Removed for parity with Scorched variant.