### PR TITLE
Refactor: Stylistics, constants and custom projectile type defintitions

### DIFF
--- a/kubejs/custom_types/extraprobe.d.ts
+++ b/kubejs/custom_types/extraprobe.d.ts
@@ -6,6 +6,7 @@ declare namespace Helper {
 
   type Items = Internal.ItemStackJS_ | `#${Special.ItemTag}` | `@${Special.Mod}` | "*";
   type ItemOrTag = { item: Special.Item } | { tag: Special.ItemTag };
+  type ItemOrTagWithCount = { item: Special.Item, count?: number } | { tag: Special.ItemTag, count?: number };
   type FluidOrTag = { fluid: Special.Fluid } | { tag: Special.FluidTag };
   interface Tooltip {
     item: Special.Item;

--- a/kubejs/server_scripts/misc/diamond_ore.js
+++ b/kubejs/server_scripts/misc/diamond_ore.js
@@ -1,4 +1,6 @@
-onEvent("tags.blocks", (event) => {
+(function diamondOreTagRemoval() {
+  onEvent("tags.blocks", (event) => {
     event.remove("minecraft:needs_iron_tool", "minecraft:diamond_ore");
     event.remove("minecraft:needs_iron_tool", "minecraft:deepslate_diamond_ore");
-});
+  });
+})();

--- a/kubejs/server_scripts/misc/interaction.d.ts
+++ b/kubejs/server_scripts/misc/interaction.d.ts
@@ -1,0 +1,95 @@
+interface ProjectileConfig {
+  projectile: { item: Special.Item };
+  particles: ProjectileSettings.Particles;
+  explosion: ProjectileSettings.Explosion;
+  createAutoJson?: ProjectileSettings.CreateAutoJSON;
+  AOE?: ProjectileSettings.AOE;
+  sound?: ProjectileSettings.Sound;
+}
+
+namespace ProjectileSettings {
+  interface CreateAutoJSON {
+    fileName: string;
+    reloadTicks: number;
+    damage: number;
+    knockback: number;
+    drag: number;
+    velocityMultiplier: number;
+    gravityMultiplier: number;
+    sticky: boolean;
+    soundPitch: number;
+  }
+
+  interface ParticlesEnabledNoColor {
+    /** Whether the ammo emits particles or not. */
+    enabled: true;
+    spread: number;
+    size: number;
+    speed: number;
+    count: number;
+    type: Special.ParticleType;
+    /** Specifies whether the particle's color can be changed. */
+    hasColor: false;
+  }
+
+  interface ParticlesEnabledWithColor extends ParticlesEnabledNoColor {
+    hasColor: true;
+    /** The color of the particle. */
+    color: [red: number, green: number, blue: number];
+  }
+
+  interface ParticlesDisabled {
+    enabled: false;
+  }
+
+  type Particles = ParticlesEnabledNoColor | ParticlesEnabledWithColor | ParticlesDisabled;
+
+  interface ExplosionEnabled {
+    enabled: true;
+    strength: number;
+    damageTerrain: boolean;
+    causesFire?: boolean;
+    silent?: boolean;
+  }
+
+  interface ExplosionDisabled {
+    enabled: false;
+  }
+
+  type Explosion = ExplosionEnabled | ExplosionDisabled;
+
+  interface AOE_Enabled {
+    enabled: true;
+    effectList: Effect[];
+    sound: Sound;
+  }
+
+  interface Effect {
+    potionEffect: Special.MobEffect;
+    potionTime: number;
+    potionAmplifier: number;
+    potionHideParticles: boolean;
+    range: `${bigint}`; // This should be a `number` but there's some jank happening on Java side
+  }
+
+  interface SoundEnabled {
+    enabled: true;
+    soundList: SoundCommand[];
+  }
+
+  type StringSoundSource = Extract<Internal.SoundSource_, string>;
+
+  interface SoundCommand {
+    soundName: Special.SoundEvent;
+    soundType: StringSoundSource;
+    soundRange: `${bigint}`; // This should be a `number` but there's some jank happening on Java side
+    soundVolume: number;
+    soundPitch: number;
+  }
+
+  interface SoundDisabled {
+    enabled: false;
+  }
+
+  type Sound = SoundEnabled | SoundDisabled;
+}

--- a/kubejs/server_scripts/misc/interaction.js
+++ b/kubejs/server_scripts/misc/interaction.js
@@ -1,3 +1,4 @@
+/// <reference types="./interaction.d.ts"/>
 /**
  * This file originally contained comments marked with "Better Comments" VS Code extension.
  * Now it has JSDoc comments instead, which have better editor integration.
@@ -99,64 +100,6 @@
     }
   });
 
-  /**
-   * @typedef ProjectileConfig
-   * @property {Projectile} projectile
-   * @property {Particles} particles
-   * @property {Explosion} explosion
-   */
-
-  /**
-   * @typedef Projectile
-   * @property {Special.Item} item Item ID.
-   */
-
-  /** @typedef {ParticlesEnabledWithNoColor | ParticlesEnabledWithColor | ParticlesDisabled} Particles */
-
-  /**
-   * @typedef ParticlesEnabledWithNoColor
-   * @property {true} enabled Whether the ammo emits particles or not.
-   * @property {number} spread
-   * @property {number} size
-   * @property {number} speed
-   * @property {number} count
-   * @property {string} type
-   * @property {number} size
-   * @property {false} hasColor Specifies whether the particle's color can be changed.
-   */
-
-  /**
-   * @typedef ParticlesEnabledWithColor
-   * @property {true} enabled Whether the ammo emits particles or not.
-   * @property {number} spread
-   * @property {number} size
-   * @property {number} speed
-   * @property {number} count
-   * @property {string} type
-   * @property {number} size
-   * @property {true} hasColor Specifies whether the particle's color can be changed.
-   * @property {[red: number, green: number, blue: number]} color The color of the particle
-   */
-
-  /**
-   * @typedef ParticlesDisabled
-   * @property {false} enabled Whether the ammo emits particles or not.
-   */
-
-  /** @typedef {ExplosionEnabled | ExplosionDisabled} Explosion */
-
-  /**
-   * @typedef ExplosionEnabled
-   * @property {true} enabled
-   * @property {number} strength
-   * @property {boolean} damageTerrain
-   */
-
-  /**
-   * @typedef ExplosionDisabled
-   * @property {false} enabled
-   */
-
   /** @type {ProjectileConfig[]} */
 
   //? createAutoJson will now also create the required json for create to understand that it can shoot that item.
@@ -212,7 +155,7 @@
       },
       sound: {
         enabled: false,
-        soundList: [],
+        // soundList: [],
       },
     },
     {
@@ -243,6 +186,7 @@
         sticky: ammo.sticky,
         sound_pitch: ammo.soundPitch,
       };
+      // @ts-expect-error This works.
       JsonIO.write(`kubejs/data/createastral/potato_cannon_projectile_types/${ammo.fileName}.json`, json);
     });
   });
@@ -254,14 +198,14 @@
         if (entity.fullNBT.Item.id === ammoType.projectile.item) {
           server.scheduleInTicks(5, (event) => {
             if (entity.removed || entity.deadOrDying || !entity.alive) {
-              let x = entity.fullNBT.Pos[0];
-              let y = entity.fullNBT.Pos[1];
-              let z = entity.fullNBT.Pos[2];
-              let dim = entity.getLevel().getDimension();
-              let explosion = entity.block.offset(0, 0, 0).createExplosion();
+              const x = entity.fullNBT.Pos[0];
+              const y = entity.fullNBT.Pos[1];
+              const z = entity.fullNBT.Pos[2];
+              const dim = entity.getLevel().getDimension();
+              const explosion = entity.block.offset(0, 0, 0).createExplosion();
               if (ammoType.particles.enabled) {
                 if (ammoType.particles.hasColor) {
-                  let [red, green, blue] = ammoType.particles.color;
+                  const [red, green, blue] = ammoType.particles.color;
                   server.runCommandSilent(
                     `execute in ${dim} run particle ${ammoType.particles.type} ${red} ${green} ${blue} ${ammoType.particles.size} ${x} ${y} ${z} ${ammoType.particles.spread} ${ammoType.particles.spread} ${ammoType.particles.spread} ${ammoType.particles.speed} ${ammoType.particles.count}`
                   );
@@ -306,48 +250,46 @@
         }
       });
     } else if (entity.type === "minecraft:item") {
-      let dim = entity.getLevel().getDimension();
-      let x = entity.x,
-        y = entity.y,
-        z = entity.z;
+      const dim = entity.getLevel().getDimension();
+      const {x, y, z} = entity;
       switch (entity.item) {
         case "createastral:fragile_sheet":
           entity.item = "createastral:broken_fragile_sheet";
           server.runCommandSilent(
-            `execute in ${dim} run particle minecraft:block minecraft:magenta_concrete_powder ${entity.x} ${entity.y} ${entity.z} 0.0 0.1 0.0 0 5`
+            `execute in ${dim} run particle minecraft:block minecraft:magenta_concrete_powder ${x} ${y} ${z} 0.0 0.1 0.0 0 5`
           );
           server.runCommandSilent(
-            `execute in ${dim} run playsound create:crushing_1 block @a ${entity.x} ${entity.y} ${entity.z}`
+            `execute in ${dim} run playsound create:crushing_1 block @a ${x} ${y} ${z}`
           );
           break;
 
         case "createastral:fragile_rocket_fin":
           entity.item = "createastral:broken_fragile_rocket_fin";
           server.runCommandSilent(
-            `execute in ${dim} run particle minecraft:block createastral:sturdy_sheet_block ${entity.x} ${entity.y} ${entity.z} 0.0 0.1 0.0 0 5`
+            `execute in ${dim} run particle minecraft:block createastral:sturdy_sheet_block ${x} ${y} ${z} 0.0 0.1 0.0 0 5`
           );
           server.runCommandSilent(
-            `execute in ${dim} run playsound create:crushing_1 block @a ${entity.x} ${entity.y} ${entity.z}`
+            `execute in ${dim} run playsound create:crushing_1 block @a ${x} ${y} ${z}`
           );
           break;
 
         case "kubejs:fragile_sheet_block":
           entity.item = "kubejs:broken_fragile_sheet_block";
           server.runCommandSilent(
-            `execute in ${dim} run particle minecraft:block kubejs:fragile_sheet_block ${entity.x} ${entity.y} ${entity.z} 0.0 0.1 0.0 0 5`
+            `execute in ${dim} run particle minecraft:block kubejs:fragile_sheet_block ${x} ${y} ${z} 0.0 0.1 0.0 0 5`
           );
           server.runCommandSilent(
-            `execute in ${dim} run playsound create:crushing_1 block @a ${entity.x} ${entity.y} ${entity.z}`
+            `execute in ${dim} run playsound create:crushing_1 block @a ${x} ${y} ${z}`
           );
           break;
 
         case "kubejs:fire_resistant_fragile_sheet_block":
           entity.item = "kubejs:broken_fire_resistant_fragile_sheet_block";
           server.runCommandSilent(
-            `execute in ${dim} run particle minecraft:block kubejs:broken_fire_resistant_fragile_sheet_block ${entity.x} ${entity.y} ${entity.z} 0.0 0.1 0.0 0 5`
+            `execute in ${dim} run particle minecraft:block kubejs:broken_fire_resistant_fragile_sheet_block ${x} ${y} ${z} 0.0 0.1 0.0 0 5`
           );
           server.runCommandSilent(
-            `execute in ${dim} run playsound create:crushing_1 block @a ${entity.x} ${entity.y} ${entity.z}`
+            `execute in ${dim} run playsound create:crushing_1 block @a ${x} ${y} ${z}`
           );
           break;
 

--- a/kubejs/server_scripts/misc/tconstruct_fluidsyncfix.js
+++ b/kubejs/server_scripts/misc/tconstruct_fluidsyncfix.js
@@ -1,4 +1,8 @@
-onEvent("block.right_click", (event) => {
-  if (event.block.id == "tconstruct:foundry_controller" && event.block.entity.tank != null)
-    event.block.entity.tank.syncFluids();
-});
+// @ts-nocheck
+// Do not type check this, this is guaranteed to work.
+(function hephaestusFluidSyncFix() {
+  onEvent("block.right_click", (event) => {
+    if (event.block.id == "tconstruct:foundry_controller" && event.block.entity.tank != null)
+      event.block.entity.tank.syncFluids();
+  });
+})();

--- a/kubejs/server_scripts/recipes/astral_generators/machines/boiler.js
+++ b/kubejs/server_scripts/recipes/astral_generators/machines/boiler.js
@@ -1,4 +1,6 @@
 (function astralGeneratorsBoilerRecipes() {
+  const { BUCKET } = global.fluids;
+
   onEvent("recipes", (event) => {
     boilerSteamFromFuel(event);
     boilerSteamFromLava(event);
@@ -17,12 +19,12 @@
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "minecraft:water",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:fluid",
           fluid: "astralgenerators:steam",
-          amount: 201600,
+          amount: 2 * BUCKET,
           mode: "output",
         },
         {
@@ -51,18 +53,18 @@
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "minecraft:lava",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "minecraft:water",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:fluid",
           fluid: "astralgenerators:steam",
-          amount: 201600,
+          amount: 2 * BUCKET,
           mode: "output",
         },
         {

--- a/kubejs/server_scripts/recipes/astral_generators/machines/fusion_reactor.js
+++ b/kubejs/server_scripts/recipes/astral_generators/machines/fusion_reactor.js
@@ -1,4 +1,5 @@
 (function astralGeneratorsFusionReactorRecipes() {
+  const { BUCKET } = global.fluids;
   onEvent("recipes", (event) => {
     fusionHelium3(event);
   });
@@ -13,18 +14,18 @@
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "techreborn:deuterium",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "techreborn:tritium",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:fluid",
           fluid: "techreborn:helium3",
-          amount: 100800,
+          amount: BUCKET,
           mode: "output",
         },
         {

--- a/kubejs/server_scripts/recipes/astral_generators/machines/particle_accelerator.js
+++ b/kubejs/server_scripts/recipes/astral_generators/machines/particle_accelerator.js
@@ -1,4 +1,5 @@
 (function astralGeneratorsParticleAcceleratorRecipes() {
+  const {BUCKET} = global.fluids;
   onEvent("recipes", (event) => {
     acceleratorSingularity(event);
   });
@@ -25,7 +26,7 @@
           type: "custommachinery:fluid",
           mode: "input",
           fluid: "minecraft:water",
-          amount: 100800,
+          amount: BUCKET,
         },
         {
           type: "custommachinery:energy",

--- a/kubejs/server_scripts/recipes/astral_generators/machines/steam_turbine.js
+++ b/kubejs/server_scripts/recipes/astral_generators/machines/steam_turbine.js
@@ -1,4 +1,5 @@
 (function astralGeneratorsSteamTurbineRecipes() {
+  const { BUCKET } = global.fluids;
   onEvent("recipes", (event) => {
     turbineSteamToEnergy(event);
   });
@@ -12,7 +13,7 @@
         {
           type: "custommachinery:fluid",
           fluid: "astralgenerators:steam",
-          amount: 84000,
+          amount: BUCKET * 5 / 12, // In order to maintain the ratio with the previous weird value. Whyyyyyyy
           mode: "input",
         },
         {

--- a/kubejs/server_scripts/recipes/create/mixing.js
+++ b/kubejs/server_scripts/recipes/create/mixing.js
@@ -1,5 +1,5 @@
 (function createMixingRecipes() {
-  const { BUCKET, GEM_BLOCK, SLIMEBALL, INGOT, GEM, NUGGET, mB } = global.fluids;
+  const { BUCKET, BOTTLE, GEM_BLOCK, SLIMEBALL, INGOT, GEM, NUGGET, mB } = global.fluids;
 
   onEvent("recipes", (event) => {
     farmersCompatMixing(event);
@@ -1182,8 +1182,8 @@
         output: ["astralfoods:bulbas_tea"],
         input: [
           "astraladditions:bulba_root",
-          { fluid: "minecraft:water", amount: 333 * mB },
-          { fluid: "milk:still_milk", amount: 333 * mB },
+          { fluid: "minecraft:water", amount: BOTTLE },
+          { fluid: "milk:still_milk", amount: BOTTLE },
         ],
         heat: "heated",
         time: 45,
@@ -2633,7 +2633,7 @@
         heat: "superheated",
       },
       {
-        output: { fluid: "kubejs:liquid_xp_nuggies", amount: 1000 },
+        output: { fluid: "kubejs:liquid_xp_nuggies", amount: NUGGET },
         input: ["create:experience_nugget"],
         heat: "heated",
         time: 10,
@@ -2651,7 +2651,7 @@
         time: 1000,
       },
       {
-        output: { fluid: "kubejs:liquid_xp_nuggies", amount: 2000 },
+        output: { fluid: "kubejs:liquid_xp_nuggies", amount: 2 * NUGGET },
         input: ["xpcrystals:xp_crystal"],
         heat: "heated",
         time: 12,
@@ -2674,7 +2674,7 @@
         time: 25,
       },
       {
-        output: { fluid: "createaddition:bioethanol", amount: 81000 },
+        output: { fluid: "createaddition:bioethanol", amount: BUCKET },
         input: ["minecraft:sugar", "create:cinder_flour", Item.of("createaddition:biomass", 2)],
       },
       {

--- a/kubejs/server_scripts/recipes/tconstruct/smeltery/casting_basin.js
+++ b/kubejs/server_scripts/recipes/tconstruct/smeltery/casting_basin.js
@@ -89,7 +89,6 @@
         fluidInput: { fluid: "tconstruct:molten_tin", amount: BUCKET },
         result: "extended_drawers:shadow_drawer",
         coolingTime: 117, // same as cooling tin block
-        // @ts-expect-error Missing tag?
         cast: { tag: "extended_drawers:drawer_containers", consumed: true },
       },
       {

--- a/kubejs/server_scripts/recipes/techreborn/grinder.js
+++ b/kubejs/server_scripts/recipes/techreborn/grinder.js
@@ -5,7 +5,7 @@
     crushingToGrinding(event);
     /**
      * @typedef GrinderRecipe
-     * @property {{item: Special.Item, count?: number}[]} input
+     * @property {Helper.ItemOrTagWithCount[]} input
      * @property {{item: Special.Item, count?: number}[]} output
      * @property {number} time
      * @property {number} power
@@ -32,7 +32,7 @@
         power: 5,
       },
       {
-        input: [{ tag: `c:basalt`, count: 1 }], //tag
+        input: [{ tag: "c:basalt", count: 1 }], //tag
         output: [{ item: "techreborn:basalt_dust", count: 1 }],
         time: 200,
         power: 5,

--- a/kubejs/server_scripts/server-constants.js
+++ b/kubejs/server_scripts/server-constants.js
@@ -352,7 +352,10 @@ global.server = Object.freeze({
      * @returns {this} The current instance.
      */
     SequencedAssemblyBuilder.prototype.addDeployingStep = function (item) {
-      this._steps.push(this._event.recipes.createDeploying(this._transitional, [this._transitional, item]));
+      // Inputs extracted into its own variable to work around the "union type too complex to represent" error.
+      /** @type {Internal.IngredientJS_} */
+      const inputs = [this._transitional, item]
+      this._steps.push(this._event.recipes.createDeploying(this._transitional, inputs));
       return this;
     };
 

--- a/kubejs/startup_scripts/fluid-constants.js
+++ b/kubejs/startup_scripts/fluid-constants.js
@@ -3,6 +3,7 @@
 global.fluids = Object.freeze({
   BUCKET: 81000,
   GEM_BLOCK: 72900,
+  BOTTLE: 27000,
   SLIMEBALL: 20250,
   INGOT: 9000,
   GEM: 8100,


### PR DESCRIPTION
This PR:
- Puts every script that wasn't in an IIFE already into an IIFE,
- Hephaestus fluid sync fix script is explicitly NOT type checked (used `// @ts-nocheck` comment),
- Changes numbers to fluid constants in places where those constants weren't used,
- Remade type definitions for custom projectile script: `interaction.js`. Types for this file now are housed in a `d.ts` file because of the amount of type definitions needed.

Moves:
- Moved fluid constants to **startup scripts**, in case startup scripts would need fluid constants too sometime (currently they don't).

From things that are slightly changed at runtime:
- Bulba tea now outputs a bottle of Bulba tea instead of 333 mB - no more stray millibuckets,
- Defined's multiblock fluid inputs and outputs now are based around a bucket amount (81000) instead of 1224 <sup>4</sup>/<sub>9</sub> mB, so now:
  - 1 bucket of Water and 1 bucket of Lava results in 2 buckets of Steam,
  - Steam Generator uses <sup>5</sup>/<sub>12</sub>th of a bucket to generate energy.

Original ratios are kept, so this change shouldn't impact already existing generators.