### PR TITLE
Removed default Automobility engine recipes

### DIFF
--- a/kubejs/server_scripts/recipes/removals.js
+++ b/kubejs/server_scripts/recipes/removals.js
@@ -5,6 +5,12 @@
     //Tech Reborn
     /** @type {Internal.RecipeFilter_[]} */
     const recipeRemovals = [
+      // Automobility default engine recipes
+      { id: "automobility:engine/copper_engine" },
+      { id: "automobility:engine/diamond_engine" },
+      { id: "automobility:engine/gold_engine" },
+      { id: "automobility:engine/iron_engine" },
+      { id: "automobility:engine/stone_engine" },
       // storage units
       { output: "techreborn:crude_storage_unit" },
       { output: "techreborn:basic_storage_unit" },


### PR DESCRIPTION
## What does this pull request do?

Removes the default Automobility engine recipes. Custom recipes have already been added.

## Changes made

The following recipes were removed:
* automobility:engine/copper_engine
* automobility:engine/diamond_engine
* automobility:engine/gold_engine
* automobility:engine/iron_engine
* automobility:engine/stone_engine
