### PR TITLE
lunarians drop phantom membranes

### DIFF
--- a/kubejs/data/ad_astra/loot_tables/entities/corrupted_lunarian.json
+++ b/kubejs/data/ad_astra/loot_tables/entities/corrupted_lunarian.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "weight": 10,
+          "weight": 5,
           "functions": [
             {
               "function": "minecraft:set_count",
@@ -33,6 +33,21 @@
             }
           ],
           "name": "ad_astra:ice_shard"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 1.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:phantom_membrane"
         }
       ]
     }


### PR DESCRIPTION
Changes the Corrupted Lunarian loot table so that it goes from this:
2/3 chance of rotten flesh
1/3 chance of ice shard
to this:
1/3 chance of rotten flesh
1/3 chance of ice shard
1/3 chance of membrane

This increases the accessibility of membranes and gives the darn lunarian a useful drop