### PR TITLE
Create chunk-corruption-preventor.pw.toml

### DIFF
--- a/mods/chunk-corruption-preventor.pw.toml
+++ b/mods/chunk-corruption-preventor.pw.toml
@@ -1,0 +1,13 @@
+filename = 'chunkcorruptionpreventor-1.0.0.jar'
+name = 'Chunk Corruption Preventor'
+side = 'both'
+
+[download]
+hash = '116d6ae7c42b8149861c59669e2845bae44b9075'
+hash-format = 'sha1'
+mode = 'metadata:curseforge'
+
+[update]
+[update.curseforge]
+file-id = 7329315
+project-id = 1403907


### PR DESCRIPTION
Description from curseforge:

Chunk Corruption Preventor is a bugfix mod that detects when a chunk corruption is about to happen, and code-injects with a "Safe Serialize" method, so that only the failing element of the chunk will be wiped rather than the entire chunk.

The logic goes like this:

    If a chunk's nbt is messed up after Mojang's code has serialized it,
    Then serialize it again
    If serialization fails again during the blockEntity section (for example)
    Then do not save the specific blockEntity that caused the fail
    And output loads of logging data to the console and chat

The intention is to help server admins and reduce the annoyance of chunk corruptions for players.

The player will receive chat output so they know what happened, they can ping an admin with the details, and they still have the rest of their chunk to play with while they wait for the admin to get online

If only one block is causing the issue, then there is no need to wipe the whole chunk!

This mod does not cause additional issues, but of course it may not work every time. If the chunk is already going to be wiped, then the game may as well try again. The whole "Safe Serialize" code is wrapped in a bunch of try/catch statements, which is ok because it doesn't run very often, and it also means there is good logging and it won't effect the map thread.

There is also no chance of an infinite loop here. Once "Safe Serialize" has run once for a saving chunk, it will not run again during the same cycle.