### PR TITLE
Update flake.nix to support non channel enviroments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     forEachSupportedSystem = f:
       inputs.nixpkgs.lib.genAttrs supportedSystems (system:
         f {
-          pkgs = import nixpkgs {inherit system;};
+          pkgs = import inputs.nixpkgs {inherit system;};
         });
   in {
     devShells = forEachSupportedSystem ({pkgs}: {


### PR DESCRIPTION
## What does this pull request do?

When using the previous flake.nix file and entering a dev shell by running `nix develop` on Nix systems that use channels this works as it is an impure environment using `NIX_PATH`. But on a Nix flake system this will result in an undefined variable as the env-var is not a constant across Nix systems.
TLDR: old setup relied on a soon-to-be legacy system that most don't use.

## Changes made

- Updated flake.nix to specifically define inputs for nixpkgs.