### PR TITLE
Add new deployment workflows

### DIFF
--- a/.github/workflows/packwiz.yml
+++ b/.github/workflows/packwiz.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create CurseForge client zip
         run: |
-          ./packwiz curseforge export -o ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip
+          ./packwiz curseforge export -o "${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip"
           ./packwiz refresh
 
       - name: Clean up after CurseForge client zip creation
@@ -117,7 +117,7 @@ jobs:
       - name: Unpack client pack for nicer artifact
         if: ${{github.event.inputs.artifacts}}
         run: |
-          unzip ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip -d ./client
+          unzip "${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip" -d ./client
 
       - name: Upload client pack to GitHub
         if: ${{ github.event.inputs.artifacts }}

--- a/.github/workflows/packwiz.yml
+++ b/.github/workflows/packwiz.yml
@@ -74,6 +74,7 @@ jobs:
           ./packwiz refresh
 
       - name: Clean up after CurseForge client zip creation
+        run: |
           ./packwiz remove servercore
           mv temp-jar/servercore* ./mods
           rm -r ./temp-jar

--- a/.github/workflows/packwiz.yml
+++ b/.github/workflows/packwiz.yml
@@ -1,129 +1,144 @@
 name: Build with packwiz
 
 on:
-    workflow_dispatch:
-        inputs:
-            artifacts:
-                description: Upload artifacts
-                required: true
-                default: "true"
-            serverpack:
-                description: Create serverpack
-                required: true
-                default: "true"
-            publish:
-                description: Publish version to CurseForge
-                required: false
-                default: "false"
-    pull_request:
-        branches: ["main", "Astral-Experimental"]
-    push:
-        branches: ["main", "Astral-Experimental"]
+  workflow_dispatch:
+    inputs:
+      artifacts:
+        description: Upload artifacts
+        required: true
+        default: "true"
+      serverpack:
+        description: Create serverpack
+        required: true
+        default: "true"
+      publish:
+        description: Publish version to CurseForge
+        required: false
+        default: "false"
+  pull_request:
+    branches: ["main", "Astral-Experimental"]
+  push:
+    branches: ["main", "Astral-Experimental"]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Repository
-              uses: actions/checkout@v4
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-            - name: setup jdk 17
-              uses: actions/setup-java@v4
-              with:
-                  java-version: 17
-                  distribution: "temurin"
+      - name: setup jdk 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
 
-            - name: Get latest packwiz binary
-              id: download-packwiz
-              uses: dawidd6/action-download-artifact@v6
-              with:
-                  workflow: go.yml
-                  branch: main
-                  name: Linux 64-bit x86
-                  repo: packwiz/packwiz
+      - name: Get latest packwiz binary
+        id: download-packwiz
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: go.yml
+          branch: main
+          name: Linux 64-bit x86
+          repo: packwiz/packwiz
 
-            - name: Make packwiz binary executable
-              run: chmod +x ./packwiz
+      - name: Make packwiz binary executable
+        run: chmod +x ./packwiz
 
-            - name: Restore cached mod downloads
-              id: cache-mods-restore
-              uses: actions/cache/restore@v4
-              with:
-                  path: /home/runner/.cache/packwiz/cache
-                  key: cached-mods
-                  restore-keys: |
-                      cached-mods-
+      - name: Restore cached mod downloads
+        id: cache-mods-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/packwiz/cache
+          key: cached-mods
+          restore-keys: |
+            cached-mods-
 
-            - name: Construct version string
-              id: construct-base-name
-              run: |
-                  echo "ASTRAL_BASE_NAME=create_astral-${{github.run_number}}" >> "$GITHUB_OUTPUT"
+      - name: Construct version string
+        id: construct-base-name
+        run: |
+          VERSION_NUMBER="$(echo "$(<pack.toml)" | grep "version =" | cut -d '"' -f 2)"
+          echo "ASTRAL_CF_NAME=Create-Astral-CurseForge-$VERSION_NUMBER-${{github.run_number}}" >> "$GITHUB_OUTPUT"
+          echo "ASTRAL_SERVER_NAME=Create-Astral-Server-$VERSION_NUMBER-${{github.run_number}}" >> "$GITHUB_OUTPUT"
 
-            - name: Create CurseForge client zip
-              run: |
-                  ./packwiz curseforge export -o ${{steps.construct-base-name.outputs.ASTRAL_BASE_NAME}}-client.zip
+      # servercore needs to be turned into a .toml for the curseforge export as CF won't accept it as an override jar
+      - name: Prepare for CurseForge client zip creation
+        run: |
+          mkdir temp-jar
+          mv mods/servercore* ./temp-jar
+          ./packwiz cf add ServerCore
 
-            - name: Prepare for serverpack creation
-              if: ${{ github.event.inputs.serverpack }}
-              run: |
-                  cat server.packwizignore >> .packwizignore
-                  mv serverpack/* ./
-                  ./packwiz refresh
-                  mkdir server
+      - name: Create CurseForge client zip
+        run: |
+          ./packwiz curseforge export -o ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip
+          ./packwiz refresh
 
-            - name: Download packwiz-installer-bootstrap
-              if: ${{ github.event.inputs.serverpack }}
-              uses: robinraju/release-downloader@v1.10
-              with:
-                  repository: packwiz/packwiz-installer-bootstrap
-                  latest: true
-                  fileName: packwiz-installer-bootstrap.jar
+      - name: Clean up after CurseForge client zip creation
+          ./packwiz remove servercore
+          mv temp-jar/servercore* ./mods
+          rm -r ./temp-jar
 
-            - name: Create serverpack
-              if: ${{ github.event.inputs.serverpack }}
-              run: |
-                  cd server
-                  java -jar ../packwiz-installer-bootstrap.jar -g -s server ../pack.toml
-                  rm -f packwiz-installer.jar
-                  ls -l
-                  cd ../
+      - name: Prepare for serverpack creation
+        if: ${{ github.event.inputs.serverpack }}
+        run: |
+          cat server.packwizignore >> .packwizignore
+          mv serverpack/* ./
+          ./packwiz refresh
+          mkdir server
 
-            - name: Cache mod downloads
-              id: cache-mods-save
-              uses: actions/cache/save@v4
-              with:
-                  path: |
-                      /home/runner/.cache/packwiz/cache
-                      ./server/mods
-                  key: cached-mods-${{ hashFiles('/home/runner/.cache/packwiz/cache/**/*') }}-${{ hashFiles('./server/mods') }}
+      - name: Download packwiz-installer-bootstrap
+        if: ${{ github.event.inputs.serverpack }}
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: packwiz/packwiz-installer-bootstrap
+          latest: true
+          fileName: packwiz-installer-bootstrap.jar
 
-            # Otherwise the artifact would be a zip in a zip, which can't be automatically installed in launchers
-            - name: Unpack client pack for nicer artifact
-              if: ${{github.event.inputs.artifacts}}
-              run: |
-                  unzip ${{steps.construct-base-name.outputs.ASTRAL_BASE_NAME}}-client.zip -d ./client
+      - name: Create serverpack
+        if: ${{ github.event.inputs.serverpack }}
+        run: |
+          cd server
+          java -jar ../packwiz-installer-bootstrap.jar -g -s server ../pack.toml
+          rm -f packwiz-installer.jar
+          ls -l
+          cd ../
 
-            - name: Upload client pack to GitHub
-              if: ${{ github.event.inputs.artifacts }}
-              uses: actions/upload-artifact@v4
-              with:
-                  name: ${{steps.construct-base-name.outputs.ASTRAL_BASE_NAME}}-client
-                  path: ./client
+      - name: Cache mod downloads
+        id: cache-mods-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /home/runner/.cache/packwiz/cache
+            ./server/mods
+          key: cached-mods-${{ hashFiles('/home/runner/.cache/packwiz/cache/**/*') }}-${{ hashFiles('./server/mods') }}
 
-            - name: Upload serverpack to GitHub
-              if: ${{ github.event.inputs.serverpack && github.event.inputs.artifacts }}
-              uses: actions/upload-artifact@v4
-              with:
-                  name: ${{steps.construct-base-name.outputs.ASTRAL_BASE_NAME}}-server
-                  path: ./server
+      # Otherwise the artifact would be a zip in a zip, which can't be automatically installed in launchers
+      - name: Unpack client pack for nicer artifact
+        if: ${{github.event.inputs.artifacts}}
+        run: |
+          unzip ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}.zip -d ./client
 
-    # This job publishes the modpack to CurseForge
-    publish:
-        runs-on: ubuntu-latest
-        needs: build
-        if: ${{github.event.inputs.publish}}
-        steps:
-            - name: Prepare files
-              uses: actions/download-artifact@v4
-            - name: List files
-              run: ls -l
+      - name: Upload client pack to GitHub
+        if: ${{ github.event.inputs.artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}
+          path: ./client
+
+      - name: Upload serverpack to GitHub
+        if: ${{ github.event.inputs.serverpack && github.event.inputs.artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{steps.construct-base-name.outputs.ASTRAL_SERVER_NAME}}
+          path: ./server
+
+  # This job publishes the modpack to CurseForge
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{github.event.inputs.publish}}
+    steps:
+      - name: Prepare files
+        uses: actions/download-artifact@v4
+      - name: List files
+        run: ls -l

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Create release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: Version to display on all fields
+        required: true
+
+jobs:
+  versioning:
+    name: Grab version numbers
+    runs-on: ubuntu-latest
+    outputs:
+      old_version: ${{steps.old-version.outputs.version}}
+      new_version: ${{github.events.inputs.new_version}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get old version
+        id: old-version
+        shell: bash
+        run: |
+          echo "version=$(echo "$(<pack.toml)" | grep "version =" | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Open Pull Request
+    needs: [versioning]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: Astral-Experimental
+
+      # cant use sed easily here because it gets weird when the version grabber greps for regex characters like [] expecially in experimental versioning
+      - name: Set pack.toml version
+        id: packwiz-version
+        shell: bash
+        run: |
+          while read -r line; do
+            echo "${line//"${{needs.versioning.outputs.old_version}}"/"${{needs.versioning.outputs.new_version}}"}"
+          done < "pack.toml" > "tmp.toml"
+          cat tmp.toml > pack.toml
+          rm tmp.toml
+
+      # need to set IFS to be empty so that read preserves whitespace
+      - name: Set FancyMenu environment variable
+        id: fancymenu-version
+        shell: bash
+        run: |
+          OLD_IFS="$IFS"
+          IFS=
+          while read -r line; do
+            echo "${line//"${{needs.versioning.outputs.old_version}}"/"${{needs.versioning.outputs.new_version}}"}"
+          done < "./config/fancymenu/user_variables.db" > "tmp.db"
+          IFS="$OLD_IFS"
+          cat tmp.db > ./config/fancymenu/user_variables.db
+          rm tmp.db
+
+      - name: Set startup debug log version
+        id: startup-version
+        shell: bash
+        run: |
+          OLD_IFS="$IFS"
+          IFS=
+          while read -r line; do
+            echo "${line//"${{needs.versioning.outputs.old_version}}"/"${{needs.versioning.outputs.new_version}}"}"
+          done < "./kubejs/startup_scripts/misc/misc.js" > "tmp.js"
+          IFS="$OLD_IFS"
+          cat tmp.js > ./kubejs/startup_scripts/misc/misc.js
+          rm tmp.db
+
+      - name: Create pull request to new release branch
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: THIS IS A TEST, THE NEW UPDATE IS NOT BEING RELEASED YET!
+          title: Merge auto/${{needs.versioning.outputs.new_version}} into main
+          branch: auto/${{needs.versioning.outputs.new_version}}
+          base: main

--- a/.packwizignore
+++ b/.packwizignore
@@ -21,6 +21,10 @@ server.packwizignore
 # The contents of the serverpack folder will automatically get lifted to the root directory on build
 serverpack
 
+# Temporary jar cache for exporting to curseforge using mods that need to be .toml
+# Is only used during the github build process
+temp-jar
+
 # Nix flake is only neccessary for development
 flake.nix
 flake.lock


### PR DESCRIPTION
## What does this pull request do?

Adds more automation workflows to ease pack deployment and improves the existing packwiz workflow

## Changes made

- Fixed an issue where the packwiz artifacts generated by the packwiz.yml workflow dispatch would get stuck on servercore when generating the client pack.

## Additional Information

Disclaimer that there are some funky workarounds used in these scripts in places but they *should* work for their intended purposes without leaving a mess.