### PR TITLE
oops

### DIFF
--- a/config/ftbquests/quests/chapters/chapter_5.snbt
+++ b/config/ftbquests/quests/chapters/chapter_5.snbt
@@ -2490,6 +2490,9 @@
 				"{ftbquests.chapter.chapter_5.blender.description2}"
 				""
 				"{ftbquests.chapter.chapter_5.blender.description4}"
+				""
+				"{image:createastral:textures/item/blender_rei_1.png width:200 height:270 align:1}"
+				"{image:createastral:textures/item/blender_rei_2.png width:200 height:216 align:1}"
 			]
 			dependencies: ["30B554B51AEFEB0C"]
 			id: "52C8D56DC0260931"


### PR DESCRIPTION
this dumbass removed the REI screenshots for the Blender in the next PR because he was editing quests on 2.1.5 rather than on his dev instance!!

this PR adds it back