### PR TITLE
chore: bump `astralgenerators` to v2.0.0-alpha5

### DIFF
--- a/mods/astral-generators-for-create-astral.pw.toml
+++ b/mods/astral-generators-for-create-astral.pw.toml
@@ -1,13 +1,13 @@
 name = "Astral: Generators (for Create: Astral)"
-filename = "astralgenerators-2.0.0-alpha4.jar"
+filename = "astralgenerators-2.0.0-alpha5.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "9cb51cd86802810d0bd9439869c273887f8e2d9a"
+hash = "de75d7adf4e7e181b1408cac2aaac1a240ef9a26"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 7828051
+file-id = 7868137
 project-id = 1109754


### PR DESCRIPTION
## What does this pull request do? [REQUIRED]

- bump astralgenerators to v2.0.0-alpha5

## Changes made [REQUIRED]

- add steam bucket

