### PR TITLE
Prevent rubble dupe methods before superheating

### DIFF
--- a/kubejs/data/yttr/loot_tables/blocks/ruined.json
+++ b/kubejs/data/yttr/loot_tables/blocks/ruined.json
@@ -1,0 +1,25 @@
+{
+  "replace": true,
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "yttr:rubble",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0,
+                "max": 2,
+                "type": "minecraft:uniform"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/data/yttr/loot_tables/blocks/ruined_container.json
+++ b/kubejs/data/yttr/loot_tables/blocks/ruined_container.json
@@ -1,0 +1,25 @@
+{
+  "replace": true,
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "yttr:rubble",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0,
+                "max": 2,
+                "type": "minecraft:uniform"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What does this pull request do?

Reduces maximum obtainable rubble from the ruined blocks. Nerfs the ruined container into the dirt as well.

## Changes made

- Fixes #628 
