### PR TITLE
Disable in-world shadow steel craft

### DIFF
--- a/defaultconfigs/create-server.toml
+++ b/defaultconfigs/create-server.toml
@@ -62,7 +62,7 @@ limitAdventureMode = true
 	enableRefinedRadianceRecipe = false
 	#.
 	#Allow the standard in-world Shadow Steel recipe.
-	enableShadowSteelRecipe = true
+	enableShadowSteelRecipe = false
 
 #.
 #Parameters and abilities of Create's kinetic mechanisms


### PR DESCRIPTION
mwahahahaha

no more void conversion. you must use the custom crafting recipe.
