### PR TITLE
less tedious coil block

### DIFF
--- a/kubejs/server_scripts/recipes/minecraft/shaped.js
+++ b/kubejs/server_scripts/recipes/minecraft/shaped.js
@@ -843,9 +843,10 @@
       },
       {
         output: "createastral:copper_heating_coil",
-        pattern: ["AAA", "AAA", "AAA"],
+        pattern: [" A ", "ABA", " A "],
         key: {
           A: "createaddition:copper_spool",
+          B: "minecraft:copper_block",
         },
       },
       {


### PR DESCRIPTION
crafting 72 spools just for one layer of the electrolyser is annoying

8 coil block = 72 spools
72 spools = 288 copper wires (BRUH)

that's 144 copper sheets to put through the rolling mill - super tedious and easy to underestimate how much you need cus of all the subcrafting.

This change maintains a similar copper cost by using a block of copper, but with much less spoolage

8 coil block = 32 spools = 128 copper wires = 64 copper sheets

muuuuuch nicer numbers