### PR TITLE
Fix Chapter 2.5 quest "Brass Casing" dependencies

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_25_the_automation_matrix.snbt
+++ b/config/ftbquests/quests/chapters/chapter_25_the_automation_matrix.snbt
@@ -858,7 +858,6 @@
 			y: 16.25d
 			shape: "diamond"
 			description: [""]
-			min_required_dependencies: 2
 			dependencies: ["737625E7DFCB0382"]
 			size: 2.5d
 			id: "1D0E2A46A37501CB"


### PR DESCRIPTION
Having the "minimum required dependencies" set to 2 with this quest only having 1 dependency prevented it from enabling, and thus completing.
