### PR TITLE
Reorder slimesteel recipes to fix mixing priority

### DIFF
--- a/kubejs/server_scripts/recipes/create/mixing.js
+++ b/kubejs/server_scripts/recipes/create/mixing.js
@@ -527,6 +527,12 @@
         time: 100,
       },
       {
+        output: Fluid.of("tconstruct:molten_slimesteel", INGOT * 2),
+        input: ["minecraft:iron_ingot", "tconstruct:sky_slime_ball", "#tconstruct:seared_blocks"],
+        heat: "superheated",
+        time: 300,
+      },
+      {
         output: Fluid.of("tconstruct:molten_slimesteel", INGOT),
         input: ["minecraft:iron_ingot", "tconstruct:sky_slime_ball", "#tconstruct:seared_blocks"],
         heat: "heated",
@@ -556,12 +562,6 @@
         output: Fluid.of("tconstruct:molten_slimesteel", INGOT),
         input: [Item.of("minecraft:iron_nugget", 9), "tconstruct:sky_slime_ball", "#tconstruct:seared_blocks"],
         heat: "heated",
-        time: 300,
-      },
-      {
-        output: Fluid.of("tconstruct:molten_slimesteel", INGOT * 2),
-        input: ["minecraft:iron_ingot", "tconstruct:sky_slime_ball", "#tconstruct:seared_blocks"],
-        heat: "superheated",
         time: 300,
       },
       {


### PR DESCRIPTION
## What does this pull request do?

Moved the higher yield, superheated recipe for slimesteel before the lower yield, heated recipe.

Registering recipes with identical ingredients but higher yield before registering ones with lower yield seems to cause mixing to behave as expected. I would prefer more people tested this before it was considered a fix, as I could have just gotten lucky with the loading process when testing.

## Changes made

This commit only affects the recipes that accept iron ingots, skyslime balls, and seared blocks and output molten slimesteel.
Those recipes have only been reordered, so nothing else should be affected.

* Fixes #463 (possible partial fix)

## Additional Information

The following are images demonstrating my test. I provided 8 slimeballs each time; you can see the resulting fluid in the top center of each image.  

Output from heated basin:
<img width="1920" height="1032" alt="slimesteel-heated" src="https://github.com/user-attachments/assets/c353c47d-2e10-45af-851e-e63af926111b" />

Output from superheated basin:
<img width="1920" height="1032" alt="slimesteel-superheated" src="https://github.com/user-attachments/assets/4dc3925c-5090-423e-8db0-c92f600619d5" />
