### PR TITLE
Fixed the Redstone Crystal quest description

### DIFF
--- a/kubejs/assets/createastral/lang/en_gb.json
+++ b/kubejs/assets/createastral/lang/en_gb.json
@@ -1712,7 +1712,7 @@
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests4.subtitle": "Wash Lime Dust.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests4.description": "Silver is used in the production of electrical machines.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests5.subtitle": "Bulk blast Sand.",
-  "ftbquests.chapter.chapter_25_the_automation_matrix.quests6.subtitle": "Shaped crafting with Red Dye and Glass",
+  "ftbquests.chapter.chapter_25_the_automation_matrix.quests6.subtitle": "Shapeless crafting with Red Dye and Glass",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests7.subtitle": "Tesla Coil charge Synthetic Redstone Crystals.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests7.description": "Redstone is not only used to craft primitive circuitry, but also to craft basic circuits and circuitry tools.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests8.subtitle": "Farm Kelp.",

--- a/kubejs/assets/createastral/lang/en_us.json
+++ b/kubejs/assets/createastral/lang/en_us.json
@@ -1680,7 +1680,7 @@
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests4.subtitle": "Wash Lime Dust.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests4.description": "Silver is used in the production of electrical machines.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests5.subtitle": "Bulk blast Sand.",
-  "ftbquests.chapter.chapter_25_the_automation_matrix.quests6.subtitle": "Shaped crafting with Red Dye and Glass",
+  "ftbquests.chapter.chapter_25_the_automation_matrix.quests6.subtitle": "Shapeless crafting with Red Dye and Glass",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests7.subtitle": "Tesla Coil charge Synthetic Redstone Crystals.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests7.description": "Redstone is not only used to craft primitive circuitry, but also to craft basic circuits and circuitry tools.",
   "ftbquests.chapter.chapter_25_the_automation_matrix.quests8.subtitle": "Farm Kelp.",


### PR DESCRIPTION
## What does this pull request do?

Changed 'Shaped' to 'Shapeless' in English translations (gb, us) of the 'Synthetic Redstone Crystal' quest in the 'Automation Matrix' chapter.

## Changes made

* Altered *kubejs/assets/createastral/lang/en_gb.json*
* Altered *kubejs/assets/createastral/lang/en_us.json*
