### PR TITLE
Bump action versions and temporary fix for packwiz

### DIFF
--- a/.github/workflows/packwiz.yml
+++ b/.github/workflows/packwiz.yml
@@ -30,15 +30,14 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
-      - name: Get latest packwiz binary
+      - name: Download packwiz binary # now with static releases instead of action artifacts!
         id: download-packwiz
-        uses: dawidd6/action-download-artifact@v21
+        uses: robinraju/release-downloader@v1.13
         with:
-          workflow: go.yml
-          branch: main
-          name: Linux 64-bit x86
-          # temorary fix for packwiz not running a go action since february, will figure out a better solution later
-          repo: The-Shortman/packwiz
+          repository: The-Shortman/packwiz
+          tag: "v1.0.0"
+          fileName: Linux_x86-64.zip
+          extract: true
 
       - name: Make packwiz binary executable
         shell: bash

--- a/.github/workflows/packwiz.yml
+++ b/.github/workflows/packwiz.yml
@@ -18,25 +18,27 @@ on:
 
 jobs:
   build:
+    name: Build Modpack
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: "temurin"
 
       - name: Get latest packwiz binary
         id: download-packwiz
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: go.yml
           branch: main
           name: Linux 64-bit x86
-          repo: packwiz/packwiz
+          # temorary fix for packwiz not running a go action since february, will figure out a better solution later
+          repo: The-Shortman/packwiz
 
       - name: Make packwiz binary executable
         shell: bash
@@ -44,7 +46,7 @@ jobs:
 
       - name: Restore cached mod downloads
         id: cache-mods-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /home/runner/.cache/packwiz/cache
           key: cached-mods
@@ -92,7 +94,7 @@ jobs:
 
       - name: Download packwiz-installer-bootstrap
         if: ${{ github.event.inputs.serverpack }}
-        uses: robinraju/release-downloader@v1.10
+        uses: robinraju/release-downloader@v1.13
         with:
           repository: packwiz/packwiz-installer-bootstrap
           latest: true
@@ -126,14 +128,14 @@ jobs:
 
       - name: Upload client pack to GitHub
         if: ${{ github.event.inputs.artifacts }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{steps.construct-base-name.outputs.ASTRAL_CF_NAME}}
           path: ./client
 
       - name: Upload serverpack to GitHub
         if: ${{ github.event.inputs.serverpack && github.event.inputs.artifacts }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{steps.construct-base-name.outputs.ASTRAL_SERVER_NAME}}
           path: ./server


### PR DESCRIPTION
## What does this pull request do?

Fixes the packwiz artifact not downloading (due to artifact expiration) by pulling from a forked packwiz repository ([The-Shortman/packwiz](https://github.com/The-Shortman/packwiz)) that has recently run a packwiz build action. This is a temporary low-effort fix at best and I will investigate a better fix at another time.

Actions have also been updated to more recent versions, I have read the changelogs and I don't believe any of the changes should break our build scripts.

## Changes made

- The packwiz binary used in Astral's CI build script is now pulled from a forked repository, as a temporary fix for expired artifacts.
- Actions used in Astral's CI build script have been updated to their newest versions where applicable.