### PR TITLE
add particles for transitional blocks

### DIFF
--- a/kubejs/startup_scripts/registry/createastral/item/item.js
+++ b/kubejs/startup_scripts/registry/createastral/item/item.js
@@ -201,6 +201,7 @@
     event.create("createastral:incomplete_copper_casing", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_copper_casing0",
         up: "createastral:item/incomplete_copper_casing0",
         down: "createastral:item/incomplete_copper_casing0",
         north: "createastral:item/incomplete_copper_casing1",
@@ -212,6 +213,7 @@
     event.create("createastral:incomplete_basic_machine_frame", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "techreborn:block/machines/structure/tier1_machine_block",
         up: "techreborn:block/machines/structure/tier1_machine_block",
         down: "create:block/copper_casing",
         north: "createastral:item/incomplete_basic_machine_frame0",
@@ -223,6 +225,7 @@
     event.create("createastral:incomplete_brass_casing", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_brass_casing",
         up: "createastral:item/incomplete_brass_casing",
         down: "createastral:item/incomplete_brass_casing",
         north: "createastral:item/incomplete_brass_casing",
@@ -234,6 +237,7 @@
     event.create("createastral:incomplete_advanced_machine_frame", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_advanced_machine_frame",
         up: "createastral:item/incomplete_advanced_machine_frame",
         down: "createastral:item/incomplete_advanced_machine_frame",
         north: "createastral:item/incomplete_advanced_machine_frame",
@@ -245,6 +249,7 @@
     event.create("createastral:incomplete_industrial_machine_frame", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_industrial_machine_frame",
         up: "createastral:item/incomplete_industrial_machine_frame",
         down: "createastral:item/incomplete_industrial_machine_frame",
         north: "createastral:item/incomplete_industrial_machine_frame",
@@ -256,6 +261,7 @@
     event.create("createastral:incomplete_refined_radiance_casing", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_refined_radiance_casing",
         up: "createastral:item/incomplete_refined_radiance_casing",
         down: "createastral:item/incomplete_refined_radiance_casing",
         north: "createastral:item/incomplete_refined_radiance_casing",
@@ -268,6 +274,7 @@
     event.create("createastral:incomplete_shadow_steel_casing", "create:sequenced_assembly").modelJson({
       parent: "minecraft:block/cube",
       textures: {
+        particle: "createastral:item/incomplete_shadow_steel_casing",
         up: "createastral:item/incomplete_shadow_steel_casing",
         down: "createastral:item/incomplete_shadow_steel_casing",
         north: "createastral:item/incomplete_shadow_steel_casing",


### PR DESCRIPTION
Transitional blocks with custom models were missing a particle texture, resulting in Missing Tex particles when doing sequenced assembly
Bug:
<img width="1600" height="1016" alt="image" src="https://github.com/user-attachments/assets/7d104432-a456-4dca-a537-d2691d62136d" />

Fix:
<img width="416" height="316" alt="image" src="https://github.com/user-attachments/assets/53431501-4348-436f-83b5-708e16ba1bf7" />

Fixed for all 7 of these custom-model transitional blocks