### PR TITLE
Typo and marimo rebalancing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,7 +3,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
-labels: [type: bug]
+labels: ["type: bug"]
 body:
     - type: textarea
       id: bug

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,7 +3,7 @@
 name: Feature Request
 description: File a feature request
 title: "[Feature Request]: "
-labels: [enhancement]
+labels: ["type: enhancement"]
 body:
     - type: textarea
       id: related-problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This update comes with a completely overhauled file structure for Astral's own c
 - Fixed the inability to create both Capacity and Potato Recovery enchanted books by changing Potato Recovery's assembly to use a Potato as a first item.
 - Fixed most fluid cell quest tasks not respecting NBT and completing when the player is holding any type of fluid cell.
 - Fixed certain blocks not being able to be picked up by wrenches.
+- Fixed the Farmer's Delight Chocolate Pie filling recipe not working due to a broken fluid amount.
 
 #### Minor mod updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This update comes with a completely overhauled file structure for Astral's own c
 
 - Added four new GUIs for the Electrolyser, Distillation Tower, Stone Growth Chamber, and Shimmer Refinery multiblock structures.
 - Added a dedicated transistional item for the Shimmer Amplifier sequenced assembly recipe.
+- Added a live version tracker on the main menu that pulls the most recent version of Astral from the GitHub repository releases.
 
 #### Behind-the-scenes
 
@@ -86,6 +87,7 @@ This update comes with a completely overhauled file structure for Astral's own c
 - Tripled the amount of time Blazing Blood can fuel liquid Blaze Burners for.
 - Changed Launch Gel's transitional item to be Slimesteel Nugget.
 - Diamond tools now need 1 Diamond worth of Molten Diamond per loop instead of 2.5 Diamonds.
+- Buffed marimo dupe recipes to now output 3 marimo instead of 2. This helps with recycling using brass funnels to extract precisely 2 marimo from the basin, leaving one in the basin to be reprocessed.
 
 #### Quality of life
 
@@ -106,6 +108,7 @@ This update comes with a completely overhauled file structure for Astral's own c
 - Made Basic, Advanced, and Industrial Machine Frames and Machine Casings able to be picked up with wrenches.
 - Re-added the in-game changelogs for 2.1.1 and 2.1.2, and preserved the changelog for 2.1.3. Also completely redesigned the in-game changelog.
 - Overhauled the in-game credits menu to include more people and generally look nicer and be more organised.
+- Baked main menu screenshot credits onto the images themselves. Best viewed in a 16:9 monitor aspect ratio.
 
 #### Bug patches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,6 @@ lang: en_GB
 
 ## Important forewords
 
-## Important forewords
-
 **YOU MUST REFER TO THE [LICENSE](/LICENSE.md) BEFORE MAKING ANY PULL REQUESTS OR PERSONAL MODIFICATIONS.**
 
 Please also refer to the [CODE_STYLE](CODE_STYLE.md) document if making contributions to any JavaScript files.

--- a/kubejs/assets/createastral/lang/en_us.json
+++ b/kubejs/assets/createastral/lang/en_us.json
@@ -2936,7 +2936,7 @@
   "ftbquests.chapter.read_the_questbook.quests17.description4": "Simply set the value in this file from 'true' to 'false'",
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Combat Music",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "The custom music you will hear throughout the pack is licensed so that you may use it &6wherever you wish&r!",
-  "ftbquests.chapter.read_the_questbook.quests18.description2": "Feel free to include it in &6YouTube videos&r or content surrounding Astral, it will not receieve strikes.",
+  "ftbquests.chapter.read_the_questbook.quests18.description2": "Feel free to include it in &6YouTube videos&r or content surrounding Astral, it will not receive strikes.",
   "ftbquests.chapter.read_the_questbook.quests18.description4": "Music was produced by Hesperyd, XETROO, PINS3Y, ethanicuss",
   "ftbquests.chapter.read_the_questbook.quests18.tasks0.title": "Astral Music Info",
   "ftbquests.chapter.read_the_questbook.quests19.title": "&6Create Big Cannon changes&r",

--- a/kubejs/server_scripts/recipes/create/filling.js
+++ b/kubejs/server_scripts/recipes/create/filling.js
@@ -158,6 +158,12 @@
         amount: 250 * mB,
       },
       {
+        input: "farmersdelight:pie_crust",
+        output: "farmersdelight:chocolate_pie",
+        fluid: "create:chocolate",
+        amount: 500 * mB,
+      },
+      {
         input: "drinkbeer:empty_beer_mug",
         output: "drinkbeer:beer_mug",
         fluid: "kubejs:miner_pale_ale_fluid",

--- a/kubejs/server_scripts/recipes/create/mixing.js
+++ b/kubejs/server_scripts/recipes/create/mixing.js
@@ -68,7 +68,7 @@
         time: 180,
       },
       {
-        output: [Item.of("createastral:shimmer_marimo", 2)],
+        output: [Item.of("createastral:shimmer_marimo", 3)],
         input: ["createastral:shimmer_marimo", "ae2:fluix_crystal_seed", { fluid: "kubejs:shimmer", amount: INGOT }],
         time: 180,
       },
@@ -78,7 +78,7 @@
         time: 180,
       },
       {
-        output: [Item.of("createastral:ender_marimo", 2)],
+        output: [Item.of("createastral:ender_marimo", 3)],
         input: [
           "createastral:ender_marimo",
           "tconstruct:ender_slime_grass_seeds",
@@ -92,7 +92,7 @@
         time: 180,
       },
       {
-        output: [Item.of("createastral:snowy_marimo", 2)],
+        output: [Item.of("createastral:snowy_marimo", 3)],
         input: ["createastral:snowy_marimo", "ad_astra:ice_shard", { fluid: "minecraft:water", amount: 500 * mB }],
         time: 180,
       },
@@ -115,7 +115,7 @@
         time: 180,
       },
       {
-        output: [Item.of("createastral:marimo", 2), { fluid: "minecraft:water", amount: 500 * mB }],
+        output: [Item.of("createastral:marimo", 3), { fluid: "minecraft:water", amount: 500 * mB }],
         input: ["createastral:marimo", { fluid: "minecraft:water", amount: 500 * mB }],
         time: 60,
       },

--- a/kubejs/server_scripts/recipes/removals.js
+++ b/kubejs/server_scripts/recipes/removals.js
@@ -684,6 +684,7 @@
       { type: "farmersdelight:cutting", input: "minecraft:gravel" },
       { type: "farmersdelight:cutting", input: "farmersdelight:wild_rice" },
       { output: "farmersdelight:wheat_dough" },
+      { id: "farmersdelight:create/filling/chocolate_pie" },
       // Hephaestus modifiers
       { id: "tconstruct:tools/modifiers/ability/double_jump" },
       { id: "tconstruct:tools/modifiers/ability/luck_level_1" },

--- a/serverpack/readme.txt
+++ b/serverpack/readme.txt
@@ -1,4 +1,8 @@
+PLEASE READ THE WHOLE DOCUMENT! It contains all the information required to set up the server, as well as some troubleshooting tips for common problems.
+
 After you've extracted the serverpack, follow these steps to fully set up the server:
+
+=-= If you downloaded this serverpack from the Astral GitHub releases, you do not need to do step 3. Step 3 only applies if you downloaded from Curseforge. =-=
 
 1. Download download the fabric server .jar version 0.16.3 at https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.16.3/0.11.1/server/jar
 2. Drag into main folder of server (with mods folder, config folder etc.), rename to exactly "server.jar"
@@ -11,17 +15,23 @@ After you've extracted the serverpack, follow these steps to fully set up the se
 5. Once server runs, an "eula.txt" will appear. Open it and set it to 'true'.
 6. Re-run the server and it should now boot.
 
-Ensure you have properly port-forwarded your ip! This varies wildly based on your internet provider, server host or country so find an online resource to help with this.
+Ensure you have properly port-forwarded your IP! This varies wildly based on your internet provider, server host, or country so find an online resource to help with this.
 To change the allocated RAM, open your relevant startup script in notepad and change the -XMX and -XMS flags from 4G or 6G to whatever amount of gigabytes of ram you prefer.
 Don't forget to op yourself through console to perform admin commands ingame 'op YOURNAME'.
 
-If the included scripts don't launch, try booting with your own, especially if using a server host who usually like to use their own start scripts and fabric .jars
+TROUBLESHOOTING:
+
+If the included startup scripts don't launch, try booting with your own, especially if using a server host who usually like to use their own start scripts and fabric .jars
 
 If server instantly crashes when booting = Java version mismatch (Use Java 17)
 
 If server does a lot of setup (30 seconds+) before crashing = Mod issue, if you added any extra mods try removing them first and see if it works.
 
-If fluids like water don't behave like fluids when you try swimming in them, check that you followed step 3.
+If fluids like water don't behave like fluids when you try swimming in them, and you downloaded the pack from Curseforge, check that you followed step 3.
+
+If there are missing quest icons in the questbook, and you downloaded the pack from Curseforge, check that you followed step 3.
+
+If none of these frequently occuring issues apply to you or the fixes don't work, you can join our discord at https://discord.gg/StW3Q5K8dJ and open a thread in the #help forum channel!
 
 ---
 


### PR DESCRIPTION
This pull request:
- Fixes #571
- Fixes tag assignment to feature requests and bug reports
- Increases recipe output of marimo dupe recipes to 3 for easier recycling using brass funnels set to extract 2 marimo, leaving one in the basin
- Updates changelog with changes missed in the menutweaks PR