### PR TITLE
Fixed a typo in the Industrial Agriculture quest

### DIFF
--- a/kubejs/assets/createastral/lang/en_gb.json
+++ b/kubejs/assets/createastral/lang/en_gb.json
@@ -2007,7 +2007,7 @@
   "ftbquests.chapter.chapter_3.quests39.title": "Industrial agriculture",
   "ftbquests.chapter.chapter_3.quests39.subtitle": "The days of manual harvesting are over.",
   "ftbquests.chapter.chapter_3.quests39.description0": "&6Mechanical Harvesters&r can harvest crops.",
-  "ftbquests.chapter.chapter_3.quests39.description2": "They are smart enough to only harvest fully-grown tools - additionally crops collected by Mechanical Harvester will be automatically replanted!",
+  "ftbquests.chapter.chapter_3.quests39.description2": "They are smart enough to only harvest fully-grown crops. Additionally, crops collected by Mechanical Harvester will be automatically replanted!",
   "ftbquests.chapter.chapter_3.quests39.description4": "&6Kelp&r will be used a lot in the future - make sure to make a large farm!",
   "ftbquests.chapter.chapter_3.quests40.subtitle": "I'm addicted to these belt things...",
   "ftbquests.chapter.chapter_3.quests40.description0": "Having wet &6Kelp&r doesn't help you much.",

--- a/kubejs/assets/createastral/lang/en_us.json
+++ b/kubejs/assets/createastral/lang/en_us.json
@@ -1975,7 +1975,7 @@
   "ftbquests.chapter.chapter_3.quests39.title": "Industrial agriculture",
   "ftbquests.chapter.chapter_3.quests39.subtitle": "The days of manual harvesting are over.",
   "ftbquests.chapter.chapter_3.quests39.description0": "&6Mechanical Harvesters&r can harvest crops.",
-  "ftbquests.chapter.chapter_3.quests39.description2": "They are smart enough to only harvest fully-grown tools - additionally crops collected by Mechanical Harvester will be automatically replanted!",
+  "ftbquests.chapter.chapter_3.quests39.description2": "They are smart enough to only harvest fully-grown crops. Additionally, crops collected by Mechanical Harvester will be automatically replanted!",
   "ftbquests.chapter.chapter_3.quests39.description4": "&6Kelp&r will be used a lot in the future - make sure to make a large farm!",
   "ftbquests.chapter.chapter_3.quests40.subtitle": "I'm addicted to these belt things...",
   "ftbquests.chapter.chapter_3.quests40.description0": "Having wet &6Kelp&r doesn't help you much.",


### PR DESCRIPTION
## What does this pull request do?

Fix the wording of the Industrial Agriculture quest description (from chapter 3).

## Changes made

Modified wording and punctuation in the following files:
* kubejs/assets/createastral/lang/en_gb.json
* kubejs/assets/createastral/lang/en_us.json
