### PR TITLE
Ch2.5: Change Blackstone quest to Basalt

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_25_the_automation_matrix.snbt
+++ b/config/ftbquests/quests/chapters/chapter_25_the_automation_matrix.snbt
@@ -2466,7 +2466,7 @@
 			]
 		}
 		{
-			icon: "minecraft:blackstone"
+			icon: "minecraft:basalt"
 			x: -26.0d
 			y: 1.0d
 			hide_dependency_lines: true
@@ -2476,7 +2476,7 @@
 				{
 					id: "6B85531A164856E6"
 					type: "item"
-					item: "minecraft:blackstone"
+					item: "minecraft:basalt"
 				}
 				{
 					id: "3FEA8A8FB08C7AEC"


### PR DESCRIPTION
## What does this pull request do?

Fixes a questbook inconsistency.

## Changes made

- In Ch2.5, change the Blackstone task/quest to require Basalt

## Additional Information

Credit to dragonics_playz on Discord for reporting.