### PR TITLE
Remove Blackstone task from Ch3 quest

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_4.snbt
+++ b/config/ftbquests/quests/chapters/chapter_4.snbt
@@ -2647,11 +2647,6 @@
 			id: "47130960FB5806A9"
 			tasks: [
 				{
-					id: "2C3778A72EB57BB5"
-					type: "item"
-					item: "minecraft:blackstone"
-				}
-				{
 					id: "7613AA318E6B7917"
 					type: "item"
 					item: "minecraft:glow_berries"


### PR DESCRIPTION
I think it was just an oversight that this wasn't removed when the Blackstone recipe got changed.