### PR TITLE
no chat restrictions

### DIFF
--- a/mods/no-chat-restrictions.pw.toml
+++ b/mods/no-chat-restrictions.pw.toml
@@ -1,0 +1,13 @@
+name = "No Chat Restrictions"
+filename = "NoChatRestrictions-Fabric-MC1.18.2-v1.0.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "8a95e07d5ac4aed7c62f8d3f0974a9eebec417bd"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 7536205
+project-id = 1442925

--- a/pack.toml
+++ b/pack.toml
@@ -6,8 +6,8 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f6bd814f22936e7e4548165799744fea6f7d31e6fb6869cd55dfcfcfa1bf83a6"
+hash = "cf6fd56b3819e20fefae67c40d458b29afecd0b9b6defac204bfd0fac375883a"
 
 [versions]
-fabric = "0.16.3"
+fabric = "0.18.4"
 minecraft = "1.18.2"


### PR DESCRIPTION
The piece of shit UK government has enforced chat restrictions for accounts that have not verified their age. This mod disables that feature.

Fabric version updated from 0.16.3 -> 0.18.4 to support this new mod