### PR TITLE
Feature/end skip

### DIFF
--- a/kubejs/data/ad_astra/planet_data/planets/the_end.json
+++ b/kubejs/data/ad_astra/planet_data/planets/the_end.json
@@ -3,9 +3,9 @@
     "galaxy": "ad_astra:milky_way",
     "solar_system": "ad_astra:proxima_centauri",
     "world": "minecraft:the_end",
-    "orbit_world": "minecraft:the_end",
+    "orbit_world": "ae2:spatial_storage",
     "parent_world": null,
-    "rocket_tier": 4,
+    "rocket_tier": 5,
     "gravity": 2.721,
     "has_atmosphere": false,
     "days_in_year": 365,
@@ -13,5 +13,5 @@
     "solar_power": 0,
     "orbit_solar_power": 0,
     "has_oxygen": false,
-    "button_color": "light_blue"
+    "button_color": "black"
 }

--- a/kubejs/data/ad_astra/planet_data/planets/the_nether.json
+++ b/kubejs/data/ad_astra/planet_data/planets/the_nether.json
@@ -3,7 +3,7 @@
     "galaxy": "ad_astra:milky_way",
     "solar_system": "ad_astra:proxima_centauri",
     "world": "minecraft:the_nether",
-    "orbit_world": "minecraft:the_end",
+    "orbit_world": "minecraft:the_nether",
     "parent_world": null,
     "rocket_tier": 4,
     "gravity": 2.721,

--- a/kubejs/data/ad_astra/planet_data/planets/the_nether.json
+++ b/kubejs/data/ad_astra/planet_data/planets/the_nether.json
@@ -3,7 +3,7 @@
     "galaxy": "ad_astra:milky_way",
     "solar_system": "ad_astra:proxima_centauri",
     "world": "minecraft:the_nether",
-    "orbit_world": "minecraft:the_nether",
+    "orbit_world": "ad_astra:venus",
     "parent_world": null,
     "rocket_tier": 4,
     "gravity": 2.721,


### PR DESCRIPTION
This PR resolves a progression skip where the player can go to the End, and fall through the world to get to the Nether. This is not intended functionality. In fact, I don't even know what the "Nether" or the "End" is.

https://discord.com/channels/813762487253860373/1457184411429634221


**Changey log:**
the nether is no longer accessible via the end
the end itself is now only accessible via the portal. rocket tier 5 means it can be registered with low gravity without showing in the planet gui.
note: dud dimensions are used as the orbit world because these can not be blank!
just in case the description above is confusing, the player can still go to the end via the end portal. this is intentional.
