### PR TITLE
Small lang fix

### DIFF
--- a/config/fancymenu/custom_locals/astralmenu/en_gb.local
+++ b/config/fancymenu/custom_locals/astralmenu/en_gb.local
@@ -43,21 +43,7 @@ astralmenu.creditsmenu.specialthanks.betatesters = Beta Testers
 astralmenu.creditsmenu.specialthanks.backgroundcredit = Thanks to Senkou for the background to the credits screen!
 astralmenu.creditsmenu.close = Close Credits
 
-astralmenu.changelog.2_1.title = Create: Astral Version 2.1
-astralmenu.changelog.2_1.close = Close Changelog
-astralmenu.changelog.2_1.label = Update 2.1
-
-astralmenu.changelog.2_1_1.title = Create: Astral Patch 2.1.1
-astralmenu.changelog.2_1_1.label = Patch 2.1.1
-
-astralmenu.changelog.2_1_2.title = Create: Astral Patch 2.1.2
-astralmenu.changelog.2_1_2.label = Patch 2.1.2
-
-astralmenu.changelog.2_1_3.title = Create: Astral Patch 2.1.3
-astralmenu.changelog.2_1_3.label = Patch 2.1.3
-
-astralmenu.changelog.2_1_4.title = Create: Astral Patch 2.1.4
-astralmenu.changelog.2_1_4.label = Patch 2.1.4
-
 astralmenu.multiplayer_error_message.line1 = If you're getting an error when joining a multiplayer server, try rejoining before reporting it as a bug!
 astralmenu.multiplayer_error_message.line2 = If you still can't join, please join the Discord (link can be found on the left hand side of the main menu) and report it in the #bug-reports channel!
+
+astralmenu.resourcepackmenu.resourcepack_help = <- Resource packs broken? Click here to fix!

--- a/config/fancymenu/custom_locals/astralmenu/ru_ru.local
+++ b/config/fancymenu/custom_locals/astralmenu/ru_ru.local
@@ -43,22 +43,6 @@ astralmenu.creditsmenu.specialthanks.betatesters = Бета-тестеры
 astralmenu.creditsmenu.specialthanks.backgroundcredit = Спасибо Senkou за фон для экрана титров!
 astralmenu.creditsmenu.close = Закрыть
 
-astralmenu.changelog.2_1.title = Create: Astral Версия 2.1
-astralmenu.changelog.2_1.close = Закрыть список изменений
-astralmenu.changelog.2_1.label = Обновление 2.1
-
-astralmenu.changelog.2_1_1.title = Create: Astral Патч 2.1.1
-astralmenu.changelog.2_1_1.label = Патч 2.1.1
-
-astralmenu.changelog.2_1_2.title = Create: Astral Патч 2.1.2
-astralmenu.changelog.2_1_2.label = Патч 2.1.2
-
-astralmenu.changelog.2_1_3.title = Create: Astral Патч 2.1.3
-astralmenu.changelog.2_1_3.label = Патч 2.1.3
-
-astralmenu.changelog.2_1_4.title = Create: Astral Патч 2.1.4
-astralmenu.changelog.2_1_4.label = Патч 2.1.4
-
 astralmenu.multiplayer_error_message.line1 = Если при входе на сервер возникает ошибка, попробуйте перезайти перед тем, как сообщать о баге!
 astralmenu.multiplayer_error_message.line2 = Если войти всё равно не удаётся, пожалуйста, перейдите в наш Discord (ссылка слева в меню) и сообщите об этом в канале #bug-reports!
 

--- a/kubejs/assets/createastral/lang/en_gb.json
+++ b/kubejs/assets/createastral/lang/en_gb.json
@@ -3197,7 +3197,7 @@
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Combat Music",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "The custom music you will hear throughout the pack is licensed so that you may use it &6wherever you wish&r!",
   "ftbquests.chapter.read_the_questbook.quests18.description2": "Feel free to include it in &6YouTube videos&r or content surrounding Astral, it will not receive strikes.",
-  "ftbquests.chapter.read_the_questbook.quests18.description4": "Music was produced by Hesperyd, XETROO, PINS3Y, ethanicuss",
+  "ftbquests.chapter.read_the_questbook.quests18.description4": "Music was produced by Hesperyd, XETROO, WORLDLINE, ethanicuss",
   "ftbquests.chapter.read_the_questbook.quests18.tasks0.title": "Astral Music Info",
   "ftbquests.chapter.read_the_questbook.quests19.title": "&6Create Big Cannon changes&r",
   "ftbquests.chapter.read_the_questbook.quests19.description0": "The progression of &6Big Cannons&r is slightly modified.",

--- a/kubejs/assets/createastral/lang/en_gb.json
+++ b/kubejs/assets/createastral/lang/en_gb.json
@@ -3192,7 +3192,7 @@
   "ftbquests.chapter.read_the_questbook.quests16.description2": "&6Locked Drawers&r are also a feature in Extended Drawers, preventing any other item from entering the locked drawer.",
   "ftbquests.chapter.read_the_questbook.quests17.subtitle": "Toggle Combat Music",
   "ftbquests.chapter.read_the_questbook.quests17.description0": "We heard your request!! Combat music has been turned down and a config option has been added.",
-  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\\\config\\\\astraladditions\\\\combatmusic.txt",
+  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\config\\astraladditions\\combatmusic.txt",
   "ftbquests.chapter.read_the_questbook.quests17.description4": "Simply set the value in this file from 'true' to 'false'",
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Combat Music",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "The custom music you will hear throughout the pack is licensed so that you may use it &6wherever you wish&r!",

--- a/kubejs/assets/createastral/lang/en_us.json
+++ b/kubejs/assets/createastral/lang/en_us.json
@@ -3157,7 +3157,7 @@
   "ftbquests.chapter.read_the_questbook.quests16.description2": "&6Locked Drawers&r are also a feature in Extended Drawers, preventing any other item from entering the locked drawer.",
   "ftbquests.chapter.read_the_questbook.quests17.subtitle": "Toggle Combat Music",
   "ftbquests.chapter.read_the_questbook.quests17.description0": "We heard your request!! Combat music has been turned down and a config option has been added.",
-  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\\\config\\\\astraladditions\\\\combatmusic.txt",
+  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\config\\astraladditions\\combatmusic.txt",
   "ftbquests.chapter.read_the_questbook.quests17.description4": "Simply set the value in this file from 'true' to 'false'",
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Combat Music",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "The custom music you will hear throughout the pack is licensed so that you may use it &6wherever you wish&r!",

--- a/kubejs/assets/createastral/lang/es_es.json
+++ b/kubejs/assets/createastral/lang/es_es.json
@@ -2932,7 +2932,7 @@
   "ftbquests.chapter.read_the_questbook.quests16.description2": "Los &6cajones bloqueados&r también son una característica de Extended Drawers, evitando que cualquier otro objeto entre en el cajón bloqueado.",
   "ftbquests.chapter.read_the_questbook.quests17.subtitle": "Alternar música de combate",
   "ftbquests.chapter.read_the_questbook.quests17.description0": "¡Escuchamos tu petición! La música de combate se ha bajado y se ha añadido una opción de configuración.",
-  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\\\config\\\\astraladditions\\\\combatmusic.txt",
+  "ftbquests.chapter.read_the_questbook.quests17.description2": ".minecraft\\config\\astraladditions\\combatmusic.txt",
   "ftbquests.chapter.read_the_questbook.quests17.description4": "Simplemente cambia el valor en este archivo de 'true' a 'false'",
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Música de combate",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "La música personalizada que escucharás a lo largo del pack tiene licencia para que puedas usarla &6donde quieras&r.",

--- a/kubejs/assets/createastral/lang/ru_ru.json
+++ b/kubejs/assets/createastral/lang/ru_ru.json
@@ -3197,7 +3197,7 @@
   "ftbquests.chapter.read_the_questbook.quests17.tasks0.title": "Боевая музыка",
   "ftbquests.chapter.read_the_questbook.quests18.description0": "Кастомная музыка, которую вы слышите в паке, лицензирована так, что вы можете использовать её &6где угодно&r!",
   "ftbquests.chapter.read_the_questbook.quests18.description2": "Смело вставляйте её в свои &6видео на YouTube&r или контент по Astral — страйков не будет.",
-  "ftbquests.chapter.read_the_questbook.quests18.description4": "Музыка написана: Hesperyd, XETROO, PINS3Y, ethanicuss",
+  "ftbquests.chapter.read_the_questbook.quests18.description4": "Музыка написана: Hesperyd, XETROO, WORLDLINE, ethanicuss",
   "ftbquests.chapter.read_the_questbook.quests18.tasks0.title": "Инфо о музыке Astral",
   "ftbquests.chapter.read_the_questbook.quests19.title": "&6Изменения Create Big Cannons&r",
   "ftbquests.chapter.read_the_questbook.quests19.description0": "Прогрессия мода &6Big Cannons&r была слегка изменена.",


### PR DESCRIPTION
## What does this pull request do?

- Replaces PINS3Y with WORLDLINE where it wasn't replaced

- Removes doubled backslashes in a filepath in one of the quest descriptions

## Changes made [REQUIRED]

- Changed PINS3Y to WORLDLINE in the "Astral Music Info" quest in ru_ru and en_gb

- Changed "\\\\" to "\\" in the combatmusic config filepath in the "Combat Music" quest in en_us, en_gb, and es_es

- Updated ru_ru and en_gb astralmenu to match en_us

